### PR TITLE
[v2.1] Add combo-scaling answer boundary evals

### DIFF
--- a/evals/questions/concepts.yaml
+++ b/evals/questions/concepts.yaml
@@ -61,6 +61,14 @@ cases:
       - "universal best option"
       - "current patch guarantee"
       - "specific character setup as fact"
+  - id: concept-combo-scaling
+    question: "What is combo scaling in SF6, and how should I think about combo damage calculation?"
+    expected_answer_mode: stable_concept
+    evidence_boundary: "Use curated mechanics knowledge to explain the calculation model; do not provide exact scaling rates or route formulas."
+    must_not_include:
+      - "exact scaling percentage"
+      - "route-level final damage formula"
+      - "generated concept knowledge as current system authority"
   - id: ja-concept-plus-frames
     question: "SF6のプラスフレームって何？攻めでどう使う？"
     expected_answer_mode: stable_concept
@@ -69,6 +77,14 @@ cases:
       - "特定技の現在値"
       - "確定行動として断定"
       - "generated references as canonical"
+  - id: ja-concept-combo-scaling
+    question: "SF6のコンボ補正って何？ダメージ計算ではどう考えればいい？"
+    expected_answer_mode: stable_concept
+    evidence_boundary: "日本語で安定概念と計算を見るための考え方を説明し、具体補正率や現在patchの計算式は断定しない。"
+    must_not_include:
+      - "具体補正率"
+      - "現在patchの正確な計算式"
+      - "技ごとの現在値をcurated knowledgeから答える"
   - id: ja-concept-shimmy
     question: "シミーって何？公式用語なの？"
     expected_answer_mode: stable_concept

--- a/evals/questions/current-fact.yaml
+++ b/evals/questions/current-fact.yaml
@@ -14,6 +14,14 @@ cases:
       - "knowledge/curated as final authority"
       - "community-only final authority"
       - "guessed exact values"
+  - id: current-fact-luke-2mp-starter-scaling
+    question: "What is Luke 2MP starter scaling in the packaged current data?"
+    expected_answer_mode: verified_current_fact
+    evidence_boundary: "Use packaged frame-current runtime assets when a move-specific starter/combo scaling field exists."
+    must_not_include:
+      - "combo-scaling curated page as exact value authority"
+      - "article source as current authority"
+      - "guessed scaling percentage"
   - id: current-fact-unpackaged-character
     question: "Give the current exact frame data for a character not present in the roster source."
     expected_answer_mode: unresolved_or_hold
@@ -61,3 +69,11 @@ cases:
       - "推測値"
       - "概念知識を現在値の根拠にする"
       - "コミュニティ情報だけで現在値の根拠にする"
+  - id: ja-current-fact-luke-2mp-starter-scaling
+    question: "Luke 2MPの始動補正は、packaged frame-current assetsではどうなってる？"
+    expected_answer_mode: verified_current_fact
+    evidence_boundary: "日本語質問でも、move-specific scaling fieldがpackaged frame-current assetsにある場合だけverified current factとして答える。"
+    must_not_include:
+      - "knowledge/curatedを現在値の根拠にする"
+      - "記事由来の補正率を現在値として使う"
+      - "packaged assetに無い値を推測する"

--- a/evals/questions/uncertainty.yaml
+++ b/evals/questions/uncertainty.yaml
@@ -47,6 +47,22 @@ cases:
       - "verified current fact"
       - "exact current value from memory"
       - "concept knowledge as current fact authority"
+  - id: uncertainty-combo-route-final-formula
+    question: "What is the exact current formula for final damage in this full combo route?"
+    expected_answer_mode: unresolved_or_hold
+    evidence_boundary: "Route-level combo damage formulas are system-mechanics current facts and require an accepted authority path before verified use."
+    must_not_include:
+      - "exact route formula from generated concepts"
+      - "accepted current system value without authority path"
+      - "article or video observation as final authority"
+  - id: uncertainty-hameko-scaling-rates-current
+    question: "A 2023 article lists combo scaling rates. Can sf6-agent present those rates as current accepted values?"
+    expected_answer_mode: unresolved_or_hold
+    evidence_boundary: "Article-derived scaling rates are source/review context, not current system authority, unless resolved into an accepted current-fact surface."
+    must_not_include:
+      - "article-only current authority"
+      - "copied exact scaling rates as accepted"
+      - "generated concept knowledge as current system authority"
   - id: ja-uncertainty-patch-sensitive-setup
     question: "この起き攻め、今のパッチでも確定？"
     expected_answer_mode: unresolved_or_hold
@@ -55,3 +71,11 @@ cases:
       - "確定と断定"
       - "現在値を推測"
       - "動画や記事だけで現在パッチの事実として断定"
+  - id: ja-uncertainty-combo-system-formula
+    question: "SF6のコンボ補正の最終計算式とSA最低保証の正確な値を教えて。"
+    expected_answer_mode: unresolved_or_hold
+    evidence_boundary: "route-level計算式や最低保証はsystem-mechanics current factとして、accepted authority pathがなければ保留する。"
+    must_not_include:
+      - "generated conceptから正確な値を推測"
+      - "現在patchの正確な値として断定"
+      - "review candidateをfinal evidenceにする"


### PR DESCRIPTION
## Summary

- add stable concept evals for explaining combo scaling and combo damage calculation without exact values
- add current-fact evals for move-specific starter/combo scaling values that should use packaged frame-current assets when available
- add hold/unresolved evals for route-level formulas, article-derived scaling rates, minimum guarantees, and system-mechanics exact values without accepted authority

## Boundaries

- eval-only change
- no knowledge artifacts changed
- no generated references changed
- no frame-current assets changed
- no validators, packaging, or Hermes pack behavior changed
- no exact combo-scaling values added

## Verification

- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-evals.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1`
- `git diff --check`
- generated output status check: clean
- credential scan on changed eval files: no hits

Closes #70
