### PR TITLE
[v2.1] Define combo notation contract for damage fixtures

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -7,3 +7,9 @@ Contracts distinguish canonical surfaces from derived surfaces and use generic s
 Some contracts describe Markdown front matter or agent-readable artifacts that are enforced by dedicated validators rather than by a generic JSON Schema runtime. Validators under `tests/validation/` are the executable contract layer for the current repo.
 
 When `source_refs.path` points to a migrated legacy file, `source_revision` identifies the commit where that historical path can be reviewed.
+
+## Human-Readable Contracts
+
+- `combo-notation.md`: notation rules for `evals/fixtures/combo-damage/*.yaml`.
+- `frame-current-runtime-assets.md`: runtime asset boundary for generated frame-current payloads.
+- `video-observation.md`: timestamped video observation artifact contract.

--- a/contracts/combo-notation.md
+++ b/contracts/combo-notation.md
@@ -1,0 +1,167 @@
+# Combo Notation Contract
+
+This contract defines how combo notation is recorded for `evals/fixtures/combo-damage/*.yaml`.
+
+It is intentionally smaller than a damage calculator input contract. The goal is to make fixture notation reviewable, stable enough for damage-hidden eval gating, and explicit about unresolved route context.
+
+## Fields
+
+Combo damage fixture cases use two notation fields:
+
+- `combo_notation_jp`: human-facing Japanese notation copied from visible overlays, source-local wording, or maintainer review notes.
+- `combo_notation_normalized`: provisional machine-facing notation written with English-compatible tokens.
+
+`combo_notation_normalized` is a review aid and future-facing bridge. It is not yet a complete damage calculator input format unless a later contract says so.
+
+## Enabled Case Precision
+
+`enabled_for_damage_hidden_eval: true` requires a precise route-to-damage mapping.
+
+An enabled case must have:
+
+- a non-empty `combo_notation_normalized`;
+- exact starter and route steps, not only a generic category;
+- clear cancel or Drive Rush placement;
+- clear OD, target-combo, branch, and timing modifiers when present;
+- a visible and unambiguous observed damage label;
+- no unresolved inherited route context;
+- `notation_confidence: high`;
+- `damage_confidence: high`;
+- `damage_visible: true`;
+- `review_status: needs_review` until a fixture-specific accepted state is designed.
+
+If any of these are missing, keep the case disabled.
+
+## Move Tokens
+
+Use numpad-style directional notation for exact normal moves:
+
+- `5LP`
+- `2LP`
+- `5MP`
+- `2MP`
+- `5HP`
+- `2HP`
+- `6HK`
+
+Use English-compatible move names for specials and supers:
+
+- `weak Stribog`
+- `medium Stribog`
+- `heavy Stribog`
+- `medium Torbalan`
+- `Triglav`
+- `OD Triglav`
+
+The token set is provisional. Prefer consistency and reviewability over inventing aliases.
+
+## Generic Starters
+
+Visible overlays may use generic starters such as:
+
+- `中攻撃`
+- `小P`
+- `大P`
+
+Represent these as generic normalized tokens only when the exact move is not known:
+
+- `medium_normal`
+- `light_punch`
+- `heavy_punch`
+
+Generic starters are not precise enough for `enabled_for_damage_hidden_eval: true` unless a later review maps the generic starter to an exact move such as `2MP` or `5MP`.
+
+## Separators And Cancel Notation
+
+Use `>` between sequential hits or actions.
+
+Use `xx` when a move is canceled into another action:
+
+- `2LP > 5LP > weak Stribog`
+- `2MP xx Drive Rush > 2HP > heavy Stribog`
+
+If the source only says "cancel rush" without a confirmed source move, keep the generic starter:
+
+- `medium_normal xx Drive Rush > 2HP > heavy Stribog`
+
+Such cases should remain disabled until the starter and cancel point are reviewed.
+
+## Drive Rush
+
+Use `Drive Rush` for rush steps.
+
+Examples:
+
+- `2MP xx Drive Rush > 2HP`
+- `Drive Rush 6HK(delayed)`
+
+If Drive Rush is inferred from commentary or inherited context rather than visible route text, record that uncertainty in `notes` and keep the case disabled.
+
+## OD Moves And Follow-ups
+
+Use `OD <move>` for overdrive moves:
+
+- `OD Triglav`
+
+If the source describes an OD follow-up without showing the full route in the same visible overlay, keep the inherited route context explicit:
+
+- `medium_normal xx Drive Rush > 2HP > heavy Stribog > medium Torbalan > OD Triglav follow-up`
+
+Inherited OD follow-up routes should remain disabled unless the full route-to-damage mapping is reviewed.
+
+## Target Combos And Branches
+
+Use `target combo` when a source names a target combo but the exact move chain is not normalized yet:
+
+- `back MP target combo`
+
+Use branch notation only for disabled candidates:
+
+- `2MP or back MP target combo`
+
+Cases with unresolved branches must remain `enabled_for_damage_hidden_eval: false`.
+
+## Timing Modifiers
+
+Put timing modifiers in parentheses after the affected token:
+
+- `Drive Rush 6HK(delayed)`
+- `6HK(slightly delayed)`
+
+Timing-sensitive cases should stay disabled unless the timing modifier is accepted by review and the future damage calculator contract can represent it.
+
+## Position And Carry Context
+
+Route notes may mention position or carry context:
+
+- `corner carry`
+- `near corner`
+- `spacing-dependent`
+
+Do not encode position context as an exact calculator input unless a later contract defines the field. If position or spacing affects the route-to-damage mapping, keep the case disabled and explain the uncertainty in `notes`.
+
+## Inherited Route Context
+
+Sometimes a video explains a route once and then shows a later variant by saying "replace the last move" or "from this position."
+
+Inherited context is insufficient for enabled damage-hidden eval unless the resulting full route is explicitly reconstructed and reviewed.
+
+Disabled cases should explain which part is inherited:
+
+- starter inherited from previous overlay;
+- final move replaced by OD variant;
+- route inferred from commentary rather than visible text;
+- position-specific setup inferred from prior segment.
+
+## Boundary
+
+This notation contract does not:
+
+- make observed damage current-system authority;
+- define a damage calculation engine;
+- define exact current system mechanics;
+- promote fixture cases to `knowledge/curated/`;
+- allow generated references to consume fixture observed damage;
+- replace `workflows/system-mechanics-fact-workflow.md`.
+
+Observed damage remains an eval oracle label only.

--- a/contracts/combo-notation.md
+++ b/contracts/combo-notation.md
@@ -75,10 +75,15 @@ Generic starters are not precise enough for `enabled_for_damage_hidden_eval: tru
 
 Use `>` between sequential hits or actions.
 
-Use `xx` when a move is canceled into another action:
+At the current fixture layer, `>` may represent observed hit/action order. It can be used when a cancel point is not yet confirmed or when the exact cancel point is not important to the reviewed fixture notation.
+
+Use `xx` when a move is canceled into another action and the cancel point is confirmed and relevant to the reviewed notation:
 
 - `2LP > 5LP > weak Stribog`
+- `5LP xx weak Stribog`
 - `2MP xx Drive Rush > 2HP > heavy Stribog`
+
+A later damage calculation input contract may require explicit cancel points for all cancel routes. This combo notation contract does not require that level of precision yet.
 
 If the source only says "cancel rush" without a confirmed source move, keep the generic starter:
 

--- a/evals/fixtures/combo-damage/README.md
+++ b/evals/fixtures/combo-damage/README.md
@@ -37,14 +37,14 @@ Disabled caseの例:
 
 ## Notation
 
-Fixture may include both human-facing Japanese notation and a provisional normalized notation.
+Fixture cases include both human-facing Japanese notation and normalized notation.
 
-Examples:
+- `combo_notation_jp`: human-facing Japanese notation from visible overlays, source-local wording, or maintainer review.
+- `combo_notation_normalized`: provisional machine-facing notation following `contracts/combo-notation.md`.
 
-- `combo_notation_jp`
-- `combo_notation_normalized`
+The normalized notation is still not a complete damage calculator input contract. It is a reviewed bridge for future damage-hidden evals.
 
-The normalized notation is provisional until a combo notation contract is defined. Do not treat the current strings as a stable machine-readable contract.
+Cases with generic starters such as `中攻撃`, inherited route context, unresolved branches, or timing ambiguity must remain disabled unless later review resolves the notation precisely enough for `enabled_for_damage_hidden_eval: true`.
 
 ## Relationship To Current Facts
 
@@ -58,6 +58,5 @@ Move-specific current values still come from `data/exports/`, `data/roster/`, an
 
 - Add a validator for `evals/fixtures/combo-damage/*.yaml`.
 - Expand fixture coverage with high-confidence cases across different route types.
-- Define a combo notation contract.
 - Define combo damage calculation input/output contracts.
 - Add damage-hidden calculation evals only after fixture and notation boundaries are reviewed.

--- a/evals/fixtures/combo-damage/README.md
+++ b/evals/fixtures/combo-damage/README.md
@@ -56,7 +56,7 @@ Move-specific current values still come from `data/exports/`, `data/roster/`, an
 
 ## Expected Follow-ups
 
-- Add a validator for `evals/fixtures/combo-damage/*.yaml`.
+- Maintain `tests/validation/validate-combo-damage-fixtures.ps1` as fixture shape evolves.
 - Expand fixture coverage with high-confidence cases across different route types.
 - Define combo damage calculation input/output contracts.
 - Add damage-hidden calculation evals only after fixture and notation boundaries are reviewed.


### PR DESCRIPTION
## Summary
- add `contracts/combo-notation.md`
- define `combo_notation_jp` versus provisional `combo_notation_normalized`
- document precision requirements for `enabled_for_damage_hidden_eval: true`
- define handling for generic starters, exact move tokens, cancel notation, Drive Rush, OD follow-ups, target-combo branches, timing modifiers, position/carry context, and inherited route context
- update `contracts/README.md` and `evals/fixtures/combo-damage/README.md`

## Boundaries
- documentation/contract only
- no fixture cases added
- no disabled cases enabled
- no damage calculator added
- no damage-hidden eval runner added
- no generated references changed
- no frame-current assets changed
- observed damage remains eval oracle material only

## Verification
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-combo-damage-fixtures.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1`
- `git diff --check`
- generated output status check: clean
- credential scan on changed files: only benign notation-token terms; no credential material

Closes #78
