### PR TITLE
Add CI for v2 validation suite

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
-*.json text eol=lf
+# Keep generated artifacts and validation output stable across Windows and Unix.
+* text=auto eol=lf

--- a/.github/workflows/v2-validation.yml
+++ b/.github/workflows/v2-validation.yml
@@ -1,0 +1,21 @@
+name: v2 validation
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  validate:
+    name: Run v2 validation suite
+    runs-on: windows-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run validation
+        shell: powershell
+        run: .\tests\validation\run-all.ps1

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -8,6 +8,8 @@ Run the full local verification sequence with:
 powershell -ExecutionPolicy Bypass -File tests/validation/run-all.ps1
 ```
 
+GitHub Actions uses the same entrypoint in `.github/workflows/v2-validation.yml` for pull requests targeting `main` and pushes to `main`.
+
 The sequence intentionally builds derived payloads before validation:
 
 ```powershell

--- a/tests/validation/validate-evals.ps1
+++ b/tests/validation/validate-evals.ps1
@@ -36,7 +36,7 @@ foreach ($relativePath in $questionFiles) {
       throw "$relativePath has unsupported expected_answer_mode: $mode"
     }
   }
-  if ($content -match '\[概念のみ\]|\[検証済み\]|\[保留\]') {
+  if ($content -match '\[\u6982\u5ff5\u306e\u307f\]|\[\u691c\u8a3c\u6e08\u307f\]|\[\u4fdd\u7559\]') {
     throw "$relativePath must check answer modes, not legacy bracket labels"
   }
   if ($content -match '\bT[1-4]\b|source_tier|core / mixed / current-fact') {

--- a/tests/validation/validate-knowledge-schema.ps1
+++ b/tests/validation/validate-knowledge-schema.ps1
@@ -142,9 +142,15 @@ foreach ($file in $files) {
   if ($relativePath -match '^knowledge/curated/' -and $content -notmatch '(?m)^\s+path:\s*') {
     $violations += "$relativePath source_refs must include a reviewable path"
   }
-  foreach ($forbidden in @('source_tier', '[概念のみ]', 'T1 / T2 / T3 / T4', 'core / mixed / current-fact')) {
-    if ($content -match [regex]::Escape($forbidden)) {
-      $violations += "$relativePath contains legacy canonical taxonomy text: $forbidden"
+  $forbiddenPatterns = @(
+    @{ Label = 'source_tier'; Pattern = [regex]::Escape('source_tier') },
+    @{ Label = 'legacy concept-only bracket label'; Pattern = '\[\u6982\u5ff5\u306e\u307f\]' },
+    @{ Label = 'T1 / T2 / T3 / T4'; Pattern = [regex]::Escape('T1 / T2 / T3 / T4') },
+    @{ Label = 'core / mixed / current-fact'; Pattern = [regex]::Escape('core / mixed / current-fact') }
+  )
+  foreach ($forbidden in $forbiddenPatterns) {
+    if ($content -match $forbidden.Pattern) {
+      $violations += "$relativePath contains legacy canonical taxonomy text: $($forbidden.Label)"
     }
   }
 }

--- a/tests/validation/validate-legacy-cleanup.ps1
+++ b/tests/validation/validate-legacy-cleanup.ps1
@@ -34,12 +34,12 @@ $canonicalRoots = @(
 )
 
 $legacyMetadataPatterns = @(
-  'source_tier',
-  '回答ラベル',
-  '根拠階層',
-  'core-community-label',
-  'concept-stable',
-  'community-labeled'
+  @{ Label = 'source_tier'; Pattern = [regex]::Escape('source_tier') },
+  @{ Label = 'legacy answer label metadata'; Pattern = '\u56de\u7b54\u30e9\u30d9\u30eb' },
+  @{ Label = 'legacy evidence tier metadata'; Pattern = '\u6839\u62e0\u968e\u5c64' },
+  @{ Label = 'core-community-label'; Pattern = [regex]::Escape('core-community-label') },
+  @{ Label = 'concept-stable'; Pattern = [regex]::Escape('concept-stable') },
+  @{ Label = 'community-labeled'; Pattern = [regex]::Escape('community-labeled') }
 )
 
 foreach ($relativeRoot in $canonicalRoots) {
@@ -56,8 +56,8 @@ foreach ($relativeRoot in $canonicalRoots) {
     $relativePath = $file.FullName.Substring($repoRoot.Length + 1).Replace('\', '/')
     $content = Get-Content -LiteralPath $file.FullName -Raw -Encoding UTF8
     foreach ($pattern in $legacyMetadataPatterns) {
-      if ($content -match [regex]::Escape($pattern)) {
-        $violations += "$relativePath contains legacy canonical metadata: $pattern"
+      if ($content -match $pattern.Pattern) {
+        $violations += "$relativePath contains legacy canonical metadata: $($pattern.Label)"
       }
     }
   }


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow for the v2 validation suite.
- Run `tests/validation/run-all.ps1` on pull requests to `main` and pushes to `main`.
- Document that GitHub Actions uses the same validation entrypoint as local testing.

## Notes
- The workflow uses `windows-latest` with `shell: powershell` to match the checked-in frame-current runtime manifest formatting produced by the existing packaging scripts.
- Local `pwsh`/PowerShell Core reformats `runtime_manifest.json`, so this workflow intentionally uses Windows PowerShell for the current generator behavior.

## Validation
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1` -> `V2 validation suite OK`
- `pwsh.exe -NoProfile -File tests/validation/run-all.ps1` was tested and revealed PowerShell Core JSON formatting drift, which is why the CI workflow uses `shell: powershell`.
- WSL `git status --porcelain` check for derived outputs -> clean after Windows PowerShell validation.
- Secret scan over changed files -> no hits.

Closes #20