### PR TITLE
[v2.1] Define system-mechanics fact workflow

### DIFF
--- a/knowledge/review/current-fact-candidates/README.md
+++ b/knowledge/review/current-fact-candidates/README.md
@@ -7,3 +7,9 @@ Entries here may cite `data/exports/`, `snapshot_manifest.json`, packaged curren
 Entries here are not final public answer evidence, must not feed generated knowledge references, are not accepted curated knowledge, and must be resolved into the current-fact data surfaces or kept on hold.
 
 Candidate artifacts here are review-only current-fact claim records, not ordinary knowledge pages. They are governed by the current-fact boundary validator and claim/source contracts rather than the curated knowledge page validator.
+
+System-mechanics current fact candidates also stay here until a dedicated accepted authority path exists.
+
+Examples include combo-scaling numeric values that are not already packaged as move-specific frame-current fields, route-level damage formulas, minimum guarantee values, system action modifiers, and patch-sensitive exception rules.
+
+See `workflows/system-mechanics-fact-workflow.md`.

--- a/skills/sf6-agent/references/current-fact-policy.md
+++ b/skills/sf6-agent/references/current-fact-policy.md
@@ -30,6 +30,16 @@ Use `unresolved / hold` when:
 - The answer would require manual-review rows, raw snapshots, normalized working data, scraping, or patch audit work.
 - A value appears only in supplemental enrichment and not in the official published rows.
 
+## System-Mechanics Current Facts
+
+Some exact current questions are about system mechanics rather than a single packaged move field.
+
+Examples include route-level combo damage formulas, minimum guarantee values, system action modifiers, and exception rules that are not directly available as packaged frame-current fields.
+
+Answer these only when the requested exact value is available in packaged frame-current assets. If the value is not packaged, use `unresolved / hold`.
+
+Do not infer exact system-mechanics values from generated concept references, article claims, video observations, or review candidates.
+
 ## Provenance In Answers
 
 When an answer depends on exact current data, mention the relevant packaged dataset names when useful. Do not expose internal repository paths as if the user must have the repository checkout.

--- a/tests/validation/validate-current-fact-boundaries.ps1
+++ b/tests/validation/validate-current-fact-boundaries.ps1
@@ -78,9 +78,9 @@ if (Test-Path -LiteralPath $candidateRoot -PathType Container) {
     $relativePath = $candidateFile.FullName.Substring($repoRoot.Length + 1).Replace('\', '/')
     $content = Get-Content -LiteralPath $candidateFile.FullName -Raw -Encoding UTF8
     foreach ($pattern in @(
-      'generated_allowed:\s*true',
+      '(?m)^\s*generated_allowed:\s*"?true"?\s*$',
       '"generated_allowed"\s*:\s*true',
-      'review_status:\s*accepted',
+      '(?m)^\s*review_status:\s*"?accepted"?\s*$',
       '"review_status"\s*:\s*"accepted"'
     )) {
       if ($content -match $pattern) {

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -9,6 +9,7 @@ Workflow docs are readable by humans and agents without requiring a skill runtim
 - [GitHub management](github-management.md)
 - [Hermes ingest profile setup](hermes-ingest-profile-setup.md)
 - [Media scratch cache policy](media-scratch-cache-policy.md)
+- [System mechanics fact workflow](system-mechanics-fact-workflow.md)
 - [Update frame data](update-frame-data.md)
 - [Ingest article](ingest-article.md)
 - [Review claims](review-claims.md)

--- a/workflows/system-mechanics-fact-workflow.md
+++ b/workflows/system-mechanics-fact-workflow.md
@@ -1,0 +1,124 @@
+# System Mechanics Fact Workflow
+
+このworkflowは、frame-current move factだけでは扱い切れないsystem mechanics current factsをreviewで保持し、誤って `knowledge/curated/` やgenerated knowledge referencesへ入れないための手順です。
+
+## 目的
+
+SF6には、moveごとのcurrent factとして扱える値と、system mechanicsとして別に確認が必要な値があります。
+
+`knowledge/curated/` は安定概念を説明できますが、exact current system valuesの正本ではありません。system mechanicsの具体値や計算式を扱う時は、このworkflowでreviewに保持し、accepted useの前にcurrent authority pathを決めます。
+
+## Frame-current fact との違い
+
+Frame-current factsは、packaged frame-current runtime assetsで解決できるmove-specific current valuesです。
+
+例:
+
+- moveごとのdamage。
+- moveごとのstartup、active、recovery、advantageなどのcurrent frame fields。
+- moveに紐づくpublished raw fieldsに含まれるstarter scalingやcombo scaling。
+- roster membershipやpackaged character availability。
+
+これらは `data/exports/` と `data/roster/` をcanonical authorityとし、derived `skills/sf6-agent/assets/frame-current/` をruntime answer surfaceとして使います。
+
+System-mechanics current factsは、単一のmove rowだけでは解決しにくいpatch-sensitiveなsystem valuesや計算規則です。
+
+例:
+
+- コンボ全体の最終ダメージ計算。
+- global scaling tableやroute-level scaling rule。
+- system actionによる補正。
+- minimum guaranteeやSA minimum damage behavior。
+- character-specific、move-specific、control-scheme-specific exceptionのうち、packaged move fieldだけで説明できないもの。
+- video/article/source observationから出た、現行patchで再検証が必要なsystem behavior。
+
+## 現在の置き場所
+
+Accepted system-mechanics current fact用のdedicated data surfaceは、まだありません。
+
+そのため、system-mechanics exact valuesや計算式は、accepted useの前に次のどちらかに分けます。
+
+1. Packaged frame-current runtime assetsで解決できるmove-specific fieldなら、frame-current factとして扱う。
+2. 解決できない場合は `knowledge/review/current-fact-candidates/` にreview-only candidateとして保持する。
+
+`knowledge/review/current-fact-candidates/` は、final public answer evidenceではありません。ここにあるcandidateはgenerated knowledge referencesへ流してはいけません。
+
+## Review flow
+
+1. Claimをstable concept、move-specific current fact、system-mechanics current factに分解する。
+2. Move-specific fieldで答えられるか確認する。
+3. Packaged frame-current runtime assetsにある値なら、current-fact answer pathへ渡す。
+4. Packaged runtime assetsで解決できないsystem valueなら、`knowledge/review/current-fact-candidates/` に保持する。
+5. Candidateには、source refs、verification state、confidence、volatility、patch sensitivity、review status、review afterを記録する。
+6. Accepted curated knowledgeへは、安定概念だけを入れる。
+7. Exact system value、計算式、例外、current patch behaviorは、current authority pathが決まるまでacceptedにしない。
+
+## Candidate artifact guidance
+
+System-mechanics candidateは、普通のcurated pageではなくreview-only current-fact candidateとして書きます。
+
+Minimum fields:
+
+- `id`
+- `title`
+- `claim_kind`
+- `source_kind`
+- `source_role`
+- `evidence_basis`
+- `verification_state`
+- `confidence`
+- `volatility`
+- `patch_sensitivity`
+- `review_status`
+- `source_refs`
+- `review_after`
+
+Recommended boundary text:
+
+- `not final public answer evidence`
+- `must not feed generated knowledge references`
+- `not accepted curated knowledge`
+- `resolved into the current-fact data surfaces or kept on hold`
+
+Use `review_status: needs_review` until the repo has a clear accepted current-fact authority path for that system value.
+
+## What not to put in curated knowledge
+
+Do not accept these into `knowledge/curated/` as exact current facts by default:
+
+- exact scaling percentages
+- minimum guarantee values
+- route-level final damage formulas
+- current-patch system action modifiers
+- character-specific or move-specific exceptions that are not already represented as packaged frame-current fields
+- values inferred only from article/video observations
+
+Curated pages may explain the stable concept and point to the relevant current-fact surface. They must not duplicate exact current system values.
+
+## Adapter answer behavior
+
+When `sf6-agent` is asked for a system-mechanics value:
+
+1. If the question asks for a stable concept, answer from generated concept references and state the boundary.
+2. If it asks for a move-specific exact value that exists in packaged frame-current runtime assets, answer from the packaged runtime assets.
+3. If it asks for a route-level formula, minimum guarantee, system modifier, or exception that is not packaged as an exact current value, use `unresolved / hold`.
+4. Do not infer exact system values from `knowledge/curated/`, generated concept references, article claims, video observations, or review candidates.
+
+For combo scaling, this means:
+
+- Explain what combo scaling is from `knowledge/curated/mechanics/combo-scaling.md`.
+- Use frame-current runtime assets for packaged move-specific damage and scaling fields when available.
+- Hold route-level final damage formulas, minimum guarantee values, and exception rules unless a future accepted system-mechanics authority path exists.
+
+## Future contract decision
+
+A dedicated system-mechanics current-fact contract or data surface is likely needed before these facts can be accepted as runtime authority.
+
+Possible future surfaces:
+
+- `contracts/system-mechanics-fact.schema.json`
+- `data/system-mechanics/`
+- a validator for `knowledge/review/current-fact-candidates/` system-mechanics artifacts
+- a generated runtime surface distinct from generated concept references
+
+Do not create those surfaces inside an unrelated curation or ingest PR. Add them only after an architecture decision defines authority, validation, and distribution behavior.


### PR DESCRIPTION
## Summary

- add `workflows/system-mechanics-fact-workflow.md` for system-mechanics current facts that are not resolved by frame-current move fields
- document that unresolved system-mechanics exact values stay under `knowledge/review/current-fact-candidates/` until an accepted authority path exists
- update `sf6-agent` current-fact policy so exact system-mechanics values are answered only from packaged frame-current assets, otherwise held as unresolved
- tighten the current-fact candidate boundary scan so quoted YAML `review_status: "accepted"` and `generated_allowed: "true"` are rejected

## Boundaries

- no exact combo-scaling values added
- no system numeric claims promoted to `knowledge/curated/`
- no generated references changed
- no frame-current assets changed
- no new contract or data surface added in this PR
- validator change is limited to the existing current-fact candidate review-only boundary scan

## Verification

- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-current-fact-boundaries.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1`
- `git diff --check`
- generated output status check: clean
- credential scan on changed files: no hits

Closes #60
