### PR TITLE
[v2.1] Pilot video observation workflow

### DIFF
--- a/docs/testing/smoke-runs/2026-05-03-video-observation-youtube-shorts-sycyvw6h8wi.md
+++ b/docs/testing/smoke-runs/2026-05-03-video-observation-youtube-shorts-sycyvw6h8wi.md
@@ -1,0 +1,87 @@
+# Video Observation Pilot: YouTube Shorts syCYVW6h8WI
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| Date | 2026-05-03 |
+| Issue | #52 |
+| Source | YouTube Shorts `syCYVW6h8WI` |
+| Canonical URL | `https://www.youtube.com/shorts/syCYVW6h8WI` |
+| Title | `【スト6】仕様を利用したテクニック！端から逃げやすくなる！` |
+| Channel | ACQUA |
+| Published/uploaded | 2026-04-29 |
+| Duration | 69 seconds |
+| Repo commit before changes | `126cc60` |
+| Scratch root | `${XDG_CACHE_HOME:-$HOME/.cache}/sf6-skills/media-ingest` |
+| Run directory | `20260503-youtube-shorts-sycyvw6h8wi` |
+
+## Method
+
+- Followed `workflows/ingest-video.md`.
+- Followed `workflows/media-scratch-cache-policy.md`.
+- Used repo-external scratch for temporary metadata, a low-resolution video copy, sparse sampled frames, a contact sheet, and Japanese auto-caption inspection.
+- Used `yt-dlp` as a temporary repo-external tool downloaded into the scratch directory.
+- Used `ffprobe` for duration/fps metadata and `ffmpeg` for sparse frame sampling.
+- Used maintainer visual inspection of sampled frames and caption paraphrases for timestamped observations.
+- Did not store raw video, raw frames, screenshots, contact sheet, browser cache, session state, or full captions/transcript in the repository.
+
+## Tooling Check
+
+| Tool / Capability | Result | Notes |
+|---|---|---|
+| YouTube metadata extraction | Pass | Title, channel, duration, upload date, and caption availability were collected into scratch. |
+| Japanese auto-caption availability | Pass | Japanese auto-generated captions were available; full transcript was not stored in repo. |
+| Temporary video access | Pass | 360x640 MP4, 30 fps, 69.077 seconds; stored only in scratch. |
+| Frame sampling | Pass | Sparse frames and one contact sheet were generated only in scratch. |
+| Hermes-native browser check | Partial | `sf6ingest` doctor shows browser/vision available, but this pilot used direct scratch-based observation for the video workflow. |
+
+## Timestamped Observation Summary
+
+| Time | Visible observation | Speaker/commentary claim | Confidence | Notes |
+|---|---|---|---|---|
+| 00:00-00:05 | ACQUA-branded Shorts layout with Japanese overlay about using an SF6 specification to escape the corner more easily. | Speaker introduces the topic as something many players may not know. | medium | Metadata and overlay support the topic only. |
+| 00:05-00:15 | Gameplay appears to show a corner/near-corner escape into jump/back-jump movement. | Speaker describes escaping from the screen edge and then holding back jump. | medium | Character identities and exact moves unresolved. |
+| 00:15-00:24 | Grounded/landing interaction is shown after jump movement. | Speaker discusses a landing window where guarding is possible and throw timing at landing. | low | This is not accepted current-system proof. |
+| 00:24-00:34 | Gameplay and overlay frame the situation as holding up/back jump and being vulnerable to strikes. | Speaker says holding up/back jump can lose to strikes. | medium | Review-only. |
+| 00:34-00:42 | Close-range sequence is presented as a back-jump-related guard example. | Speaker says the character is back-jumping but guarding and contrasts throw escape with guarding strikes. | medium | Visual support is partial. |
+| 00:42-00:56 | Same demonstration context continues. | Speaker explains a small landing guard-only window and holding back jump becoming guard against strikes during that window. | low | Potential current mechanic; needs verification. |
+| 00:57-01:09 | Final summary-style segment. | Speaker says the technique is strong but not universal, can still lose to throws or later attacks, and treats the behavior as specification. | medium | Useful as source-local explanation only. |
+
+## Artifacts Created
+
+- `knowledge/sources/videos/youtube-shorts-sycyvw6h8wi.md`
+- `knowledge/evidence/video-observations/youtube-shorts-sycyvw6h8wi.observations.md`
+- `knowledge/review/unresolved/youtube-shorts-sycyvw6h8wi.review.md`
+
+No `knowledge/evidence/claims/*.claims.md` artifact was created because this first pilot only needed source metadata, observations, and review holding.
+
+## Boundaries
+
+- Raw video stored in repo: no.
+- Raw frames or screenshots stored in repo: no.
+- Full transcript stored in repo: no.
+- Curated promotion: no.
+- Generated references updated: no.
+- Frame-current assets updated: no.
+- Video-derived observations remain `observation / needs_review`.
+- Speaker claims about landing behavior, throw timing, strike interaction, and specification status are not accepted current facts.
+
+## Cleanup
+
+- Scratch cleanup was performed after artifact drafting and validation.
+- Retained scratch cache as canonical evidence: no.
+- Repo-local media/state scan result: no unexpected media/state files after cleanup.
+
+## Findings
+
+- The existing `workflows/ingest-video.md` and `contracts/video-observation.schema.json` were sufficient for a first coarse video observation artifact.
+- A dedicated validator for `knowledge/evidence/video-observations/*.observations.md` is still missing.
+- A dedicated validator for `knowledge/sources/videos/*.md` is still missing.
+- Short vertical videos can be observed safely as review-only evidence, but low resolution, overlays, and auto-caption quality limit confidence.
+
+## Follow-ups
+
+- Add an executable validator for video observation artifacts.
+- Consider a video source artifact validator once more video sources exist.
+- Review whether the observed technique should become a candidate claim only after independent gameplay/current-patch verification.

--- a/docs/testing/smoke-runs/2026-05-03-video-observation-youtube-shorts-sycyvw6h8wi.md
+++ b/docs/testing/smoke-runs/2026-05-03-video-observation-youtube-shorts-sycyvw6h8wi.md
@@ -34,7 +34,7 @@
 | Japanese auto-caption availability | Pass | Japanese auto-generated captions were available; full transcript was not stored in repo. |
 | Temporary video access | Pass | 360x640 MP4, 30 fps, 69.077 seconds; stored only in scratch. |
 | Frame sampling | Pass | Sparse frames and one contact sheet were generated only in scratch. |
-| Hermes-native browser check | Partial | `sf6ingest` doctor shows browser/vision available, but this pilot used direct scratch-based observation for the video workflow. |
+| Hermes/browser tooling | Out of scope | This pilot did not rely on Hermes-native browser/vision. It used repo-external scratch-based video observation with `yt-dlp`, `ffprobe`, `ffmpeg`, sparse frame sampling, contact-sheet inspection, and Japanese auto-caption inspection. |
 
 ## Timestamped Observation Summary
 

--- a/knowledge/evidence/video-observations/youtube-shorts-sycyvw6h8wi.observations.md
+++ b/knowledge/evidence/video-observations/youtube-shorts-sycyvw6h8wi.observations.md
@@ -1,0 +1,181 @@
+---
+id: video-observation-youtube-shorts-sycyvw6h8wi
+title: YouTube Shorts syCYVW6h8WI Video Observation Pilot
+source_kind: reproducible_observation
+source_role: video_observation_pilot
+review_status: needs_review
+review_after: "2026-08-03"
+---
+
+# YouTube Shorts syCYVW6h8WI Video Observation Pilot
+
+This artifact records timestamped observations from one short SF6 video source. It is an observation artifact, not accepted strategy knowledge, and it must not feed generated references without later review.
+
+## Source
+
+- Source metadata: `knowledge/sources/videos/youtube-shorts-sycyvw6h8wi.md`
+- Source URL: `https://www.youtube.com/shorts/syCYVW6h8WI`
+- Accessed: 2026-05-03
+- Observation method: repo-external temporary video download, sparse frame sampling, contact-sheet inspection, and Japanese auto-caption inspection.
+- Raw media stored in repo: no.
+- Full transcript stored in repo: no.
+
+## Timestamped Observations
+
+| Time | Observation kind | Visible observation | Speaker/commentary claim | Confidence | Notes |
+|---|---|---|---|---|---|
+| 00:00-00:05 | visual + commentary | The Short opens with ACQUA branding, a face-cam layout, and Japanese overlay text about using an SF6 specification to escape from the corner more easily. | Speaker introduces the topic as something many players may not know. | medium | Title/overlay are visible; the exact gameplay claim is not verified here. |
+| 00:05-00:15 | visual + commentary | Gameplay appears in the upper portion. One character moves from a corner/near-corner escape situation into a jump/back-jump sequence. | Speaker describes escaping from the screen edge and then holding back jump. | medium | Character identities and exact move names are unresolved due to resolution and layout. |
+| 00:15-00:24 | commentary | The sampled frames show both characters returning toward a grounded interaction after jump movement. | Speaker claims there are landing frames where guarding is possible, and discusses throw timing at landing. | low | This is a speaker claim about game behavior, not accepted current fact. |
+| 00:24-00:34 | visual + commentary | The clip shows a grounded interaction after jump movement; overlay text refers to holding up and losing to strikes. | Speaker says holding up/back jump can lose to strikes. | medium | This supports a review-only observation about the video explanation, not setup validity. |
+| 00:34-00:42 | visual + commentary | A sequence appears to show a character guarding in close range after a back-jump-related setup; the overlay/commentary emphasize guard behavior. | Speaker says the character is back-jumping but guarding, and contrasts throw escape with guarding strikes. | medium | Visual support is partial; current mechanics and input timing require verification. |
+| 00:42-00:56 | commentary | The visible gameplay stays in the same close-range demonstration context. | Speaker explains that landing has a small window where only guard is possible, and that holding back jump can become guard if the opponent strikes during that window. | low | This is potentially current-system knowledge and must remain review-only. |
+| 00:57-01:09 | commentary | The final portion returns to summary-style face-cam/gameplay presentation. | Speaker says the technique is strong but not universal, can lose to meaty throw or later attacks, and treats the behavior as a specification rather than a bug. | medium | Useful as source-local explanation. Do not promote without review and current verification. |
+
+## Contract-Shaped Observation Payload
+
+This payload follows the shape of `contracts/video-observation.schema.json` at a coarse pilot level. Segment text is paraphrased; no full transcript is stored.
+
+```json
+{
+  "schema_version": "2.0.0",
+  "clip_metadata": {
+    "clip_id": "youtube-shorts-sycyvw6h8wi",
+    "source_fps": 30,
+    "normalized_fps": 60,
+    "total_frames": 4145
+  },
+  "actor_bindings": [
+    {
+      "actor_ref": "actor_a",
+      "character_slug": null,
+      "binding_confidence": 0.25,
+      "binding_basis": [
+        "character_visual",
+        "unknown"
+      ]
+    },
+    {
+      "actor_ref": "actor_b",
+      "character_slug": null,
+      "binding_confidence": 0.25,
+      "binding_basis": [
+        "character_visual",
+        "unknown"
+      ]
+    }
+  ],
+  "segments": [
+    {
+      "segment_id": "seg-0001",
+      "track": "global_phase",
+      "kind": "fight_active",
+      "start_frame": 0,
+      "end_frame": 4145,
+      "confidence": 0.7,
+      "evidence_refs": [
+        "ev-video-sample"
+      ],
+      "summary": "Shorts layout with SF6 gameplay, face cam, and Japanese explanatory overlays."
+    },
+    {
+      "segment_id": "seg-0002",
+      "track": "transcript",
+      "kind": "utterance_span",
+      "start_frame": 6,
+      "end_frame": 300,
+      "confidence": 0.7,
+      "evidence_refs": [
+        "ev-auto-caption"
+      ],
+      "language": "ja",
+      "text_summary": "Speaker introduces a specification-based corner escape topic."
+    },
+    {
+      "segment_id": "seg-0003",
+      "track": "interaction",
+      "kind": "side_switch_candidate",
+      "start_frame": 300,
+      "end_frame": 900,
+      "confidence": 0.45,
+      "evidence_refs": [
+        "ev-frame-sample"
+      ],
+      "summary": "Gameplay appears to demonstrate jump/back-jump movement around a corner or near-corner escape context."
+    },
+    {
+      "segment_id": "seg-0004",
+      "track": "transcript",
+      "kind": "utterance_span",
+      "start_frame": 900,
+      "end_frame": 1440,
+      "confidence": 0.65,
+      "evidence_refs": [
+        "ev-auto-caption"
+      ],
+      "language": "ja",
+      "text_summary": "Speaker discusses landing guard behavior and throw timing."
+    },
+    {
+      "segment_id": "seg-0005",
+      "track": "interaction",
+      "kind": "block_connect_candidate",
+      "start_frame": 2040,
+      "end_frame": 2520,
+      "confidence": 0.4,
+      "evidence_refs": [
+        "ev-frame-sample",
+        "ev-auto-caption"
+      ],
+      "summary": "A close-range sequence is presented as a back-jump-related guard example."
+    },
+    {
+      "segment_id": "seg-0006",
+      "track": "transcript",
+      "kind": "utterance_span",
+      "start_frame": 2520,
+      "end_frame": 3360,
+      "confidence": 0.65,
+      "evidence_refs": [
+        "ev-auto-caption"
+      ],
+      "language": "ja",
+      "text_summary": "Speaker explains a small landing window where guard can occur and frames the behavior as a game specification."
+    },
+    {
+      "segment_id": "seg-0007",
+      "track": "transcript",
+      "kind": "utterance_span",
+      "start_frame": 3420,
+      "end_frame": 4145,
+      "confidence": 0.65,
+      "evidence_refs": [
+        "ev-auto-caption"
+      ],
+      "language": "ja",
+      "text_summary": "Speaker gives limitations: the technique is strong but not universal and can still lose to throws or later attacks."
+    }
+  ],
+  "derived_events": [
+    {
+      "event_id": "event-0001",
+      "kind": "corner_escape_technique_explanation_candidate",
+      "source_segment_ids": [
+        "seg-0002",
+        "seg-0003",
+        "seg-0004",
+        "seg-0005",
+        "seg-0006",
+        "seg-0007"
+      ]
+    }
+  ]
+}
+```
+
+## Boundary Notes
+
+- Observed gameplay and caption summaries are review-only observations.
+- Speaker claims about landing frames, throw timing, strike interaction, or specification status are not accepted current facts.
+- Character identities, exact actions, input timing, setup reliability, and current patch applicability remain unresolved.
+- No raw media, frames, screenshots, contact sheets, or full captions are stored in the repository.

--- a/knowledge/review/unresolved/youtube-shorts-sycyvw6h8wi.review.md
+++ b/knowledge/review/unresolved/youtube-shorts-sycyvw6h8wi.review.md
@@ -1,0 +1,73 @@
+---
+id: sf6-review-youtube-shorts-sycyvw6h8wi
+title: YouTube Shorts syCYVW6h8WI Video Observation Pilot Review
+claim_kind: observation
+source_kind: reproducible_observation
+source_role: video_observation_pilot_review
+evidence_basis:
+  - "Video source metadata recorded in knowledge/sources/videos/youtube-shorts-sycyvw6h8wi.md."
+  - "Timestamped observations recorded in knowledge/evidence/video-observations/youtube-shorts-sycyvw6h8wi.observations.md."
+  - "Repo-external scratch media was used only for temporary observation and was not committed."
+  - "No claim was promoted to curated knowledge during the pilot."
+verification_state: unverified
+confidence: 0.35
+volatility: patch_sensitive
+patch_sensitivity: high
+review_status: needs_review
+source_refs:
+  - label: "Source metadata: YouTube Shorts syCYVW6h8WI"
+    path: "knowledge/sources/videos/youtube-shorts-sycyvw6h8wi.md"
+    accessed_at: "2026-05-03"
+  - label: "Video observations: YouTube Shorts syCYVW6h8WI"
+    path: "knowledge/evidence/video-observations/youtube-shorts-sycyvw6h8wi.observations.md"
+    accessed_at: "2026-05-03"
+review_after: "2026-08-03"
+summary: "Review holding note for a first video observation workflow pilot using a short ACQUA YouTube Shorts source about a corner-escape technique."
+---
+
+# YouTube Shorts syCYVW6h8WI Video Observation Pilot Review
+
+This review note tracks the first v2 video observation workflow pilot. It is canonical review tracking, but it is not accepted curated knowledge and must not feed generated knowledge references.
+
+## Review Status
+
+- Video source metadata artifact created: yes.
+- Timestamped video observation artifact created: yes.
+- Candidate claims artifact created: no; observations were sufficient for this first pilot.
+- Raw video stored in repo: no.
+- Raw frames or screenshots stored in repo: no.
+- Full transcript stored in repo: no.
+- Scratch/cache policy followed: yes.
+- Curated promotion performed: no.
+- Generated references changed: no.
+- Exact current values stored: no.
+- Current verification required for technique reliability: yes.
+
+## Held Observations
+
+The source appears to explain an SF6 corner-escape idea involving jump or back-jump input after leaving the corner and a possible landing guard interaction. This remains a source-local observation.
+
+The following categories stay unresolved:
+
+- Whether the described landing behavior is current across the relevant patch/version.
+- Exact landing-frame, throw, guard, strike, or input timing details.
+- Character-specific or stage-position-specific reliability.
+- Whether the demonstrated sequence works as a reusable defensive option outside the clip context.
+- Whether the visual sequence confirms the speaker claim or only illustrates it.
+- Japanese terminology normalization for any future curated wording.
+
+## Review Notes
+
+- The video is useful for testing video observation artifact shape and timestamped observation practice.
+- Speaker/commentary claims were separated from visible observations.
+- Visual observation confidence is limited by vertical Shorts layout, low resolution, face-cam overlay, and sparse frame sampling.
+- Any future candidate claim should cite the video observation artifact as `source_kind = reproducible_observation`, set `review_status = needs_review`, and pass review before curated promotion.
+- Do not use this video as final public answer evidence.
+
+## Workflow Findings
+
+- `workflows/ingest-video.md` was practical for separating clip metadata, timestamped visual observations, transcript/commentary summaries, and review-only handling.
+- `contracts/video-observation.schema.json` was usable as a coarse payload shape inside the Markdown artifact, but there is no executable validator for `knowledge/evidence/video-observations/*.observations.md` yet.
+- `knowledge/sources/videos/` has no dedicated source artifact validator yet.
+- A future validator should check video observation payload shape, no full transcript/media storage claims, source references, and review-only status.
+- The media scratch/cache policy was necessary because the pilot used temporary raw video and frames outside the repo.

--- a/knowledge/sources/videos/youtube-shorts-sycyvw6h8wi.md
+++ b/knowledge/sources/videos/youtube-shorts-sycyvw6h8wi.md
@@ -1,0 +1,48 @@
+---
+id: source-video-youtube-shorts-sycyvw6h8wi
+title: "【スト6】仕様を利用したテクニック！端から逃げやすくなる！"
+source_kind: community
+source_role: video_observation_pilot_source
+author: "ACQUA"
+publisher: "YouTube Shorts"
+url: "https://www.youtube.com/shorts/syCYVW6h8WI"
+published_at: "2026-04-29"
+accessed_at: "2026-05-03"
+captured_at: "2026-05-03"
+copyright_policy: "no full video, raw frames, screenshots, or full transcript stored"
+review_status: needs_review
+review_after: "2026-08-03"
+---
+
+# Source Summary
+
+ACQUA氏による日本語のYouTube Shorts。タイトルと動画内テロップは、SF6の仕様を利用して画面端から逃げやすくするテクニックを扱う短尺動画として示している。
+
+動画内では、画面端からジャンプで逃げた後にバックジャンプを入れ続ける状況、着地付近で打撃・投げ・ガードが絡む説明、そして「強いが万能ではない」という注意が扱われている。これは動画観測pilot用sourceであり、現在仕様やセットアップ妥当性の最終根拠ではない。
+
+## Extracted Scope
+
+- Video ID: `syCYVW6h8WI`.
+- Canonical URL: `https://www.youtube.com/shorts/syCYVW6h8WI`.
+- Channel: ACQUA.
+- Channel URL: `https://www.youtube.com/channel/UCSpaguDcAEfDzpL7vf7QTEQ`.
+- Published/uploaded date from YouTube metadata: 2026-04-29.
+- Duration: 69 seconds.
+- Source language: Japanese.
+- Captions/transcript: Japanese auto-generated captions were available for inspection, but the full transcript is not stored in this repository.
+- Useful for: testing video source metadata, timestamped visual observations, transcript/commentary separation, and review-only holding.
+- Not useful for: accepting current patch facts, exact setup timing, exact frame behavior, matchup advice, or universal strategy conclusions without separate verification.
+
+## Media Handling
+
+- Raw video was temporarily downloaded to a repo-external scratch directory for this pilot.
+- Sparse frames and a contact sheet were generated only in repo-external scratch for maintainer inspection.
+- Raw video, frames, screenshots, contact sheets, browser cache, session state, and full captions/transcript are not stored in this repository.
+- Scratch/cache handling followed `workflows/media-scratch-cache-policy.md`.
+
+## Reviewer Notes
+
+- Treat this as a community video observation source, not final public answer evidence.
+- The video appears useful for testing how visual observations and speaker claims should be separated.
+- Any claim about SF6 landing behavior, throw timing, back-jump input behavior, or current patch reliability must stay review-only until independently verified.
+- Do not promote observations from this source into `knowledge/curated/` without separate review.


### PR DESCRIPTION
## Summary

- Pilot the v2 video observation workflow with one short YouTube Shorts SF6 source.
- Add source metadata, timestamped video observations, and review-only holding for `syCYVW6h8WI`.
- Keep this as observation / needs_review only; no candidate claims were created for this first pilot.

Source:
- https://www.youtube.com/shorts/syCYVW6h8WI

## Changed Surfaces

- `knowledge/sources/videos/youtube-shorts-sycyvw6h8wi.md`
- `knowledge/evidence/video-observations/youtube-shorts-sycyvw6h8wi.observations.md`
- `knowledge/review/unresolved/youtube-shorts-sycyvw6h8wi.review.md`
- `docs/testing/smoke-runs/2026-05-03-video-observation-youtube-shorts-sycyvw6h8wi.md`

## Boundary Notes

- No raw video, raw frames, screenshots, contact sheet, browser cache, session state, or full transcript is stored in the repo.
- Temporary media and sampled frames were kept under repo-external scratch and removed after the run.
- Speaker/commentary claims are separated from visible observations.
- Video-derived content remains `observation / needs_review`.
- `knowledge/curated/`, generated references, and frame-current assets were not changed.

## Validation

- `tests/validation/run-all.ps1`: pass
- `git diff --check`: pass
- Generated output cleanliness check: no generated/frame-current changes
- Repo-local media/state scan: no hits
- Changed-file credential scan: no hits
- Scratch cleanup: done; temporary run directory removed after drafting/validation

## Findings / Follow-ups

- `workflows/ingest-video.md` and `contracts/video-observation.schema.json` were sufficient for a first coarse video observation artifact.
- There is still no executable validator for `knowledge/evidence/video-observations/*.observations.md`.
- There is still no dedicated validator for `knowledge/sources/videos/*.md`.
- The observed technique should not become a candidate claim until separately reviewed and verified against current gameplay behavior.

Closes #52.
