### PR TITLE
Define Japanese-first operating language policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,14 @@
 - Use answer modes and evidence-boundary behavior to evaluate answer quality.
 - Keep answer behavior grounded in contracts, evals, and source boundaries.
 
+## Language Policy
+
+- Japanese is the primary operating language for SF6 user questions, source summaries, review notes, and curated prose when appropriate.
+- Metadata keys, artifact IDs, schema enum values, filenames, generated markers, and validator contracts remain English-compatible.
+- Do not duplicate canonical knowledge only to create separate English/Japanese versions.
+- Keep `skills/sf6-agent/` as the single public adapter unless a later architecture decision changes it.
+- See `docs/architecture/language-policy.md`.
+
 ## Workflow Rules
 
 - Maintainer procedures belong under `workflows/`.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -3,3 +3,4 @@
 Architecture docs define the v2 source-of-truth model.
 
 - [v2-architecture.md](./v2-architecture.md)
+- [language-policy.md](./language-policy.md)

--- a/docs/architecture/language-policy.md
+++ b/docs/architecture/language-policy.md
@@ -1,0 +1,62 @@
+# Language Policy
+
+SF6 Knowledge Agent Kit is Japanese-first in operation and English-compatible in structure.
+
+## Japanese-first Operation
+
+Japanese prose is allowed and encouraged for:
+
+- user-facing guidance
+- source summaries
+- review notes
+- curated explanations
+- maintainer notes for Japanese sources
+
+When users ask in Japanese, `sf6-agent` should answer in Japanese unless they ask otherwise.
+
+## English-compatible Structure
+
+Keep these English-compatible and stable:
+
+- metadata keys
+- artifact IDs
+- schema enum values
+- filenames and path slugs
+- generated markers
+- validator contracts
+- package and installer interfaces
+
+## Canonical Knowledge
+
+Do not duplicate canonical knowledge pages only to create separate English and Japanese versions.
+
+A curated page may use Japanese prose when that is the most natural operating language. The page remains canonical because of its artifact path, metadata, source references, review status, and validation, not because of English prose.
+
+## Localized Files
+
+`.ja.*` files may be used for human-facing localized documentation when they improve usability.
+
+Examples that may be appropriate:
+
+- `README.ja.md`
+- `docs/distribution/agents/codex.ja.md`
+
+Avoid `.ja.*` files for canonical knowledge pages or core workflows unless an architecture decision defines how canonical and localized variants stay synchronized.
+
+## Public Adapter
+
+Keep `skills/sf6-agent/` as the single public adapter for now.
+
+Do not create `sf6-agent-ja` unless a later architecture decision shows that a separate Japanese adapter is necessary and can be validated without duplicate source-of-truth drift.
+
+## Source Ingest
+
+Japanese source ingest should summarize and review in Japanese by default when useful.
+
+The repo may store Japanese summaries, Japanese review notes, and Japanese claim explanations. It must not store full copyrighted articles, transcripts, or large excerpts by default.
+
+## Current Facts
+
+Language policy does not change current-fact authority.
+
+Exact current facts remain grounded in `data/exports/`, `data/roster/`, and derived frame-current runtime assets.

--- a/docs/architecture/v2-architecture.md
+++ b/docs/architecture/v2-architecture.md
@@ -36,7 +36,7 @@ Frame-current assets come from `data/exports/` plus `data/roster/` only. They mu
 
 V2 uses generic evidence metadata. Canonical artifacts should describe source kind, source role, evidence basis, verification state, confidence, volatility, patch sensitivity, review status, source references, and review timing.
 
-Historical labels and source-tier names may appear only when documenting deprecated v1 behavior. They are not v2 metadata fields.
+These fields are the metadata vocabulary used by current contracts, evals, and validators.
 
 ## Answer Modes
 
@@ -48,7 +48,7 @@ Public answers should communicate the mode and evidence boundary naturally:
 - `observation`
 - `unresolved_or_hold`
 
-Evals check whether the answer mode and boundary behavior are correct. They do not require legacy bracket labels.
+Evals check whether the answer mode and boundary behavior are correct.
 
 ## Hermes
 


### PR DESCRIPTION
## Summary

Defines the repository language policy as Japanese-first in operation and English-compatible in structure.

## Changed Surfaces

- Added `docs/architecture/language-policy.md`.
- Linked it from `docs/architecture/README.md`.
- Added a short Language Policy pointer to `AGENTS.md`.
- Tightened `docs/architecture/v2-architecture.md` wording to describe current metadata and answer-mode behavior directly.

## Boundary Notes

- No knowledge artifacts changed.
- No generated references changed.
- No frame-current assets changed.
- No validators changed.
- No `.ja.*` files created.
- No separate Japanese skill created.
- `skills/sf6-agent/` remains the single public adapter.

## Validation

```text
powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1
V2 validation suite OK
```

Additional checks:

```text
git diff --check: pass
derived output status: clean
changed-file credential material scan: no hits
architecture/AGENTS old wording scan: no hits
```

Closes #44