### PR TITLE
[v2.1] Expand JP combo damage oracle fixture coverage

### DIFF
--- a/docs/testing/smoke-runs/2026-05-04-jp-combo-damage-oracle-coverage.md
+++ b/docs/testing/smoke-runs/2026-05-04-jp-combo-damage-oracle-coverage.md
@@ -1,0 +1,57 @@
+# JP Combo Damage Oracle Fixture Coverage Smoke Run
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| Date | 2026-05-04 |
+| Issue | #76 |
+| Source | これ一本で全てわかるJPコンボ講座【りゅうせい・スト６】 |
+| Source URL | `https://www.youtube.com/watch?v=nyFNgnzjV3M` |
+| Video ID | `nyFNgnzjV3M` |
+| Selected scope | `00:57-02:00` mid-attack combo chapter expansion |
+| Scratch root | repo-external `${XDG_CACHE_HOME:-$HOME/.cache}/sf6-skills/media-ingest/` |
+| Raw media stored in repo | no |
+| Full transcript stored in repo | no |
+
+## Tooling
+
+| Tool / Capability | Result | Notes |
+|---|---|---|
+| YouTube metadata inspection | pass | `yt-dlp` via `uvx` confirmed title, channel, duration, and upload date. |
+| Section download | pass | `00:57-02:00` was temporarily downloaded outside the repo. |
+| Frame/contact-sheet inspection | pass | Sparse frames, still frames, and a contact sheet were generated outside the repo. |
+| Caption/transcript inspection | unavailable/partial | `yt-dlp --list-subs` listed automatic caption formats, but the video reported no downloadable subtitles. Full transcript was not stored. |
+| Fixture coverage expansion | partial | Four mid-attack coverage candidates were recorded, all disabled for damage-hidden eval because notation still needs review. |
+
+## Observed Fixture Candidates
+
+| Case | Timestamp | Combo notation | Observed damage | Fixture status | Confidence | Notes |
+|---|---:|---|---:|---|---|---|
+| `jp-mid-rush-triglav-1824` | `01:10` | `中攻撃キャンセルラッシュ > しゃがみ大P > 強ストリボーグ > 中トルバラン > トリグラフ` | 1824 | disabled candidate | medium/high | Overlay and damage label are clear, but the starter is generic `中攻撃`. |
+| `jp-mid-rush-od-triglav-3260` | `01:18` | `中攻撃キャンセルラッシュ > しゃがみ大P > 強ストリボーグ > 中トルバラン > ODトリグラフ追撃` | 3260 | disabled candidate | medium/high | OD follow-up variant is visible, but the full route inherits prior overlay context. |
+| `jp-mid-corner-carry-rush-fhk-2763` | `01:33` | `中攻撃キャンセルラッシュ > しゃがみ大P > 強ストリボーグ > 前ステ > ラッシュ前大K(ちょい遅らせ) > トリグラフ` | 2763 | disabled candidate | medium/high | Adds corner-carry coverage; delayed forward-heavy-kick timing needs notation review. |
+| `jp-mid-position-carry-1484` | `01:56` | `しゃがみ中P始動から端まで運ぶ位置別ルート` | 1484 | disabled candidate | low/high | Damage label is visible, but the inspected frame does not contain a complete route overlay. |
+
+## Boundaries
+
+- This run expands eval oracle fixture coverage, not curated knowledge.
+- Observed damage is not current-system authority.
+- The fixture must not feed generated references.
+- Newly added cases remain `enabled_for_damage_hidden_eval: false`.
+- Damage-hidden calculation evals are out of scope for this run.
+- End-to-end video analysis is out of scope for this run.
+- Raw video, frames, screenshots, contact sheets, and full captions/transcript are not stored in repo.
+
+## Repo Boundary And Cleanup
+
+- Repo-local media/state scan: no hits after excluding `.git` and `skills/sf6-agent/assets/frame-current/`.
+- Scratch cleanup: done.
+- Generated references: unchanged.
+- Frame-current assets: unchanged.
+
+## Findings
+
+- The mid-attack chapter provides useful route-shape coverage, but not enough exact notation confidence to enable new damage-hidden eval cases.
+- The main blocker is combo notation specificity: generic `中攻撃`, inherited route context, OD follow-up notation, delayed input timing, and position-specific route mapping.
+- The existing fixture validator correctly permits disabled candidates while preserving the boundary around enabled cases.

--- a/evals/fixtures/combo-damage/jp-ryusei-nyfngnzjv3m.yaml
+++ b/evals/fixtures/combo-damage/jp-ryusei-nyfngnzjv3m.yaml
@@ -10,9 +10,9 @@ source:
   character: jp
   accessed_at: "2026-05-04"
 scope:
-  chapter: basic_light_combos
+  chapter: basic_light_and_mid_attack_combos
   start_time: "00:08"
-  end_time: "00:57"
+  end_time: "02:00"
 boundary:
   fixture_role: damage_oracle
   not_curated_knowledge: true
@@ -60,3 +60,51 @@ cases:
     damage_confidence: high
     review_status: needs_review
     notes: "Likely the higher-damage crouching medium punch branch based on commentary, but keep disabled until notation and branch mapping are reviewed."
+  - id: jp-mid-rush-triglav-1824
+    timestamp: "01:10"
+    combo_notation_jp: "中攻撃キャンセルラッシュ > しゃがみ大P > 強ストリボーグ > 中トルバラン > トリグラフ"
+    combo_notation_normalized: "medium_normal xx Drive Rush > 2HP > heavy Stribog > medium Torbalan > Triglav"
+    observed_damage: 1824
+    observed_damage_source: training_ui_combo_damage
+    damage_visible: true
+    enabled_for_damage_hidden_eval: false
+    notation_confidence: medium
+    damage_confidence: high
+    review_status: needs_review
+    notes: "The visible overlay and damage label are clear, but the starter is generic `中攻撃` rather than an exact move. Keep disabled until the combo notation contract can represent or resolve the starter."
+  - id: jp-mid-rush-od-triglav-3260
+    timestamp: "01:18"
+    combo_notation_jp: "中攻撃キャンセルラッシュ > しゃがみ大P > 強ストリボーグ > 中トルバラン > ODトリグラフ追撃"
+    combo_notation_normalized: "medium_normal xx Drive Rush > 2HP > heavy Stribog > medium Torbalan > OD Triglav follow-up"
+    observed_damage: 3260
+    observed_damage_source: training_ui_combo_damage
+    damage_visible: true
+    enabled_for_damage_hidden_eval: false
+    notation_confidence: medium
+    damage_confidence: high
+    review_status: needs_review
+    notes: "The damage label is clear, but the overlay only states that replacing the final Triglav with OD Triglav adds another Triglav hit. Keep disabled until the full route and OD follow-up notation are reviewed."
+  - id: jp-mid-corner-carry-rush-fhk-2763
+    timestamp: "01:33"
+    combo_notation_jp: "中攻撃キャンセルラッシュ > しゃがみ大P > 強ストリボーグ > 前ステ > ラッシュ前大K(ちょい遅らせ) > トリグラフ"
+    combo_notation_normalized: "medium_normal xx Drive Rush > 2HP > heavy Stribog > forward dash > Drive Rush 6HK(delayed) > Triglav"
+    observed_damage: 2763
+    observed_damage_source: training_ui_combo_damage
+    damage_visible: true
+    enabled_for_damage_hidden_eval: false
+    notation_confidence: medium
+    damage_confidence: high
+    review_status: needs_review
+    notes: "This adds corner-carry coverage, but the generic medium starter and delayed forward-heavy-kick timing need notation review before damage-hidden evaluation."
+  - id: jp-mid-position-carry-1484
+    timestamp: "01:56"
+    combo_notation_jp: "しゃがみ中P始動から端まで運ぶ位置別ルート"
+    combo_notation_normalized: null
+    observed_damage: 1484
+    observed_damage_source: training_ui_combo_damage
+    damage_visible: true
+    enabled_for_damage_hidden_eval: false
+    notation_confidence: low
+    damage_confidence: high
+    review_status: needs_review
+    notes: "The damage label is visible, but the route overlay is not complete in the inspected frame. Keep as a disabled position/carry candidate."

--- a/knowledge/evidence/video-observations/youtube-nyfngnzjv3m-jp-combos.observations.md
+++ b/knowledge/evidence/video-observations/youtube-nyfngnzjv3m-jp-combos.observations.md
@@ -16,8 +16,8 @@ This artifact records timestamped observations from a limited section of one Jap
 - Source metadata: `knowledge/sources/videos/youtube-nyfngnzjv3m.md`
 - Source URL: `https://www.youtube.com/watch?v=nyFNgnzjV3M`
 - Accessed: 2026-05-04
-- Observation method: repo-external temporary section download, sparse frame sampling, still-frame/crop inspection, contact-sheet inspection, and Japanese auto-caption inspection.
-- Observed section: `00:08-00:57` from the original video.
+- Observation method: repo-external temporary section downloads, sparse frame sampling, still-frame/crop inspection, contact-sheet inspection, and YouTube metadata inspection.
+- Observed section: `00:08-02:00` from the original video.
 - Raw media stored in repo: no.
 - Full transcript stored in repo: no.
 
@@ -29,6 +29,11 @@ This artifact records timestamped observations from a limited section of one Jap
 | 00:12-00:23 | visual + commentary | Overlay shows `しゃがみ小P > 立ち小P > 弱ストリボーグ`. The training UI later shows combo damage `1240`. | Speaker describes the basic route as crouching jab/jab into Stribog; captions are noisy but align with the visible overlay. | high | Use as the first usable oracle fixture case. Damage is an observed video label, not current-system authority. |
 | 00:31-00:45 | visual + commentary | Overlay shows `小P > 小Pキャンセル > しゃがみ中P or 引き中Pタゲコン > 中ストリボーグ`. A later training UI frame shows combo damage `1482`. | Speaker says there are routes after using rush from jab. | medium | The route-to-damage mapping is less certain because the overlay lists alternatives. Keep as review-needed fixture candidate. |
 | 00:41-00:57 | visual + commentary | The same rush-extension discussion continues. A later training UI frame shows combo damage `1527`. | Speaker says the crouching medium punch route has higher damage, based on auto-caption and visible context. | medium | Likely the higher-damage crouching MP variant, but keep route mapping review-needed until manual verification. |
+| 00:57-01:10 | visual + commentary | The mid-attack chapter begins. Overlay shows `中攻撃キャンセルラッシュ > しゃがみ大P > 強ストリボーグ > 中トルバラン > トリグラフ`. The training UI later shows combo damage `1824`. | Embedded explanatory text and commentary frame this as a combo from mid attacks after cancel rush. | medium | Route overlay and damage label are clear, but `中攻撃` is a generic starter rather than an exact move. Keep disabled for damage-hidden eval. |
+| 01:10-01:21 | visual + commentary | The same route is discussed with the final Triglav changed to OD Triglav. The training UI shows combo damage `3260`. | Embedded explanatory text says using OD Triglav for the final Triglav gives one more Triglav hit. | medium | Useful OD follow-up coverage, but the full route is partly inherited from the preceding overlay. Keep disabled until notation review. |
+| 01:27-01:36 | visual + commentary | Overlay shows `中攻撃キャンセルラッシュ > しゃがみ大P > 強ストリボーグ > 前ステ > ラッシュ前大K(ちょい遅らせ) > トリグラフ`. The training UI shows combo damage `2763`. | Embedded explanatory text describes this as a route to push the opponent toward the corner. | medium | Adds corner-carry coverage. The generic starter and delayed forward-heavy-kick timing need notation review before enabling. |
+| 01:37-01:48 | visual + commentary | The route demonstration continues while explanatory text warns that inputting forward heavy kick too early can reduce damage because only one hit connects. | Embedded explanatory text cautions about timing and lower damage when forward heavy kick is too early. | medium | This is explanatory context, not an oracle case. |
+| 01:56-02:00 | visual + commentary | A later frame shows combo damage `1484` while on-screen text says this spacing lets crouching medium punch carry to the corner. | Embedded explanatory text discusses carrying to the corner when crouching medium punch hits from this position. | low/medium | Damage is visible, but the route overlay is incomplete in the inspected frame. Keep as disabled position/carry candidate. |
 
 ## Contract-Shaped Observation Payload
 
@@ -38,10 +43,10 @@ This payload follows the shape of `contracts/video-observation.schema.json` at a
 {
   "schema_version": "2.0.0",
   "clip_metadata": {
-    "clip_id": "youtube-nyfngnzjv3m-jp-basic-light",
+    "clip_id": "youtube-nyfngnzjv3m-jp-combo-coverage",
     "source_fps": 60,
     "normalized_fps": 60,
-    "duration_seconds": 49
+    "duration_seconds": 112
   },
   "actor_bindings": [
     {
@@ -100,6 +105,42 @@ This payload follows the shape of `contracts/video-observation.schema.json` at a
       "end_time": "00:57",
       "confidence": 0.55,
       "summary": "A second rush-extension variant is associated with observed damage 1527; route mapping remains review-needed."
+    },
+    {
+      "segment_id": "seg-0005",
+      "track": "combo_observation",
+      "kind": "combo_damage_oracle_candidate",
+      "start_time": "00:57",
+      "end_time": "01:10",
+      "confidence": 0.65,
+      "summary": "Mid-attack cancel-rush route overlay is visible and associated with observed damage 1824; starter remains generic."
+    },
+    {
+      "segment_id": "seg-0006",
+      "track": "combo_observation",
+      "kind": "combo_damage_oracle_candidate",
+      "start_time": "01:10",
+      "end_time": "01:21",
+      "confidence": 0.6,
+      "summary": "OD Triglav follow-up variant is associated with observed damage 3260; full route inherits context from the previous overlay."
+    },
+    {
+      "segment_id": "seg-0007",
+      "track": "combo_observation",
+      "kind": "combo_damage_oracle_candidate",
+      "start_time": "01:27",
+      "end_time": "01:36",
+      "confidence": 0.6,
+      "summary": "Corner-carry route overlay is visible and associated with observed damage 2763; delayed forward-heavy-kick timing remains notation review-needed."
+    },
+    {
+      "segment_id": "seg-0008",
+      "track": "combo_observation",
+      "kind": "combo_damage_oracle_candidate",
+      "start_time": "01:56",
+      "end_time": "02:00",
+      "confidence": 0.45,
+      "summary": "Position/carry discussion is associated with observed damage 1484, but route overlay is incomplete."
     }
   ],
   "derived_events": [
@@ -109,7 +150,11 @@ This payload follows the shape of `contracts/video-observation.schema.json` at a
       "source_segment_ids": [
         "seg-0002",
         "seg-0003",
-        "seg-0004"
+        "seg-0004",
+        "seg-0005",
+        "seg-0006",
+        "seg-0007",
+        "seg-0008"
       ]
     }
   ]

--- a/knowledge/review/unresolved/youtube-nyfngnzjv3m-jp-combos.review.md
+++ b/knowledge/review/unresolved/youtube-nyfngnzjv3m-jp-combos.review.md
@@ -22,12 +22,12 @@ source_refs:
     path: "knowledge/evidence/video-observations/youtube-nyfngnzjv3m-jp-combos.observations.md"
     accessed_at: "2026-05-04"
 review_after: "2026-08-04"
-summary: "Review holding note for a first JP combo/damage oracle fixture extracted from a limited section of Ryusei's JP combo guide video."
+summary: "Review holding note for JP combo/damage oracle fixture candidates extracted from limited sections of Ryusei's JP combo guide video."
 ---
 
 # YouTube nyFNgnzjV3M JP Combo Damage Oracle Fixture Review
 
-This review note tracks a JP combo/damage oracle fixture seed. It is canonical review tracking, but it is not accepted curated knowledge and must not feed generated knowledge references.
+This review note tracks JP combo/damage oracle fixture candidates. It is canonical review tracking, but it is not accepted curated knowledge and must not feed generated knowledge references.
 
 ## Review Status
 
@@ -46,14 +46,18 @@ This review note tracks a JP combo/damage oracle fixture seed. It is canonical r
 
 ## Held Observations
 
-The selected source section appears to demonstrate JP basic light-start routes and jab-rush extension routes. The baseline light-start route has high confidence as an oracle seed because the visible overlay and damage label are clear.
+The selected source sections appear to demonstrate JP basic light-start routes, jab-rush extension routes, and mid-attack cancel-rush routes. The baseline light-start route has high confidence as an oracle seed because the visible overlay and damage label are clear.
 
 The rush-extension variants remain less certain because the overlay presents alternative route branches and the observed damage labels must be mapped to the exact route variant before they can be used as enabled damage-hidden calculation cases.
+
+The mid-attack expansion adds several coverage candidates with visible damage labels, including cancel-rush, OD Triglav follow-up, and corner-carry route shapes. These remain disabled because the visible overlays use generic starters such as `中攻撃`, inherit route context from prior overlays, or require timing notation such as delayed forward-heavy-kick input.
 
 The following categories stay unresolved:
 
 - Exact normalization from Japanese combo notation to a future machine-readable combo notation contract.
 - Whether ambiguous rush-extension cases map to crouching medium punch or back-medium-punch target-combo variants.
+- Whether generic starters such as `中攻撃` can be represented safely in damage-hidden calculation inputs.
+- Whether OD Triglav follow-up and delayed forward-heavy-kick timing need dedicated notation fields.
 - Whether drive-rush state, hit count, spacing, counter state, training settings, or patch state affects the observed damage.
 - Whether observed damage values reproduce in-game under the same conditions.
 - Whether a future damage calculation engine has sufficient current-system data to compute the oracle values.
@@ -64,11 +68,11 @@ The following categories stay unresolved:
 - Observed damage is not accepted current-system authority.
 - Do not use the fixture to answer public questions about JP combo damage unless a later calculation workflow and current-system authority path define that behavior.
 - Do not promote the fixture into `knowledge/curated/`.
-- A future validator should check `evals/fixtures/combo-damage/*.yaml` before these fixtures are used broadly.
+- `tests/validation/validate-combo-damage-fixtures.ps1` now checks the fixture boundary and enabled/disabled case fields.
 
 ## Workflow Findings
 
 - `workflows/ingest-video.md` and `workflows/media-scratch-cache-policy.md` were enough for source metadata, observation, review, and cleanup boundaries.
 - The fixture introduces a new eval support surface under `evals/fixtures/combo-damage/`.
 - A future issue should define a combo notation contract before damage-hidden calculation evals depend on ambiguous notation.
-- A later issue should add a combo damage oracle fixture validator after at least one fixture shape has been reviewed.
+- The coverage expansion confirms that route notation, not observed damage visibility, is the main blocker for enabling more damage-hidden eval cases.

--- a/knowledge/sources/videos/youtube-nyfngnzjv3m.md
+++ b/knowledge/sources/videos/youtube-nyfngnzjv3m.md
@@ -29,8 +29,8 @@ review_after: "2026-08-04"
 - Published/uploaded date from YouTube metadata: 2025-10-25.
 - Duration from YouTube metadata: 1503 seconds.
 - Source language: Japanese.
-- Captions/transcript: Japanese auto-generated captions were available for temporary inspection, but the full captions/transcript are not stored in this repository.
-- Pilot scope: `00:08-00:57` basic light combo chapter.
+- Captions/transcript: YouTube caption availability and embedded explanatory text were checked during temporary observation, but the full captions/transcript are not stored in this repository.
+- Pilot scope: `00:08-02:00` basic light and mid-attack combo chapters.
 - Useful for: building a JP combo/damage oracle fixture and testing the separation between video observation, combo notation, observed damage, and later calculation evaluation.
 - Not useful for: accepting current patch combo damage rules, route-level damage formulas, scaling tables, minimum guarantees, or system-mechanics exact values without separate verification.
 


### PR DESCRIPTION
## Summary
- expand `evals/fixtures/combo-damage/jp-ryusei-nyfngnzjv3m.yaml` beyond the initial light-combo seed
- add four mid-attack coverage candidates from `00:57-02:00` of the same Ryusei JP combo guide video
- keep all new cases disabled for damage-hidden eval because notation still needs review
- update source, video observation, review, and smoke report artifacts

## Added coverage
- `jp-mid-rush-triglav-1824`: mid-attack cancel-rush route, observed damage 1824
- `jp-mid-rush-od-triglav-3260`: OD Triglav follow-up variant, observed damage 3260
- `jp-mid-corner-carry-rush-fhk-2763`: corner-carry route with delayed forward-heavy kick, observed damage 2763
- `jp-mid-position-carry-1484`: position/carry candidate, observed damage 1484

## Boundaries
- observed damage remains eval oracle material only
- no new curated knowledge
- no generated references updated
- no frame-current assets changed
- no raw video, frames, screenshots, contact sheets, or full transcript stored in repo
- no damage calculator or damage-hidden eval runner added
- newly added cases are `enabled_for_damage_hidden_eval: false`

## Verification
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-combo-damage-fixtures.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-video-artifacts.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-ingest-artifacts.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1`
- `git diff --check`
- generated output status check: clean
- repo-local media/state scan: no hits
- scratch cleanup: done
- credential scan on changed files: no hits

Closes #76
