### PR TITLE
Document Hermes ingest profile setup

### DIFF
--- a/workflows/README.md
+++ b/workflows/README.md
@@ -7,6 +7,7 @@ Workflow docs are readable by humans and agents without requiring a skill runtim
 ## Canonical Procedures
 
 - [GitHub management](github-management.md)
+- [Hermes ingest profile setup](hermes-ingest-profile-setup.md)
 - [Update frame data](update-frame-data.md)
 - [Ingest article](ingest-article.md)
 - [Review claims](review-claims.md)

--- a/workflows/hermes-ingest-profile-setup.md
+++ b/workflows/hermes-ingest-profile-setup.md
@@ -58,8 +58,12 @@ Before using `sf6ingest` for article ingest:
 
 ```bash
 test -n "$HERMES_HOME"
+repo_root="$(git rev-parse --show-toplevel)"
 case "$HERMES_HOME" in
-  /absolute/path/to/SF6-skills/*) echo "HERMES_HOME is inside the repo; stop" ;;
+  "$repo_root"/*)
+    echo "HERMES_HOME is inside the repo; stop"
+    exit 1
+    ;;
   *) echo "HERMES_HOME is outside the repo" ;;
 esac
 

--- a/workflows/hermes-ingest-profile-setup.md
+++ b/workflows/hermes-ingest-profile-setup.md
@@ -1,0 +1,88 @@
+# Hermes Ingest Profile Setup
+
+This workflow documents how maintainers should set up and verify a dedicated Hermes profile for SF6 Knowledge Agent Kit article ingest and review assistance.
+
+Hermes is an optional maintainer harness. It is not required for article ingest, and Hermes memory is not canonical SF6 knowledge.
+
+## Profile Roles
+
+Use separate Hermes profiles for separate maintainer tasks:
+
+- `sf6smoke`: smoke tests for Hermes harness behavior.
+- `sf6ingest`: article ingest and review workflow assistance.
+
+The ingest profile should help draft source summaries, candidate claims, and review notes while following `workflows/ingest-article.md`.
+
+Final source, claim, and review outputs must be committed as repo artifacts under `knowledge/`. A Hermes profile, session, memory entry, or chat transcript is not a source of truth.
+
+## Profile Isolation
+
+Hermes profile state is profile-scoped. Config, provider authentication, sessions, memory, cron state, managed skills, and `.env` files can differ between profiles.
+
+Profile isolation is not a filesystem sandbox. Run Hermes from a deliberate working directory, keep `HERMES_HOME` outside this repository, and verify repository cleanliness after each run.
+
+## Provider Authentication
+
+Runtime/provider authentication is profile-scoped. A new or cloned ingest profile may discover repo skills but still fail non-interactive execution until that profile has completed its own provider authentication.
+
+For a new `sf6ingest` profile:
+
+1. Create or select a Hermes profile whose home directory is outside this repo.
+2. Configure provider authentication interactively for that profile.
+3. Run `hermes doctor` with the ingest profile selected.
+4. Run a small non-interactive command with the ingest profile before using it for article ingest.
+
+Do not copy credentials into this repository. Do not paste tokens, API keys, device codes, `.env` contents, or account-specific auth output into issue comments, PR bodies, smoke reports, or workflow docs.
+
+## Recommended Setup Shape
+
+Use repo-external profile state:
+
+```bash
+export HERMES_HOME="$HOME/.hermes/profiles/sf6ingest"
+```
+
+Configure Hermes so it can discover the repo's public adapter skills without turning Hermes state into repo state. When using external skill discovery, prefer the repo `skills/` directory:
+
+```yaml
+skills:
+  external_dirs:
+    - /absolute/path/to/SF6-skills/skills
+```
+
+Do not configure `workflows/` as a skill directory. Workflows are canonical maintainer procedures, not public adapter skills.
+
+## Verification
+
+Before using `sf6ingest` for article ingest:
+
+```bash
+test -n "$HERMES_HOME"
+case "$HERMES_HOME" in
+  /absolute/path/to/SF6-skills/*) echo "HERMES_HOME is inside the repo; stop" ;;
+  *) echo "HERMES_HOME is outside the repo" ;;
+esac
+
+hermes doctor
+hermes chat -Q --max-turns 1 -q "Reply with one sentence confirming this profile can run non-interactively."
+```
+
+After any Hermes-assisted ingest run:
+
+```bash
+git status --porcelain
+find . -maxdepth 3 \( -name ".hermes" -o -name ".env" -o -iname "*session*" -o -iname "*memory*" -o -iname "*cron*" \)
+```
+
+The expected repository state is clean except for intentional repo artifacts such as source notes, candidate claims, review notes, or smoke reports.
+
+## Ingest Boundaries
+
+When Hermes assists article ingest:
+
+- `workflows/ingest-article.md` remains the canonical ingest procedure.
+- Hermes may draft summaries, claim decomposition, and review notes.
+- Maintainer review normalizes outputs before commit.
+- Canonical outputs belong under `knowledge/sources/`, `knowledge/evidence/claims/`, and `knowledge/review/`.
+- Claims do not become curated knowledge until reviewed and promoted through the repo workflow.
+- Do not store full copyrighted articles, transcripts, large excerpts, credentials, or private local state in the repo.


### PR DESCRIPTION
## Summary

Documents the recommended Hermes profile/auth setup for article ingest and review assistance.

## Changed Surfaces

- Added `workflows/hermes-ingest-profile-setup.md`.
- Linked it from `workflows/README.md`.

## Key Points

- `sf6smoke` is for harness smoke tests.
- `sf6ingest` is for article ingest and review workflow assistance.
- Hermes provider authentication is profile-scoped.
- Profile isolation is not a filesystem sandbox.
- `HERMES_HOME`, profile state, credentials, sessions, memory, cron, and `.env` files must stay outside the repository.
- Hermes memory is not canonical SF6 knowledge.
- `workflows/ingest-article.md` remains the canonical ingest procedure.
- Final outputs must be repo artifacts under `knowledge/`.

## Boundary Notes

- Documentation/workflow only.
- No knowledge artifacts changed.
- No generated references changed.
- No frame-current assets changed.
- No validators changed.
- No packaging or Hermes pack behavior changed.

## Validation

```text
powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1
V2 validation suite OK
```

Additional checks:

```text
git diff --check: pass
derived output status: clean
credential material scan: no secret material
```

Closes #40