### PR TITLE
[v2.1] Clarify maintainer-critical Japanese docs policy

### DIFF
--- a/docs/architecture/japanese-maintainer-docs-policy.md
+++ b/docs/architecture/japanese-maintainer-docs-policy.md
@@ -104,6 +104,18 @@ review_after: "2026-08-01"
 
 This policy does not require adding front matter to every localized doc immediately. It defines the expected direction when localized companions are introduced.
 
+## Maintainer-critical English Docs
+
+Maintainer-critical docs should not remain English-only when that blocks Japanese-speaking maintainers from understanding repository operation.
+
+For each maintainer-critical doc, choose one of these approaches:
+
+1. Write the canonical prose in Japanese while keeping paths, metadata, commands, and schema terms English-compatible.
+2. Keep the canonical prose in English and add a `.ja.*` human-readable companion with a clear localization role.
+3. Add an inline Japanese summary when a full companion would be too heavy.
+
+This does not mean every file needs a strict 1:1 translation. Fast-changing workflows should prefer Japanese-first canonical prose or an inline Japanese summary unless a sync policy exists.
+
 ## Workflows
 
 Frequently changing maintainer workflows should avoid strict English/Japanese translation pairs unless a sync policy exists.


### PR DESCRIPTION
## Summary

- Refine `docs/architecture/japanese-maintainer-docs-policy.md` with a new `Maintainer-critical English Docs` section.
- Clarify that important maintainer docs should not remain English-only when that blocks Japanese-speaking maintainers.
- Preserve the existing boundary that not every file needs strict 1:1 translation.

## Policy Notes

The new section defines three options for maintainer-critical docs:

1. Japanese-first canonical prose while keeping paths, metadata, commands, and schema terms English-compatible.
2. English canonical prose with a `.ja.*` human-readable companion and clear localization role.
3. Inline Japanese summary when a full companion would be too heavy.

It also states that fast-changing workflows should prefer Japanese-first canonical prose or inline Japanese summaries unless a sync policy exists.

## Out of Scope

- No `README.ja.md`.
- No `AGENTS.ja.md`.
- No architecture `.ja.md` companions.
- No workflow translation.
- No knowledge, generated reference, validator, or packaging changes.

## Validation

- `tests/validation/run-all.ps1`: pass
- `git diff --check`: pass
- Generated output cleanliness check: no generated/frame-current changes
- Changed-file credential scan: no hits

Closes #64.
