### PR TITLE
[v2.1] Retire migration-only legacy taxonomy guards

### DIFF
--- a/tests/validation/validate-evals.ps1
+++ b/tests/validation/validate-evals.ps1
@@ -42,6 +42,11 @@ foreach ($relativePath in $questionFiles) {
       if ($key -notin $allowedTopLevelKeys) {
         $violations += "$relativePath has unsupported top-level eval key: $key"
       }
+    } elseif ($line -match '^ {2}-\s+([A-Za-z0-9_]+):') {
+      $key = $Matches[1]
+      if ($key -notin $allowedCaseKeys) {
+        $violations += "$relativePath has unsupported eval case key: $key"
+      }
     } elseif ($line -match '^ {4}([A-Za-z0-9_]+):') {
       $key = $Matches[1]
       if ($key -notin $allowedCaseKeys) {

--- a/tests/validation/validate-evals.ps1
+++ b/tests/validation/validate-evals.ps1
@@ -22,25 +22,49 @@ foreach ($relativePath in $questionFiles + $rubricFiles) {
   }
 }
 
+$allowedTopLevelKeys = @('cases')
+$allowedCaseKeys = @(
+  'id',
+  'question',
+  'expected_answer_mode',
+  'evidence_boundary',
+  'must_not_include'
+)
+
 foreach ($relativePath in $questionFiles) {
   $content = Get-Content -LiteralPath (Join-Path $repoRoot $relativePath) -Raw -Encoding UTF8
+  $normalized = $content -replace "`r`n", "`n"
+  $violations = @()
+
+  foreach ($line in ($normalized -split "`n")) {
+    if ($line -match '^([A-Za-z0-9_]+):') {
+      $key = $Matches[1]
+      if ($key -notin $allowedTopLevelKeys) {
+        $violations += "$relativePath has unsupported top-level eval key: $key"
+      }
+    } elseif ($line -match '^ {4}([A-Za-z0-9_]+):') {
+      $key = $Matches[1]
+      if ($key -notin $allowedCaseKeys) {
+        $violations += "$relativePath has unsupported eval case key: $key"
+      }
+    }
+  }
+
   foreach ($needle in @('id:', 'question:', 'expected_answer_mode:', 'evidence_boundary:', 'must_not_include:')) {
     if ($content -notmatch [regex]::Escape($needle)) {
-      throw "$relativePath missing eval metadata: $needle"
+      $violations += "$relativePath missing eval metadata: $needle"
     }
   }
   $modeMatches = [regex]::Matches($content, 'expected_answer_mode:\s*([A-Za-z0-9_/-]+)')
   foreach ($modeMatch in $modeMatches) {
     $mode = $modeMatch.Groups[1].Value
     if ($mode -notin @('stable_concept', 'verified_current_fact', 'strategy_or_matchup_knowledge', 'observation', 'unresolved_or_hold')) {
-      throw "$relativePath has unsupported expected_answer_mode: $mode"
+      $violations += "$relativePath has unsupported expected_answer_mode: $mode"
     }
   }
-  if ($content -match '\[\u6982\u5ff5\u306e\u307f\]|\[\u691c\u8a3c\u6e08\u307f\]|\[\u4fdd\u7559\]') {
-    throw "$relativePath must check answer modes, not legacy bracket labels"
-  }
-  if ($content -match '\bT[1-4]\b|source_tier|core / mixed / current-fact') {
-    throw "$relativePath must not preserve legacy taxonomy in eval metadata"
+
+  if ($violations.Count -gt 0) {
+    throw ($violations -join '; ')
   }
 }
 

--- a/tests/validation/validate-knowledge-schema.ps1
+++ b/tests/validation/validate-knowledge-schema.ps1
@@ -22,6 +22,12 @@ $requiredFields = @(
   'review_after'
 )
 
+$allowedFields = $requiredFields + @(
+  'summary',
+  'generated_allowed',
+  'must_not_include'
+)
+
 $allowedClaimKinds = @('stable_concept', 'strategy_or_matchup', 'observation', 'unresolved')
 $allowedSourceKinds = @('official', 'reproducible_observation', 'maintained_third_party', 'community', 'maintainer_note', 'unknown')
 $allowedVerificationStates = @('verified', 'partially_verified', 'unverified', 'conflicting', 'not_applicable')
@@ -106,6 +112,12 @@ foreach ($file in $files) {
   $relativePath = $file.FullName.Substring($repoRoot.Length + 1).Replace('\', '/')
   $metadata = Read-FrontMatter $file
 
+  foreach ($field in $metadata.Keys) {
+    if ($field -notin $allowedFields) {
+      $violations += "$relativePath has unsupported metadata field: $field"
+    }
+  }
+
   foreach ($field in $requiredFields) {
     if (-not $metadata.Contains($field)) {
       $violations += "$relativePath missing metadata field: $field"
@@ -141,17 +153,6 @@ foreach ($file in $files) {
   $content = Get-Content -LiteralPath $file.FullName -Raw -Encoding UTF8
   if ($relativePath -match '^knowledge/curated/' -and $content -notmatch '(?m)^\s+path:\s*') {
     $violations += "$relativePath source_refs must include a reviewable path"
-  }
-  $forbiddenPatterns = @(
-    @{ Label = 'source_tier'; Pattern = [regex]::Escape('source_tier') },
-    @{ Label = 'legacy concept-only bracket label'; Pattern = '\[\u6982\u5ff5\u306e\u307f\]' },
-    @{ Label = 'T1 / T2 / T3 / T4'; Pattern = [regex]::Escape('T1 / T2 / T3 / T4') },
-    @{ Label = 'core / mixed / current-fact'; Pattern = [regex]::Escape('core / mixed / current-fact') }
-  )
-  foreach ($forbidden in $forbiddenPatterns) {
-    if ($content -match $forbidden.Pattern) {
-      $violations += "$relativePath contains legacy canonical taxonomy text: $($forbidden.Label)"
-    }
   }
 }
 

--- a/tests/validation/validate-legacy-cleanup.ps1
+++ b/tests/validation/validate-legacy-cleanup.ps1
@@ -23,46 +23,6 @@ foreach ($relativePath in $legacyPaths) {
   }
 }
 
-$canonicalRoots = @(
-  'AGENTS.md',
-  'README.md',
-  'knowledge',
-  'contracts',
-  'evals',
-  'workflows',
-  'skills/sf6-agent'
-)
-
-$legacyMetadataPatterns = @(
-  @{ Label = 'source_tier'; Pattern = [regex]::Escape('source_tier') },
-  @{ Label = 'legacy answer label metadata'; Pattern = '\u56de\u7b54\u30e9\u30d9\u30eb' },
-  @{ Label = 'legacy evidence tier metadata'; Pattern = '\u6839\u62e0\u968e\u5c64' },
-  @{ Label = 'core-community-label'; Pattern = [regex]::Escape('core-community-label') },
-  @{ Label = 'concept-stable'; Pattern = [regex]::Escape('concept-stable') },
-  @{ Label = 'community-labeled'; Pattern = [regex]::Escape('community-labeled') }
-)
-
-foreach ($relativeRoot in $canonicalRoots) {
-  $path = Join-Path $repoRoot $relativeRoot
-  if (-not (Test-Path -LiteralPath $path)) {
-    continue
-  }
-  $files = if (Test-Path -LiteralPath $path -PathType Leaf) {
-    @(Get-Item -LiteralPath $path)
-  } else {
-    @(Get-ChildItem -LiteralPath $path -Recurse -File)
-  }
-  foreach ($file in $files) {
-    $relativePath = $file.FullName.Substring($repoRoot.Length + 1).Replace('\', '/')
-    $content = Get-Content -LiteralPath $file.FullName -Raw -Encoding UTF8
-    foreach ($pattern in $legacyMetadataPatterns) {
-      if ($content -match $pattern.Pattern) {
-        $violations += "$relativePath contains legacy canonical metadata: $($pattern.Label)"
-      }
-    }
-  }
-}
-
 if ($violations.Count -gt 0) {
   throw ($violations -join '; ')
 }


### PR DESCRIPTION
## Summary
- Replace migration-only raw v1 vocabulary scans with v2-native allowlist checks in knowledge and eval validators.
- Keep v2 enum, required metadata, current-fact boundary, generated-surface, and legacy directory absence validation intact.
- Narrow legacy cleanup validation back to removed surface/path absence instead of scanning canonical prose for old vocabulary strings.

## Details
- `validate-knowledge-schema.ps1` now rejects unsupported ordinary knowledge frontmatter keys.
- `validate-evals.ps1` now rejects unsupported top-level and case metadata keys while preserving answer-mode enum validation.
- `validate-legacy-cleanup.ps1` still checks legacy paths are absent, but no longer scans canonical text for migration-era vocabulary.

## Validation
- Temporary guard check: unsupported knowledge frontmatter key fails `validate-knowledge-schema.ps1`.
- Temporary guard check: unsupported eval case key fails `validate-evals.ps1`.
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-knowledge-schema.ps1` -> `Knowledge schema OK`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-evals.ps1` -> `Evals OK`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-legacy-cleanup.ps1` -> `Legacy cleanup OK`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1` -> `V2 validation suite OK`
- Derived output status check -> clean
- Changed-file secret scan -> no hits

Closes #24