### PR TITLE
[v2.1] Record packaged sf6-agent smoke run

### DIFF
--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -5,6 +5,7 @@ The v2 validation suite protects schemas, boundaries, generated markers, distrib
 Manual adapter behavior checks:
 
 - `docs/testing/sf6-agent-smoke.md`
+- `docs/testing/smoke-runs/`
 
 Run the full local verification sequence with:
 

--- a/docs/testing/smoke-runs/2026-05-01-codex-cli-sf6-agent.md
+++ b/docs/testing/smoke-runs/2026-05-01-codex-cli-sf6-agent.md
@@ -1,0 +1,58 @@
+# sf6-agent Smoke Run: Codex CLI
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| Date | 2026-05-01 |
+| Agent | Codex CLI 0.128.0-alpha.1 |
+| Model | gpt-5.5 |
+| Bundle source | `.dist/sf6-agent-bundle.zip` |
+| Commit | `1c0a9b77fb0bf66da78c5403b62c0af2ec91df32` |
+| Extracted adapter root | `/tmp/sf6-agent-smoke-aNq80u/sf6-agent` |
+| Full repo checkout visible | no |
+
+## Method
+
+The release bundle was built with `tests/validation/run-all.ps1`, extracted to a temporary directory, and tested with Codex CLI using the extracted `sf6-agent/` directory as the working root.
+
+The smoke prompt instructed the agent to use only the packaged adapter surface:
+
+- `SKILL.md`
+- `references/answer-policy.md`
+- `references/current-fact-policy.md`
+- `references/uncertainty-policy.md`
+- `references/generated-*`
+- `assets/frame-current/`
+
+The prompt explicitly denied access to `knowledge/`, `data/exports/`, `data/roster/`, `contracts/`, and `workflows/`. Exact current values were not pasted into this report.
+
+## Results
+
+| Case | Expected mode | Observed mode | Result | Notes |
+|---:|---|---|---|---|
+| 1 | `stable_concept` | `stable_concept` | Pass | Generated concept references were used for stable concept grounding; no exact frame lookup was needed. |
+| 2 | `stable_concept` | `stable_concept` | Pass | The answer boundary separated frame advantage from guaranteed follow-up claims. |
+| 3 | `stable_concept` | `stable_concept` | Pass | Shimmy was treated as community terminology, not official wording. |
+| 4 | `stable_concept` | `stable_concept` | Pass | Hit confirm was treated as a stable concept; routes and windows were kept as separate current or strategy claims. |
+| 5 | `stable_concept` | `stable_concept` | Pass | Meaty timing was treated as a concept; exact wake-up setups were kept behind current verification. |
+| 6 | `verified_current_fact` | `verified_current_fact` | Pass | Luke was packaged and the requested block field was present in the official packaged row. Exact value withheld. |
+| 7 | `verified_current_fact` | `verified_current_fact` | Pass | Luke's packaged official row contained both requested fields. Exact values withheld. |
+| 8 | `unresolved_or_hold` | `unresolved_or_hold` | Pass | A character outside packaged roster/assets could not be verified. |
+| 9 | `verified_current_fact` | `verified_current_fact` | Pass | `official_raw` was treated as controlling authority; supplemental enrichment was not allowed to override it. |
+| 10 | `unresolved_or_hold` | `unresolved_or_hold` | Pass | A missing dataset was treated as a hold condition; no repo-local maintenance was assumed. |
+| 11 | `unresolved_or_hold` | `unresolved_or_hold` | Pass | The setup was treated as underspecified and patch-sensitive. |
+| 12 | `unresolved_or_hold` | `unresolved_or_hold` | Pass | A video anecdote alone was not promoted to general strategy knowledge. |
+| 13 | `unresolved_or_hold` | `unresolved_or_hold` | Pass | Conflicting third-party current facts without packaged frame-current assets were held. |
+
+## Findings
+
+- Packaged-surface behavior matched the expected modes for all 13 cases.
+- Exact current frame answers stayed limited to `assets/frame-current/`, with `official_raw` as controlling source.
+- Generated references were used for stable concept grounding only, not canonical exact current data.
+- Missing, conflicting, underspecified, or non-packaged current facts were held.
+
+## Follow-ups
+
+- None required for this smoke run.
+


### PR DESCRIPTION
## Summary

- Run the `sf6-agent` smoke test against an extracted `.dist/sf6-agent-bundle.zip` adapter, not the full repository checkout.
- Record the Codex CLI smoke results under `docs/testing/smoke-runs/`.
- Link smoke run records from `docs/testing/README.md`.

## Smoke setup

- Bundle source: `.dist/sf6-agent-bundle.zip` built by `tests/validation/run-all.ps1`
- Extracted adapter root: `/tmp/sf6-agent-smoke-aNq80u/sf6-agent`
- Agent: Codex CLI 0.128.0-alpha.1
- Full repo checkout visible to smoke agent: no

## Results

- 13 / 13 smoke cases passed.
- Concept cases preserved `stable_concept` boundaries.
- Current-fact cases used packaged frame-current authority or held.
- Uncertainty cases held instead of inventing facts.
- Generated references were not treated as canonical exact current data.
- Exact current values were not pasted into the smoke report.

## Validation

- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1` -> `V2 validation suite OK`
- Derived output status check -> clean
- `git diff --check` -> clean
- Changed-file secret scan -> no hits
- Exact current value pattern scan on smoke report -> no hits

Closes #28