### PR TITLE
[v2.1] Build JP combo damage oracle fixture from video source

### DIFF
--- a/docs/testing/smoke-runs/2026-05-04-jp-combo-damage-oracle-fixture.md
+++ b/docs/testing/smoke-runs/2026-05-04-jp-combo-damage-oracle-fixture.md
@@ -1,0 +1,56 @@
+# JP Combo Damage Oracle Fixture Smoke Run
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| Date | 2026-05-04 |
+| Issue | #72 |
+| Source | これ一本で全てわかるJPコンボ講座【りゅうせい・スト６】 |
+| Source URL | `https://www.youtube.com/watch?v=nyFNgnzjV3M` |
+| Video ID | `nyFNgnzjV3M` |
+| Selected scope | `00:08-00:57` basic light combo chapter |
+| Scratch root | repo-external `${XDG_CACHE_HOME:-$HOME/.cache}/sf6-skills/media-ingest/` |
+| Raw media stored in repo | no |
+| Full transcript stored in repo | no |
+
+## Tooling
+
+| Tool / Capability | Result | Notes |
+|---|---|---|
+| YouTube metadata inspection | pass | `yt-dlp` via `uvx` wrote metadata only to repo-external scratch. |
+| Section download | pass | The selected section was temporarily downloaded outside the repo. |
+| Frame/contact-sheet inspection | pass | Sparse frames, stills, crops, and contact sheets were generated outside the repo. |
+| Japanese auto-caption inspection | partial | Captions were useful for chapter/context, but noisy for exact route notation. Full captions are not stored in repo. |
+| Oracle fixture creation | partial | One high-confidence enabled case and two review-needed disabled candidates were recorded. |
+
+## Observed Fixture Cases
+
+| Case | Timestamp | Combo notation | Observed damage | Fixture status | Confidence | Notes |
+|---|---:|---|---:|---|---|---|
+| `jp-basic-light-stribog-001` | `00:23` | `しゃがみ小P > 立ち小P > 弱ストリボーグ` | 1240 | enabled seed | high | Overlay and combo damage label are clear. |
+| `jp-basic-light-rush-extension-1482` | `00:45` | `小P > 小Pキャンセル > しゃがみ中P or 引き中Pタゲコン > 中ストリボーグ` | 1482 | review-needed disabled candidate | low/medium | Route-to-damage mapping is ambiguous. |
+| `jp-basic-light-rush-extension-1527` | `00:56` | `小P > 小Pキャンセル > しゃがみ中P or 引き中Pタゲコン > 中ストリボーグ` | 1527 | review-needed disabled candidate | medium | Likely higher-damage branch, but still needs route normalization review. |
+
+## Boundaries
+
+- This run builds an eval oracle fixture, not curated knowledge.
+- Observed damage is not current-system authority.
+- The fixture must not feed generated references.
+- Damage-hidden calculation evals are out of scope for this run.
+- End-to-end video analysis is out of scope for this run.
+- Raw video, frames, screenshots, contact sheets, and full captions/transcript are not stored in repo.
+
+## Repo Boundary And Cleanup
+
+- Repo-local media/state scan: no hits after excluding `.git` and `skills/sf6-agent/assets/frame-current/`.
+- Scratch cleanup: done.
+- Generated references: unchanged.
+- Frame-current assets: unchanged.
+
+## Findings
+
+- The high-confidence baseline route is suitable as a first oracle seed.
+- The rush-extension alternatives should remain disabled until combo notation and branch mapping are manually reviewed.
+- A future combo notation contract is needed before broader damage calculation tests.
+- A future fixture validator should check `evals/fixtures/combo-damage/*.yaml` once the shape is accepted.

--- a/evals/fixtures/combo-damage/README.md
+++ b/evals/fixtures/combo-damage/README.md
@@ -1,0 +1,63 @@
+# Combo Damage Oracle Fixtures
+
+このdirectoryは、コンボ表記と動画・検証runで観測したdamage labelを保持するeval fixture surfaceです。
+
+ここにあるartifactは、damage-hidden calculation evalや将来のcombo damage calculator検証に使うためのoracle候補です。`knowledge/curated/` ではなく、public answer用のcurrent-system authorityでもありません。
+
+## Boundary
+
+- `observed_damage` はeval oracle labelです。
+- `observed_damage` はaccepted current-system factではありません。
+- Fixtureはgenerated referencesへ流してはいけません。
+- Fixtureはpublic answer sourceとして直接使ってはいけません。
+- Raw video、frames、screenshots、contact sheets、browser cache、full transcriptはrepoに保存しません。
+- Source metadata、video observations、review notesを参照し、観測条件と不確実性を追えるようにします。
+
+## Enabled And Disabled Cases
+
+`enabled_for_damage_hidden_eval: true` のcaseだけが、damage-hidden calculation evalの入力候補です。
+
+Enabled caseは少なくとも次を満たす必要があります。
+
+- combo notationが明確。
+- observed damageが明確。
+- route-to-damage対応が明確。
+- `notation_confidence: high`。
+- `damage_confidence: high`。
+- `review_status: needs_review` または、将来定義されるfixture-specific accepted state。
+
+`enabled_for_damage_hidden_eval: false` のcaseは、観測済みでもまだ計算evalには使いません。
+
+Disabled caseの例:
+
+- overlayが複数route候補を示している。
+- route-to-damage対応が曖昧。
+- notation normalizationが未確定。
+- damage labelは見えるが、該当routeの条件が不明。
+
+## Notation
+
+Fixture may include both human-facing Japanese notation and a provisional normalized notation.
+
+Examples:
+
+- `combo_notation_jp`
+- `combo_notation_normalized`
+
+The normalized notation is provisional until a combo notation contract is defined. Do not treat the current strings as a stable machine-readable contract.
+
+## Relationship To Current Facts
+
+Combo damage fixtures are useful for testing whether a future calculator can reproduce observed results. They do not make the observed values authoritative.
+
+Exact current system mechanics still require the workflow in `workflows/system-mechanics-fact-workflow.md`.
+
+Move-specific current values still come from `data/exports/`, `data/roster/`, and generated frame-current runtime assets when packaged.
+
+## Expected Follow-ups
+
+- Add a validator for `evals/fixtures/combo-damage/*.yaml`.
+- Expand fixture coverage with high-confidence cases across different route types.
+- Define a combo notation contract.
+- Define combo damage calculation input/output contracts.
+- Add damage-hidden calculation evals only after fixture and notation boundaries are reviewed.

--- a/evals/fixtures/combo-damage/jp-ryusei-nyfngnzjv3m.yaml
+++ b/evals/fixtures/combo-damage/jp-ryusei-nyfngnzjv3m.yaml
@@ -1,0 +1,62 @@
+fixture_id: jp-ryusei-nyfngnzjv3m
+fixture_kind: combo_damage_oracle
+schema_version: "0.1.0"
+source:
+  type: youtube
+  url: "https://www.youtube.com/watch?v=nyFNgnzjV3M"
+  video_id: nyFNgnzjV3M
+  title: "これ一本で全てわかるJPコンボ講座【りゅうせい・スト６】"
+  channel: "りゅうせい"
+  character: jp
+  accessed_at: "2026-05-04"
+scope:
+  chapter: basic_light_combos
+  start_time: "00:08"
+  end_time: "00:57"
+boundary:
+  fixture_role: damage_oracle
+  not_curated_knowledge: true
+  not_current_system_authority: true
+  raw_media_stored_in_repo: false
+  full_transcript_stored_in_repo: false
+  generated_references_allowed: false
+source_refs:
+  - knowledge/sources/videos/youtube-nyfngnzjv3m.md
+  - knowledge/evidence/video-observations/youtube-nyfngnzjv3m-jp-combos.observations.md
+cases:
+  - id: jp-basic-light-stribog-001
+    timestamp: "00:23"
+    combo_notation_jp: "しゃがみ小P > 立ち小P > 弱ストリボーグ"
+    combo_notation_normalized: "2LP > 5LP > weak Stribog"
+    observed_damage: 1240
+    observed_damage_source: training_ui_combo_damage
+    damage_visible: true
+    enabled_for_damage_hidden_eval: true
+    notation_confidence: high
+    damage_confidence: high
+    review_status: needs_review
+    notes: "Visible overlay and damage label are clear. Use as the first oracle seed only; do not treat as curated knowledge or current-system authority."
+  - id: jp-basic-light-rush-extension-1482
+    timestamp: "00:45"
+    combo_notation_jp: "小P > 小Pキャンセル > しゃがみ中P or 引き中Pタゲコン > 中ストリボーグ"
+    combo_notation_normalized: null
+    observed_damage: 1482
+    observed_damage_source: training_ui_combo_damage
+    damage_visible: true
+    enabled_for_damage_hidden_eval: false
+    notation_confidence: low
+    damage_confidence: high
+    review_status: needs_review
+    notes: "The overlay lists alternative branches, so route-to-damage mapping needs manual review before this case can be used for damage-hidden calculation."
+  - id: jp-basic-light-rush-extension-1527
+    timestamp: "00:56"
+    combo_notation_jp: "小P > 小Pキャンセル > しゃがみ中P or 引き中Pタゲコン > 中ストリボーグ"
+    combo_notation_normalized: null
+    observed_damage: 1527
+    observed_damage_source: training_ui_combo_damage
+    damage_visible: true
+    enabled_for_damage_hidden_eval: false
+    notation_confidence: medium
+    damage_confidence: high
+    review_status: needs_review
+    notes: "Likely the higher-damage crouching medium punch branch based on commentary, but keep disabled until notation and branch mapping are reviewed."

--- a/knowledge/evidence/video-observations/youtube-nyfngnzjv3m-jp-combos.observations.md
+++ b/knowledge/evidence/video-observations/youtube-nyfngnzjv3m-jp-combos.observations.md
@@ -1,0 +1,125 @@
+---
+id: video-observation-youtube-nyfngnzjv3m-jp-combos
+title: YouTube nyFNgnzjV3M JP Combo Damage Oracle Fixture Observation
+source_kind: reproducible_observation
+source_role: combo_damage_oracle_observation
+review_status: needs_review
+review_after: "2026-08-04"
+---
+
+# YouTube nyFNgnzjV3M JP Combo Damage Oracle Fixture Observation
+
+This artifact records timestamped observations from a limited section of one Japanese JP combo guide video. It is an observation artifact, not accepted strategy knowledge, and it must not feed generated references without later review.
+
+## Source
+
+- Source metadata: `knowledge/sources/videos/youtube-nyfngnzjv3m.md`
+- Source URL: `https://www.youtube.com/watch?v=nyFNgnzjV3M`
+- Accessed: 2026-05-04
+- Observation method: repo-external temporary section download, sparse frame sampling, still-frame/crop inspection, contact-sheet inspection, and Japanese auto-caption inspection.
+- Observed section: `00:08-00:57` from the original video.
+- Raw media stored in repo: no.
+- Full transcript stored in repo: no.
+
+## Timestamped Observations
+
+| Time | Observation kind | Visible observation | Speaker/commentary claim | Confidence | Notes |
+|---|---|---|---|---|---|
+| 00:08-00:12 | visual + commentary | The chapter opens with JP gameplay and an overlay reading `JPの基本コンボ(小技始動)`. | Speaker introduces this as a basic JP combo section. | high | Chapter boundary and topic are clear from overlay and captions. |
+| 00:12-00:23 | visual + commentary | Overlay shows `しゃがみ小P > 立ち小P > 弱ストリボーグ`. The training UI later shows combo damage `1240`. | Speaker describes the basic route as crouching jab/jab into Stribog; captions are noisy but align with the visible overlay. | high | Use as the first usable oracle fixture case. Damage is an observed video label, not current-system authority. |
+| 00:31-00:45 | visual + commentary | Overlay shows `小P > 小Pキャンセル > しゃがみ中P or 引き中Pタゲコン > 中ストリボーグ`. A later training UI frame shows combo damage `1482`. | Speaker says there are routes after using rush from jab. | medium | The route-to-damage mapping is less certain because the overlay lists alternatives. Keep as review-needed fixture candidate. |
+| 00:41-00:57 | visual + commentary | The same rush-extension discussion continues. A later training UI frame shows combo damage `1527`. | Speaker says the crouching medium punch route has higher damage, based on auto-caption and visible context. | medium | Likely the higher-damage crouching MP variant, but keep route mapping review-needed until manual verification. |
+
+## Contract-Shaped Observation Payload
+
+This payload follows the shape of `contracts/video-observation.schema.json` at a coarse fixture-build level. Segment text is paraphrased; no full transcript is stored.
+
+```json
+{
+  "schema_version": "2.0.0",
+  "clip_metadata": {
+    "clip_id": "youtube-nyfngnzjv3m-jp-basic-light",
+    "source_fps": 60,
+    "normalized_fps": 60,
+    "duration_seconds": 49
+  },
+  "actor_bindings": [
+    {
+      "actor_ref": "player_jp",
+      "character_slug": "jp",
+      "binding_confidence": 0.9,
+      "binding_basis": [
+        "video title",
+        "visible JP mirror-match UI",
+        "combo overlay"
+      ]
+    },
+    {
+      "actor_ref": "dummy_jp",
+      "character_slug": "jp",
+      "binding_confidence": 0.8,
+      "binding_basis": [
+        "training mode UI",
+        "visible character model"
+      ]
+    }
+  ],
+  "segments": [
+    {
+      "segment_id": "seg-0001",
+      "track": "chapter",
+      "kind": "basic_light_combo_intro",
+      "start_time": "00:08",
+      "end_time": "00:12",
+      "confidence": 0.9,
+      "summary": "JP basic light-start combo chapter begins."
+    },
+    {
+      "segment_id": "seg-0002",
+      "track": "combo_observation",
+      "kind": "combo_damage_oracle_candidate",
+      "start_time": "00:12",
+      "end_time": "00:23",
+      "confidence": 0.85,
+      "summary": "Visible overlay shows crouching light punch into standing light punch into weak Stribog; training UI shows combo damage 1240."
+    },
+    {
+      "segment_id": "seg-0003",
+      "track": "combo_observation",
+      "kind": "combo_damage_oracle_candidate",
+      "start_time": "00:31",
+      "end_time": "00:45",
+      "confidence": 0.55,
+      "summary": "Visible overlay shows a jab-rush extension with crouching medium punch or back-medium-punch target-combo branch into medium Stribog; one observed damage label is 1482."
+    },
+    {
+      "segment_id": "seg-0004",
+      "track": "combo_observation",
+      "kind": "combo_damage_oracle_candidate",
+      "start_time": "00:41",
+      "end_time": "00:57",
+      "confidence": 0.55,
+      "summary": "A second rush-extension variant is associated with observed damage 1527; route mapping remains review-needed."
+    }
+  ],
+  "derived_events": [
+    {
+      "event_id": "event-0001",
+      "kind": "jp_combo_damage_oracle_fixture_seed",
+      "source_segment_ids": [
+        "seg-0002",
+        "seg-0003",
+        "seg-0004"
+      ]
+    }
+  ]
+}
+```
+
+## Boundary Notes
+
+- These are review-only observations.
+- Observed damage values are eval oracle labels, not accepted current facts.
+- Speaker claims about route usefulness, relative damage, or current applicability are not accepted current facts.
+- Combo notation normalization, input timing, drive-rush state, and route variants remain review-needed before a damage calculator consumes ambiguous cases.
+- No raw media, frames, screenshots, contact sheets, or full captions are stored in the repository.

--- a/knowledge/review/unresolved/youtube-nyfngnzjv3m-jp-combos.review.md
+++ b/knowledge/review/unresolved/youtube-nyfngnzjv3m-jp-combos.review.md
@@ -1,0 +1,74 @@
+---
+id: sf6-review-youtube-nyfngnzjv3m-jp-combos
+title: YouTube nyFNgnzjV3M JP Combo Damage Oracle Fixture Review
+claim_kind: observation
+source_kind: reproducible_observation
+source_role: combo_damage_oracle_fixture_review
+evidence_basis:
+  - "Video source metadata recorded in knowledge/sources/videos/youtube-nyfngnzjv3m.md."
+  - "Timestamped observations recorded in knowledge/evidence/video-observations/youtube-nyfngnzjv3m-jp-combos.observations.md."
+  - "Combo/damage fixture recorded in evals/fixtures/combo-damage/jp-ryusei-nyfngnzjv3m.yaml."
+  - "Repo-external scratch media was used only for temporary observation and was not committed."
+verification_state: unverified
+confidence: 0.45
+volatility: patch_sensitive
+patch_sensitivity: high
+review_status: needs_review
+source_refs:
+  - label: "Source metadata: YouTube nyFNgnzjV3M"
+    path: "knowledge/sources/videos/youtube-nyfngnzjv3m.md"
+    accessed_at: "2026-05-04"
+  - label: "Video observations: YouTube nyFNgnzjV3M JP combos"
+    path: "knowledge/evidence/video-observations/youtube-nyfngnzjv3m-jp-combos.observations.md"
+    accessed_at: "2026-05-04"
+review_after: "2026-08-04"
+summary: "Review holding note for a first JP combo/damage oracle fixture extracted from a limited section of Ryusei's JP combo guide video."
+---
+
+# YouTube nyFNgnzjV3M JP Combo Damage Oracle Fixture Review
+
+This review note tracks a JP combo/damage oracle fixture seed. It is canonical review tracking, but it is not accepted curated knowledge and must not feed generated knowledge references.
+
+## Review Status
+
+- Video source metadata artifact created: yes.
+- Timestamped video observation artifact created: yes.
+- Combo/damage oracle fixture created: yes.
+- Candidate claims artifact created: no; the fixture is eval/test material, not a public answer claim.
+- Raw video stored in repo: no.
+- Raw frames or screenshots stored in repo: no.
+- Full transcript stored in repo: no.
+- Scratch/cache policy followed: yes.
+- Curated promotion performed: no.
+- Generated references changed: no.
+- Exact current-system values accepted: no.
+- Current verification required before public use: yes.
+
+## Held Observations
+
+The selected source section appears to demonstrate JP basic light-start routes and jab-rush extension routes. The baseline light-start route has high confidence as an oracle seed because the visible overlay and damage label are clear.
+
+The rush-extension variants remain less certain because the overlay presents alternative route branches and the observed damage labels must be mapped to the exact route variant before they can be used as enabled damage-hidden calculation cases.
+
+The following categories stay unresolved:
+
+- Exact normalization from Japanese combo notation to a future machine-readable combo notation contract.
+- Whether ambiguous rush-extension cases map to crouching medium punch or back-medium-punch target-combo variants.
+- Whether drive-rush state, hit count, spacing, counter state, training settings, or patch state affects the observed damage.
+- Whether observed damage values reproduce in-game under the same conditions.
+- Whether a future damage calculation engine has sufficient current-system data to compute the oracle values.
+
+## Review Notes
+
+- Observed damage is an eval oracle label only.
+- Observed damage is not accepted current-system authority.
+- Do not use the fixture to answer public questions about JP combo damage unless a later calculation workflow and current-system authority path define that behavior.
+- Do not promote the fixture into `knowledge/curated/`.
+- A future validator should check `evals/fixtures/combo-damage/*.yaml` before these fixtures are used broadly.
+
+## Workflow Findings
+
+- `workflows/ingest-video.md` and `workflows/media-scratch-cache-policy.md` were enough for source metadata, observation, review, and cleanup boundaries.
+- The fixture introduces a new eval support surface under `evals/fixtures/combo-damage/`.
+- A future issue should define a combo notation contract before damage-hidden calculation evals depend on ambiguous notation.
+- A later issue should add a combo damage oracle fixture validator after at least one fixture shape has been reviewed.

--- a/knowledge/sources/videos/youtube-nyfngnzjv3m.md
+++ b/knowledge/sources/videos/youtube-nyfngnzjv3m.md
@@ -1,0 +1,49 @@
+---
+id: source-video-youtube-nyfngnzjv3m
+title: "これ一本で全てわかるJPコンボ講座【りゅうせい・スト６】"
+source_kind: community
+source_role: combo_damage_oracle_fixture_source
+author: "りゅうせい"
+publisher: "YouTube"
+url: "https://www.youtube.com/watch?v=nyFNgnzjV3M"
+published_at: "2025-10-25"
+accessed_at: "2026-05-04"
+captured_at: "2026-05-04"
+copyright_policy: "no full video, raw frames, screenshots, contact sheets, or full transcript stored"
+review_status: needs_review
+review_after: "2026-08-04"
+---
+
+# Source Summary
+
+りゅうせい氏による日本語のJPコンボ講座動画。動画metadataでは、JPの基本小技コンボ、中攻撃からのコンボ、画面端コンボ、SA2コンボ、Year3から使える新コンボなどの章立てが確認できる。
+
+このsource artifactは、動画内の一部区間からJPのcombo notationとobserved damageをreview可能なoracle fixtureへ落とすためのsource metadataである。これはnot final public answer evidenceであり、コンボダメージのcurrent-system authorityでも、accepted curated knowledgeでもない。
+
+## Extracted Scope
+
+- Video ID: `nyFNgnzjV3M`.
+- Canonical URL: `https://www.youtube.com/watch?v=nyFNgnzjV3M`.
+- Channel: りゅうせい.
+- Channel URL: `https://www.youtube.com/channel/UCPr2Pyu41o1O7NXl4eDaLPw`.
+- Published/uploaded date from YouTube metadata: 2025-10-25.
+- Duration from YouTube metadata: 1503 seconds.
+- Source language: Japanese.
+- Captions/transcript: Japanese auto-generated captions were available for temporary inspection, but the full captions/transcript are not stored in this repository.
+- Pilot scope: `00:08-00:57` basic light combo chapter.
+- Useful for: building a JP combo/damage oracle fixture and testing the separation between video observation, combo notation, observed damage, and later calculation evaluation.
+- Not useful for: accepting current patch combo damage rules, route-level damage formulas, scaling tables, minimum guarantees, or system-mechanics exact values without separate verification.
+
+## Media Handling
+
+- Raw video was temporarily downloaded to a repo-external scratch directory for this fixture build.
+- Sparse frames, still frames, crops, and contact sheets were generated only in repo-external scratch for maintainer inspection.
+- Raw video, frames, screenshots, contact sheets, browser cache, session state, and full captions/transcript are not stored in this repository.
+- Scratch/cache handling followed `workflows/media-scratch-cache-policy.md`.
+
+## Reviewer Notes
+
+- Treat this as a community video source for eval fixture construction, not final public answer evidence.
+- Observed damage values are oracle labels for testing, not accepted current-system facts.
+- Combo notation derived from video overlays and captions may need Japanese notation normalization before a damage calculator can use it.
+- Do not promote observed damage, route notation, or speaker claims from this source into `knowledge/curated/`.


### PR DESCRIPTION
## Summary

- add source metadata for Ryusei's JP combo guide video `nyFNgnzjV3M`
- add timestamped observations for the `00:08-00:57` basic light combo section
- add a JP combo/damage oracle fixture with one enabled high-confidence seed and two disabled review-needed candidates
- add `evals/fixtures/combo-damage/README.md` to document fixture boundaries, enabled/disabled case rules, and follow-ups
- add review and smoke-run notes documenting uncertainty, repo boundary, and scratch cleanup

## Boundaries

- fixture/oracle only, not curated knowledge
- no raw video, frames, screenshots, contact sheets, browser cache, or full transcript stored in repo
- observed damage is eval oracle material, not current-system authority
- no generated references changed
- no frame-current assets changed
- no damage calculation engine or damage-hidden eval added in this PR
- no end-to-end video analysis test added in this PR

## Verification

- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-video-artifacts.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-current-fact-boundaries.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-evals.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1`
- `git diff --check`
- repo-local media/state scan: no hits
- generated output status check: clean
- scratch cleanup: done
- credential scan on changed files: no hits

Closes #72
