### PR TITLE
Define media scratch cache policy

### DIFF
--- a/workflows/README.md
+++ b/workflows/README.md
@@ -8,6 +8,7 @@ Workflow docs are readable by humans and agents without requiring a skill runtim
 
 - [GitHub management](github-management.md)
 - [Hermes ingest profile setup](hermes-ingest-profile-setup.md)
+- [Media scratch cache policy](media-scratch-cache-policy.md)
 - [Update frame data](update-frame-data.md)
 - [Ingest article](ingest-article.md)
 - [Review claims](review-claims.md)

--- a/workflows/media-scratch-cache-policy.md
+++ b/workflows/media-scratch-cache-policy.md
@@ -94,7 +94,7 @@ After media ingest work, verify the repository did not receive raw media or loca
 ```bash
 git status --porcelain
 
-find . -maxdepth 4 \
+find . \
   \( -name ".hermes" -o -name ".env" -o -iname "*session*" -o -iname "*memory*" -o -iname "*cron*" \
      -o -iname "*.png" -o -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.webp" \
      -o -iname "*.mp4" -o -iname "*.mov" -o -iname "*.mkv" \) \

--- a/workflows/media-scratch-cache-policy.md
+++ b/workflows/media-scratch-cache-policy.md
@@ -1,0 +1,119 @@
+# Media Scratch Cache Policy
+
+This workflow defines how maintainers should handle temporary images, screenshots, videos, browser artifacts, and vision artifacts during image-aware or video ingest.
+
+Raw media is working material. It is not canonical SF6 knowledge and should not be committed to this repository by default.
+
+## Repo Boundary
+
+The repository should store reviewable knowledge artifacts, not raw media caches.
+
+Allowed repo artifacts include:
+
+- source URLs
+- `accessed_at` and `captured_at` metadata
+- short source summaries
+- image or video observation summaries
+- image index or timestamp references
+- uncertainty notes
+- candidate claims
+- review notes
+
+Forbidden repo artifacts by default include:
+
+- raw article images
+- screenshots
+- copied article image assets
+- downloaded videos or clips
+- full transcripts
+- large excerpts
+- browser cache artifacts
+- session, memory, cron, or profile state
+- credentials, tokens, or local `.env` files
+
+## Scratch Root
+
+Use a repo-external scratch/cache root for temporary media work.
+
+Recommended WSL/Linux/macOS root:
+
+```bash
+scratch_root="${XDG_CACHE_HOME:-$HOME/.cache}/sf6-skills/media-ingest"
+```
+
+Optional Windows equivalent:
+
+```text
+%LOCALAPPDATA%\sf6-skills\media-ingest\
+```
+
+Do not use repo-local paths such as `tmp/`, `.cache/`, `downloads/`, or `assets/raw/` for media ingest scratch files.
+
+## Per-run Directory
+
+Create one directory per ingest run:
+
+```bash
+run_id="$(date +%Y%m%d)-<source-slug>"
+run_dir="$scratch_root/$run_id"
+mkdir -p "$run_dir"
+```
+
+Example:
+
+```bash
+~/.cache/sf6-skills/media-ingest/20260502-mizen-simple-yomi/
+```
+
+The run directory may hold temporary downloads, extracted frames, screenshots, OCR intermediates, browser exports, or other working files while the ingest run is active.
+
+## Cleanup And Retention
+
+Default behavior: delete scratch files after the run.
+
+```bash
+du -sh "$run_dir"
+rm -rf "$run_dir"
+test ! -e "$run_dir"
+```
+
+If temporary media must be retained briefly:
+
+- keep it outside the repo;
+- record the reason in the smoke report or maintainer notes;
+- prefer retention of 7 days or less;
+- do not treat retained local cache as canonical evidence;
+- delete it when the review task is complete.
+
+Retained cache is only a maintainer convenience. Repo artifacts such as source metadata, observations, claims, and review notes are the reviewable record.
+
+## Verification
+
+After media ingest work, verify the repository did not receive raw media or local state:
+
+```bash
+git status --porcelain
+
+find . -maxdepth 4 \
+  \( -name ".hermes" -o -name ".env" -o -iname "*session*" -o -iname "*memory*" -o -iname "*cron*" \
+     -o -iname "*.png" -o -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.webp" \
+     -o -iname "*.mp4" -o -iname "*.mov" -o -iname "*.mkv" \) \
+  -not -path "./.git/*" \
+  -not -path "./skills/sf6-agent/assets/frame-current/*" \
+  | sort
+```
+
+Record in the PR or smoke report whether cleanup was completed or whether repo-external cache remains temporarily with a reason.
+
+## Hermes And Browser/Vision State
+
+Hermes, browser, and vision profile state must remain outside the repository.
+
+Hermes memory, browser cache, screenshots, downloaded images, extracted frames, and session state are not canonical SF6 knowledge. If Hermes-native vision is tested, this scratch policy still applies.
+
+Final outputs should be normalized into repository artifacts under the appropriate surfaces, such as:
+
+- `knowledge/sources/`
+- `knowledge/evidence/claims/`
+- `knowledge/review/`
+- `docs/testing/smoke-runs/`


### PR DESCRIPTION
## Summary

Defines a repo-external scratch/cache policy for image-aware and video ingest workflows.

The goal is to prevent raw images, screenshots, videos, browser artifacts, sessions, memory, and credentials from accumulating in the repository or becoming canonical knowledge.

## Changed Surfaces

- Added `workflows/media-scratch-cache-policy.md`.
- Linked it from `workflows/README.md`.

## Policy Highlights

- Raw media is working material, not canonical SF6 knowledge.
- Use repo-external scratch root such as `${XDG_CACHE_HOME:-$HOME/.cache}/sf6-skills/media-ingest`.
- Use per-run directories such as `<cache-root>/<YYYYMMDD>-<source-slug>/`.
- Default behavior is to delete scratch files after the run.
- Short retention, when needed, must stay repo-external, have a reason, and should prefer 7 days or less.
- Retained local cache is never canonical evidence.
- Repo artifacts should be source URLs, summaries, observations, claims, review notes, and uncertainty notes.
- Workflow includes repo-local media/state scan guidance.
- Hermes/browser/vision profile state remains repo-external and non-canonical.

## Boundary Notes

- Documentation/workflow only.
- No knowledge artifacts changed.
- No generated references changed.
- No frame-current assets changed.
- No validators changed.
- No packaging or Hermes pack behavior changed.
- No raw media assets added.

## Validation

```text
powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1
V2 validation suite OK
```

Additional checks:

```text
git diff --check: pass
derived output status: clean
repo-local media/state scan: no hits
changed-file credential material scan: no secret material
```

Closes #49