### PR TITLE
[v2.1] Define harness roles and distribution boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,15 @@
 - Keep `skills/sf6-agent/` as the single public adapter unless a later architecture decision changes it.
 - See `docs/architecture/language-policy.md`.
 
+## Harness And Distribution Roles
+
+- `skills/sf6-agent/` is the public answer adapter.
+- `AGENTS.md`, `workflows/*`, `tests/validation/*`, `packages/*`, and `contracts/*` are repo-local maintainer surfaces.
+- Hermes is a recommended optional maintainer harness when configured, but Hermes memory and profile state are not canonical.
+- `packs/hermes-sf6/*` is repo-local optional harness support, not public answer-skill behavior.
+- APM / Agent Skills may support public `sf6-agent` distribution or repo-local setup manifests, but do not create a public repo-maintainer skill package without a later architecture decision.
+- See `docs/architecture/harness-and-distribution-roles.md`.
+
 ## Workflow Rules
 
 - Maintainer procedures belong under `workflows/`.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -4,3 +4,4 @@ Architecture docs define the v2 source-of-truth model.
 
 - [v2-architecture.md](./v2-architecture.md)
 - [language-policy.md](./language-policy.md)
+- [harness-and-distribution-roles.md](./harness-and-distribution-roles.md)

--- a/docs/architecture/harness-and-distribution-roles.md
+++ b/docs/architecture/harness-and-distribution-roles.md
@@ -1,0 +1,88 @@
+# Harness And Distribution Roles
+
+SF6 Knowledge Agent Kit separates public answer distribution from repo-local maintenance.
+
+The public package should help agents answer Street Fighter 6 questions. Repo-local maintainer surfaces should help maintainers grow and validate this repository after cloning it.
+
+## Public Answer Adapter
+
+`skills/sf6-agent/` is the public answer adapter.
+
+It is the surface intended for users and agents that need SF6 answers, not repository maintenance behavior.
+
+Public distribution should focus on:
+
+- `skills/sf6-agent/SKILL.md`
+- hand-written adapter policies under `skills/sf6-agent/references/`
+- generated reference payloads under `skills/sf6-agent/references/generated-*`
+- frame-current runtime assets under `skills/sf6-agent/assets/frame-current/`
+- release bundles derived from those adapter surfaces
+
+Do not create a separate `sf6-agent-ja` adapter at this stage.
+
+## Repo-local Maintainer Surfaces
+
+The following are repo-local maintainer surfaces:
+
+- `AGENTS.md`
+- `workflows/*`
+- `tests/validation/*`
+- `packages/*`
+- `contracts/*`
+- `docs/architecture/*`
+- `packs/hermes-sf6/*`
+
+Maintainers use these after cloning the repository. They are not public answer skills and do not need to be externally distributed as a public repo-maintainer skill package.
+
+## Hermes Maintainer Harness
+
+Hermes is an optional maintainer harness for knowledge ingest, review, image observation, video observation, and repeated workflow execution.
+
+Hermes is recommended when a configured maintainer profile is available, but it is not required. Maintainers may use Codex, other agents, or manual workflows when Hermes is unavailable.
+
+Hermes memory, sessions, profile state, browser state, cron state, and local managed skills are not canonical SF6 knowledge.
+
+Final outputs must be repo artifacts, such as:
+
+- `knowledge/sources/*`
+- `knowledge/evidence/claims/*`
+- `knowledge/evidence/video-observations/*`
+- `knowledge/review/*`
+- `knowledge/curated/*` after review and promotion
+- `docs/testing/smoke-runs/*`
+
+## Hermes Wrappers
+
+`packs/hermes-sf6/*` is repo-local optional Hermes harness support.
+
+Hermes wrappers, if added later, should be thin wrappers around canonical workflows such as:
+
+- `workflows/ingest-article.md`
+- `workflows/ingest-video.md`
+- `workflows/review-claims.md`
+- `workflows/media-scratch-cache-policy.md`
+- `workflows/hermes-ingest-profile-setup.md`
+
+Wrappers must not become independent source-of-truth procedures. If a wrapper discovers a better procedure, update the canonical workflow first or in the same PR.
+
+## Codex And Repo Development
+
+Codex, humans, or other agents may be used for repo development, PR work, validators, packaging, and GitHub operations.
+
+`workflows/github-management.md` is repo-local maintainer workflow guidance. It is not public answer skill behavior.
+
+Repository development work belongs in repo-local surfaces such as `AGENTS.md`, `workflows/*`, `tests/validation/*`, `packages/*`, and `contracts/*`.
+
+## APM And Agent Skills
+
+APM or Agent Skills may be considered for public `sf6-agent` distribution.
+
+APM may also support repo-local maintainer setup manifests after cloning this repository.
+
+Do not create a public repo-maintainer skill package at this stage. Repo maintainer workflows require a clone of this repository and should remain repo-local unless a later architecture decision says otherwise.
+
+## Language Policy
+
+This boundary follows the Japanese-first operating policy in `docs/architecture/language-policy.md`.
+
+Japanese prose is allowed and encouraged where appropriate. Metadata keys, artifact IDs, schema enum values, filenames and path slugs, generated markers, validator contracts, package interfaces, and installer interfaces remain English-compatible.

--- a/docs/architecture/harness-and-distribution-roles.md
+++ b/docs/architecture/harness-and-distribution-roles.md
@@ -34,6 +34,8 @@ The following are repo-local maintainer surfaces:
 
 Maintainers use these after cloning the repository. They are not public answer skills and do not need to be externally distributed as a public repo-maintainer skill package.
 
+“Repo-local” describes distribution and access boundaries; it does not mean non-canonical. Some repo-local surfaces, such as `contracts/` and `workflows/`, are canonical within the repository.
+
 ## Hermes Maintainer Harness
 
 Hermes is an optional maintainer harness for knowledge ingest, review, image observation, video observation, and repeated workflow execution.


### PR DESCRIPTION
## Summary

- Add `docs/architecture/harness-and-distribution-roles.md` to define public adapter, repo-local maintainer surfaces, Hermes harness, and distribution boundaries.
- Link the new architecture doc from `docs/architecture/README.md`.
- Add a short AGENTS entry so agents keep public `sf6-agent` distribution separate from repo-local maintainer workflows.

## Boundary Notes

- `skills/sf6-agent/` remains the only public answer adapter.
- `AGENTS.md`, `workflows/*`, `tests/validation/*`, `packages/*`, `contracts/*`, architecture docs, and `packs/hermes-sf6/*` are repo-local maintainer surfaces.
- Hermes is recommended, not required, for configured knowledge ingest/review/media observation runs.
- Hermes memory, sessions, profile state, browser state, cron state, and local managed skills are not canonical.
- APM / Agent Skills may be considered for public `sf6-agent` distribution or repo-local setup manifests, not a public repo-maintainer skill package.

## Validation

- `tests/validation/run-all.ps1`: pass
- `git diff --check`: pass
- Generated output cleanliness check: no generated/frame-current changes
- Changed-file credential scan: only existing safety-rule wording in `AGENTS.md`, no credential material

Closes #54.
