### PR TITLE
[v2.1] Expand answer-mode eval coverage

### DIFF
--- a/evals/questions/concepts.yaml
+++ b/evals/questions/concepts.yaml
@@ -6,6 +6,22 @@ cases:
     must_not_include:
       - "exact current move frame values"
       - "generated surface as canonical source"
+  - id: concept-plus-frames-not-guaranteed-pressure
+    question: "If I am plus after a blocked attack, does that mean my next option is guaranteed?"
+    expected_answer_mode: stable_concept
+    evidence_boundary: "Explain the stable turn-advantage concept while separating advantage from guaranteed outcomes."
+    must_not_include:
+      - "guaranteed follow-up"
+      - "specific current block advantage"
+      - "character-specific setup validity"
+  - id: concept-punishability
+    question: "What does punishable mean in SF6?"
+    expected_answer_mode: stable_concept
+    evidence_boundary: "Explain the stable punishability concept without asserting current move-specific punish windows."
+    must_not_include:
+      - "specific current startup"
+      - "specific current recovery"
+      - "runtime asset value quoted from memory"
   - id: concept-shimmy
     question: "What is a shimmy and why does it beat throw tech?"
     expected_answer_mode: stable_concept
@@ -13,3 +29,35 @@ cases:
     must_not_include:
       - "official-definition claim without support"
       - "character-specific guaranteed setup"
+  - id: concept-shimmy-community-term
+    question: "Is shimmy an official SF6 term, and what does it usually mean?"
+    expected_answer_mode: stable_concept
+    evidence_boundary: "Use the community terminology boundary and avoid claiming official wording."
+    must_not_include:
+      - "official game terminology"
+      - "guaranteed in the current patch"
+      - "exact matchup prescription"
+  - id: concept-hit-confirm
+    question: "What is a hit confirm?"
+    expected_answer_mode: stable_concept
+    evidence_boundary: "Explain the stable concept without naming current character-specific confirm routes as verified facts."
+    must_not_include:
+      - "current optimal route"
+      - "specific current frame window"
+      - "unreviewed character route"
+  - id: concept-meaty-timing
+    question: "What does meaty timing mean on an opponent's wake-up?"
+    expected_answer_mode: stable_concept
+    evidence_boundary: "Explain the timing concept without claiming a setup is current-patch verified."
+    must_not_include:
+      - "verified current setup"
+      - "specific active-frame value"
+      - "guaranteed against all wake-up options"
+  - id: concept-okizeme-wakeup-pressure
+    question: "What is okizeme or wake-up pressure in SF6?"
+    expected_answer_mode: stable_concept
+    evidence_boundary: "Explain the stable post-knockdown pressure concept while keeping matchup and patch-specific claims out."
+    must_not_include:
+      - "universal best option"
+      - "current patch guarantee"
+      - "specific character setup as fact"

--- a/evals/questions/current-fact.yaml
+++ b/evals/questions/current-fact.yaml
@@ -6,6 +6,14 @@ cases:
     must_not_include:
       - "raw snapshot as final public evidence"
       - "manual-review row as final public evidence"
+  - id: current-fact-runtime-assets-required
+    question: "Tell me the current startup and block advantage for a named move."
+    expected_answer_mode: verified_current_fact
+    evidence_boundary: "Use only packaged frame-current runtime assets derived from data/exports and data/roster."
+    must_not_include:
+      - "knowledge/curated as final authority"
+      - "community-only final authority"
+      - "guessed exact values"
   - id: current-fact-unpackaged-character
     question: "Give the current exact frame data for a character not present in the roster source."
     expected_answer_mode: unresolved_or_hold
@@ -13,3 +21,35 @@ cases:
     must_not_include:
       - "guessed exact values"
       - "third-party-only final authority"
+  - id: current-fact-unknown-move-hold
+    question: "Give the current exact frame data for a move that is not present in the packaged runtime asset."
+    expected_answer_mode: unresolved_or_hold
+    evidence_boundary: "Hold when the packaged current-fact asset lacks the requested move or field."
+    must_not_include:
+      - "invented move lookup"
+      - "nearest move substituted as fact"
+      - "legacy skill path as authority"
+  - id: current-fact-community-only-rejection
+    question: "A community page lists a current frame value that is not in the packaged data. Can sf6-agent answer it as verified?"
+    expected_answer_mode: unresolved_or_hold
+    evidence_boundary: "Community-only current values are not final authority for verified current facts."
+    must_not_include:
+      - "community-only verified fact"
+      - "third-party final authority"
+      - "accepted current value without runtime asset"
+  - id: current-fact-supplemental-no-override
+    question: "If supplemental enrichment disagrees with official_raw for a current value, which source controls the answer?"
+    expected_answer_mode: verified_current_fact
+    evidence_boundary: "official_raw controls exact current facts; supplemental enrichment can add context but cannot override it."
+    must_not_include:
+      - "supplemental overrides official_raw"
+      - "third-party final authority"
+      - "conflict resolved by preference"
+  - id: current-fact-missing-dataset-hold
+    question: "A user asks for exact current frame data from a dataset that is missing from the bundle. What should sf6-agent do?"
+    expected_answer_mode: unresolved_or_hold
+    evidence_boundary: "Hold when the requested exact current fact is unavailable in packaged current-fact assets."
+    must_not_include:
+      - "guess from concept knowledge"
+      - "answer from generated concept references"
+      - "unpackaged dataset as verified"

--- a/evals/questions/current-fact.yaml
+++ b/evals/questions/current-fact.yaml
@@ -7,7 +7,7 @@ cases:
       - "raw snapshot as final public evidence"
       - "manual-review row as final public evidence"
   - id: current-fact-runtime-assets-required
-    question: "Tell me the current startup and block advantage for a named move."
+    question: "Tell me the current startup and block advantage for Luke's crouching medium punch."
     expected_answer_mode: verified_current_fact
     evidence_boundary: "Use only packaged frame-current runtime assets derived from data/exports and data/roster."
     must_not_include:

--- a/evals/questions/uncertainty.yaml
+++ b/evals/questions/uncertainty.yaml
@@ -6,3 +6,43 @@ cases:
     must_not_include:
       - "third-party override of official data"
       - "invented reconciliation"
+  - id: uncertainty-patch-sensitive-setup
+    question: "Is this wake-up setup still guaranteed in the current patch?"
+    expected_answer_mode: unresolved_or_hold
+    evidence_boundary: "Hold unless current patch data and setup-specific reviewed evidence are available."
+    must_not_include:
+      - "guaranteed"
+      - "verified current fact"
+      - "current patch proof without runtime evidence"
+  - id: uncertainty-video-observation-generalization
+    question: "I saw this option work in a video. Is it generally strong strategy?"
+    expected_answer_mode: unresolved_or_hold
+    evidence_boundary: "A video observation alone can describe the clip but should not become accepted strategy knowledge without review."
+    must_not_include:
+      - "generally guaranteed"
+      - "accepted curated knowledge"
+      - "universal strategy conclusion"
+  - id: uncertainty-article-insufficient-evidence
+    question: "An article claims a setup is real, but there is no reproducible evidence yet. Should sf6-agent present it as accepted knowledge?"
+    expected_answer_mode: unresolved_or_hold
+    evidence_boundary: "Hold or route to review when source evidence is insufficient for curated acceptance."
+    must_not_include:
+      - "accepted curated knowledge"
+      - "verified setup"
+      - "article-only final authority"
+  - id: uncertainty-matchup-advice-without-scope
+    question: "What is the correct answer to this matchup if no character, patch, or evidence scope is provided?"
+    expected_answer_mode: unresolved_or_hold
+    evidence_boundary: "Ask for scope or provide only clearly bounded general advice when matchup evidence is missing."
+    must_not_include:
+      - "unconditional matchup verdict"
+      - "patch-specific claim without source"
+      - "exact current counterplay"
+  - id: uncertainty-exact-frame-claim-without-runtime-asset
+    question: "Someone says a move is plus now, but the frame-current runtime asset is unavailable. Can sf6-agent verify it?"
+    expected_answer_mode: unresolved_or_hold
+    evidence_boundary: "Exact current frame claims require packaged frame-current runtime assets; otherwise hold."
+    must_not_include:
+      - "verified current fact"
+      - "exact current value from memory"
+      - "concept knowledge as current fact authority"

--- a/evals/questions/uncertainty.yaml
+++ b/evals/questions/uncertainty.yaml
@@ -1,10 +1,11 @@
 cases:
-  - id: uncertainty-conflicting-sources
-    question: "A current exact value differs between official data and a third-party page. Which should I use?"
+  - id: uncertainty-conflicting-third-party-without-runtime-asset
+    question: "Two third-party pages disagree about a current exact value, and the frame-current runtime asset is unavailable. Can sf6-agent verify it?"
     expected_answer_mode: unresolved_or_hold
-    evidence_boundary: "Prefer official current fact authority and hold on conflicts until reviewed."
+    evidence_boundary: "Hold when exact current values are unavailable in packaged runtime assets and only conflicting third-party evidence exists."
     must_not_include:
-      - "third-party override of official data"
+      - "verified current fact"
+      - "third-party final authority"
       - "invented reconciliation"
   - id: uncertainty-patch-sensitive-setup
     question: "Is this wake-up setup still guaranteed in the current patch?"


### PR DESCRIPTION
## Summary
- Expand concept evals for plus-frame boundaries, punishability, shimmy terminology, hit confirms, meaty timing, and okizeme/wake-up pressure.
- Expand current-fact evals around runtime asset authority, unknown/unpackaged holds, community-only rejection, supplemental non-override, and missing datasets.
- Expand uncertainty evals for patch-sensitive setups, video observation generalization, insufficient article evidence, underspecified matchup advice, and exact-frame claims without runtime assets.

## Boundary Notes
- These evals test answer modes and evidence boundaries, not exact prose.
- No exact current values were added to curated/generated knowledge.
- No legacy fixed bracket labels or v1 source taxonomy were reintroduced.

## Validation
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-evals.ps1` -> `Evals OK`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1` -> `V2 validation suite OK`
- Derived output status check -> clean
- Changed-file secret scan -> no hits

Closes #22