### PR TITLE
[v2.1] Define Japanese maintainer documentation policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,14 @@
 - Keep `skills/sf6-agent/` as the single public adapter unless a later architecture decision changes it.
 - See `docs/architecture/language-policy.md`.
 
+## Japanese Maintainer Documentation
+
+- Maintainer-facing prose may be Japanese-first when it improves repo operation.
+- Required repo and skill behavior must stay in canonical entrypoints such as `AGENTS.md` and `skills/sf6-agent/SKILL.md`; do not rely on `.ja.*` companion files for required behavior.
+- Do not duplicate canonical knowledge only to create separate English/Japanese versions.
+- Use `.ja.*` files for human-facing localized docs only when their canonical, companion, or summary role is clear.
+- See `docs/architecture/japanese-maintainer-docs-policy.md`.
+
 ## Harness And Distribution Roles
 
 - `skills/sf6-agent/` is the public answer adapter.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -5,3 +5,4 @@ Architecture docs define the v2 source-of-truth model.
 - [v2-architecture.md](./v2-architecture.md)
 - [language-policy.md](./language-policy.md)
 - [harness-and-distribution-roles.md](./harness-and-distribution-roles.md)
+- [japanese-maintainer-docs-policy.md](./japanese-maintainer-docs-policy.md)

--- a/docs/architecture/japanese-maintainer-docs-policy.md
+++ b/docs/architecture/japanese-maintainer-docs-policy.md
@@ -1,0 +1,115 @@
+# Japanese Maintainer Documentation Policy
+
+SF6 Knowledge Agent Kit is maintained primarily for Japanese-speaking maintainers while preserving English-compatible repository structure.
+
+This policy clarifies how maintainer-facing docs can use Japanese prose without creating duplicate canonical sources of truth.
+
+## Core Principle
+
+Maintainer-facing prose may be Japanese-first when it improves repository operation.
+
+Do not make English the automatic canonical prose language and Japanese the automatic companion language. Use the language that best supports the canonical surface and its maintainers.
+
+Do not create duplicate canonical English/Japanese source-of-truth pages.
+
+## Japanese Canonical Prose
+
+Japanese prose may be canonical for:
+
+- maintainer workflows
+- source summaries
+- review notes
+- curated explanations
+- image and video observation notes
+- maintainer notes for Japanese sources
+
+These artifacts remain canonical because of their paths, metadata, source references, review status, and validation, not because they are written in English.
+
+## English-compatible Structure
+
+Keep these English-compatible and stable:
+
+- metadata keys
+- artifact IDs
+- schema enum values
+- filenames and path slugs
+- generated markers
+- validator contracts
+- package and installer interfaces
+- command names and script names
+
+Japanese prose must not require Japanese-only metadata keys, schema enum values, filenames, or validator contracts.
+
+## Required Entrypoints
+
+Required repo and skill behavior must live in the canonical entrypoints that agents actually read.
+
+Do not move required rules only into `.ja.*` companion files.
+
+Examples:
+
+- `AGENTS.md` must contain required repo guidance directly.
+- `skills/sf6-agent/SKILL.md` must contain required skill behavior directly.
+- Hand-written policy files under `skills/sf6-agent/references/` must contain required adapter behavior directly.
+
+Localized companions may explain or summarize these entrypoints for humans, but they are not enough for required agent behavior unless a later architecture decision changes discovery behavior.
+
+## Knowledge Pages
+
+Do not duplicate `knowledge/curated/` pages only to create separate English and Japanese canonical versions.
+
+A curated page may be written in Japanese when that is the natural operating language. Its canonical status comes from its repository path, metadata, source references, review status, and validation.
+
+If an English explanation is useful later, prefer a concise maintainer note, generated distribution surface, or localized public doc rather than a second canonical curated page.
+
+## Localized Companion Files
+
+`.ja.*` files may be used for human-facing localized documentation when useful, especially:
+
+- architecture explanations
+- distribution docs
+- testing docs
+- quickstart docs
+- human-facing summaries
+
+When a `.ja.*` file is added for maintainer-facing docs, it should state whether it is:
+
+- canonical
+- localized companion
+- summary
+
+If it is a localized companion, it should identify the source file it follows.
+
+Example front matter shape:
+
+```yaml
+---
+language: ja
+localization_role: localized_companion
+localized_from: docs/architecture/example.md
+sync_policy: meaning_equivalent
+review_after: "2026-08-01"
+---
+```
+
+This policy does not require adding front matter to every localized doc immediately. It defines the expected direction when localized companions are introduced.
+
+## Workflows
+
+Frequently changing maintainer workflows should avoid strict English/Japanese translation pairs unless a sync policy exists.
+
+A workflow may be Japanese-first canonical text instead of maintaining separate English and Japanese versions.
+
+This is especially appropriate for workflows primarily used by Japanese-speaking maintainers, such as Japanese article ingest, video observation, review, and media scratch/cache handling.
+
+## Distribution
+
+Localized public docs such as `README.ja.md` or agent-specific quickstarts may be considered later.
+
+Do not create `sf6-agent-ja` only for language localization unless a later architecture decision shows that a separate adapter is necessary and can be validated without duplicate source-of-truth drift.
+
+## Relationship To Language Policy
+
+This policy refines `docs/architecture/language-policy.md` for maintainer documentation.
+
+The repository remains Japanese-first in operation and English-compatible in structure.

--- a/docs/architecture/japanese-maintainer-docs-policy.md
+++ b/docs/architecture/japanese-maintainer-docs-policy.md
@@ -4,6 +4,16 @@ SF6 Knowledge Agent Kit is maintained primarily for Japanese-speaking maintainer
 
 This policy clarifies how maintainer-facing docs can use Japanese prose without creating duplicate canonical sources of truth.
 
+## 日本語要約
+
+このrepoでは、メンテナー向けの説明文やworkflow本文は日本語を正本として書いてよいです。
+
+ただし、metadata key、artifact ID、schema enum、filename、validator contract、command名などは英語互換を保ちます。
+
+`AGENTS.md` や `skills/sf6-agent/SKILL.md` のようにagentが実際に読む入口では、必須ルールを `.ja.*` companion に逃がさず、entrypoint本体に書きます。
+
+`knowledge/curated/` は英語版と日本語版で二重正本化しません。
+
 ## Core Principle
 
 Maintainer-facing prose may be Japanese-first when it improves repository operation.


### PR DESCRIPTION
## Summary

- Add `docs/architecture/japanese-maintainer-docs-policy.md`.
- Link it from `docs/architecture/README.md`.
- Add a short `AGENTS.md` pointer for required entrypoint behavior and `.ja.*` companion boundaries.

## Policy Notes

- Maintainer-facing prose may be Japanese-first when it improves repo operation.
- English is not automatically the canonical prose language with Japanese as a secondary companion.
- Required repo and skill behavior must remain in canonical entrypoints such as `AGENTS.md` and `skills/sf6-agent/SKILL.md`.
- `.ja.*` companion files are for human-facing localized docs when their canonical/companion/summary role is clear.
- `knowledge/curated/` should not be duplicated into separate English/Japanese canonical pages.
- Metadata keys, IDs, schema enums, filenames/path slugs, generated markers, validator contracts, package interfaces, command names, and script names remain English-compatible.

## Out of Scope

- No workflow translation in this PR.
- No `.ja.*` companion files created in this PR.
- No knowledge artifact changes.
- No generated reference changes.
- No validator or packaging changes.

## Validation

- `tests/validation/run-all.ps1`: pass
- `git diff --check`: pass
- Generated output cleanliness check: no generated/frame-current changes
- Changed-file credential scan: only existing safety-rule wording in `AGENTS.md`, no credential material

Closes #56.
