### PR TITLE
[v2.1] Re-review JP combo fixture candidates

### DIFF
--- a/docs/testing/smoke-runs/2026-05-04-jp-combo-notation-contract-review.md
+++ b/docs/testing/smoke-runs/2026-05-04-jp-combo-notation-contract-review.md
@@ -1,0 +1,58 @@
+# JP Combo Notation Contract Review Smoke Run
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| Date | 2026-05-04 |
+| Issue | #80 |
+| Fixture | `evals/fixtures/combo-damage/jp-ryusei-nyfngnzjv3m.yaml` |
+| Contract | `contracts/combo-notation.md` |
+| Source video | `https://www.youtube.com/watch?v=nyFNgnzjV3M` |
+| Raw media inspected | no new media inspection |
+| Generated references changed | no |
+| Frame-current assets changed | no |
+
+## Review Method
+
+This run re-reviewed existing disabled combo damage fixture candidates against `contracts/combo-notation.md`.
+
+No new source video was inspected. No raw video, frames, screenshots, contact sheets, browser cache, or transcript files were created or stored.
+
+## Contract Verdicts
+
+| Case | Previous status | Verdict | Reason |
+|---|---|---|---|
+| `jp-basic-light-stribog-001` | enabled | keep enabled | Exact starter and route order remain clear enough for the current fixture layer. |
+| `jp-basic-light-rush-extension-1482` | disabled | keep disabled | Alternative branches and unresolved normalized notation block enabled status. |
+| `jp-basic-light-rush-extension-1527` | disabled | keep disabled | Higher-damage branch is plausible but still inferred. |
+| `jp-mid-rush-triglav-1824` | disabled | keep disabled | Generic `medium_normal` starter is not precise enough. |
+| `jp-mid-rush-od-triglav-3260` | disabled | keep disabled | Generic starter plus inherited OD follow-up context blocks enabled status. |
+| `jp-mid-corner-carry-rush-fhk-2763` | disabled | keep disabled | Generic starter, corner-carry context, and delayed `Drive Rush 6HK` timing remain unresolved. |
+| `jp-mid-position-carry-1484` | disabled | keep disabled | Route overlay is incomplete and position/carry context is unresolved. |
+
+## Boundaries
+
+- Observed damage remains eval oracle material only.
+- No case was promoted to curated knowledge.
+- No disabled case was enabled.
+- No damage calculator was added.
+- No damage-hidden eval runner was added.
+- No generated references were updated.
+
+## Findings
+
+- The existing enabled seed remains acceptable under the current fixture-layer notation contract.
+- The disabled candidates are blocked by notation specificity, not damage label visibility.
+- The next enabling work requires exact starter/branch/timing review or a future damage calculation input contract.
+
+## Verification
+
+- `tests/validation/validate-combo-damage-fixtures.ps1`: pass.
+- `tests/validation/validate-ingest-artifacts.ps1`: pass.
+- `tests/validation/validate-doc-links.ps1`: pass.
+- `tests/validation/run-all.ps1`: pass.
+- `git diff --check`: pass.
+- Generated output status check: clean.
+- Repo-local media/state scan: no hits.
+- Changed-file sensitive-material scan: no hits.

--- a/evals/fixtures/combo-damage/jp-ryusei-nyfngnzjv3m.yaml
+++ b/evals/fixtures/combo-damage/jp-ryusei-nyfngnzjv3m.yaml
@@ -35,7 +35,7 @@ cases:
     notation_confidence: high
     damage_confidence: high
     review_status: needs_review
-    notes: "Visible overlay and damage label are clear. Use as the first oracle seed only; do not treat as curated knowledge or current-system authority."
+    notes: "Contract review: remains enabled. Visible overlay and damage label are clear, normalized notation has exact starter and route order, and no unresolved branch or inherited context is required. Do not treat as curated knowledge or current-system authority."
   - id: jp-basic-light-rush-extension-1482
     timestamp: "00:45"
     combo_notation_jp: "小P > 小Pキャンセル > しゃがみ中P or 引き中Pタゲコン > 中ストリボーグ"
@@ -47,7 +47,7 @@ cases:
     notation_confidence: low
     damage_confidence: high
     review_status: needs_review
-    notes: "The overlay lists alternative branches, so route-to-damage mapping needs manual review before this case can be used for damage-hidden calculation."
+    notes: "Contract review: remains disabled. The overlay lists alternative branches, normalized notation is unresolved, and route-to-damage mapping is not precise enough for damage-hidden evaluation."
   - id: jp-basic-light-rush-extension-1527
     timestamp: "00:56"
     combo_notation_jp: "小P > 小Pキャンセル > しゃがみ中P or 引き中Pタゲコン > 中ストリボーグ"
@@ -59,7 +59,7 @@ cases:
     notation_confidence: medium
     damage_confidence: high
     review_status: needs_review
-    notes: "Likely the higher-damage crouching medium punch branch based on commentary, but keep disabled until notation and branch mapping are reviewed."
+    notes: "Contract review: remains disabled. This is likely the higher-damage crouching medium punch branch, but `likely` branch mapping is not enough for enabled status under the notation contract."
   - id: jp-mid-rush-triglav-1824
     timestamp: "01:10"
     combo_notation_jp: "中攻撃キャンセルラッシュ > しゃがみ大P > 強ストリボーグ > 中トルバラン > トリグラフ"
@@ -71,7 +71,7 @@ cases:
     notation_confidence: medium
     damage_confidence: high
     review_status: needs_review
-    notes: "The visible overlay and damage label are clear, but the starter is generic `中攻撃` rather than an exact move. Keep disabled until the combo notation contract can represent or resolve the starter."
+    notes: "Contract review: remains disabled. `medium_normal` represents generic `中攻撃`; generic starters are not precise enough for enabled status until mapped to an exact move such as `2MP` or `5MP`."
   - id: jp-mid-rush-od-triglav-3260
     timestamp: "01:18"
     combo_notation_jp: "中攻撃キャンセルラッシュ > しゃがみ大P > 強ストリボーグ > 中トルバラン > ODトリグラフ追撃"
@@ -83,7 +83,7 @@ cases:
     notation_confidence: medium
     damage_confidence: high
     review_status: needs_review
-    notes: "The damage label is clear, but the overlay only states that replacing the final Triglav with OD Triglav adds another Triglav hit. Keep disabled until the full route and OD follow-up notation are reviewed."
+    notes: "Contract review: remains disabled. The route uses generic `medium_normal` and inherited OD follow-up context; the full route-to-damage mapping is not reviewed enough for enabled status."
   - id: jp-mid-corner-carry-rush-fhk-2763
     timestamp: "01:33"
     combo_notation_jp: "中攻撃キャンセルラッシュ > しゃがみ大P > 強ストリボーグ > 前ステ > ラッシュ前大K(ちょい遅らせ) > トリグラフ"
@@ -95,7 +95,7 @@ cases:
     notation_confidence: medium
     damage_confidence: high
     review_status: needs_review
-    notes: "This adds corner-carry coverage, but the generic medium starter and delayed forward-heavy-kick timing need notation review before damage-hidden evaluation."
+    notes: "Contract review: remains disabled. The route has generic `medium_normal`, corner-carry context, and `Drive Rush 6HK(delayed)` timing that a future damage calculator input contract cannot yet represent."
   - id: jp-mid-position-carry-1484
     timestamp: "01:56"
     combo_notation_jp: "しゃがみ中P始動から端まで運ぶ位置別ルート"
@@ -107,4 +107,4 @@ cases:
     notation_confidence: low
     damage_confidence: high
     review_status: needs_review
-    notes: "The damage label is visible, but the route overlay is not complete in the inspected frame. Keep as a disabled position/carry candidate."
+    notes: "Contract review: remains disabled. The damage label is visible, but the route overlay is incomplete and position/carry context is not an exact calculator input."

--- a/knowledge/review/unresolved/youtube-nyfngnzjv3m-jp-combos.review.md
+++ b/knowledge/review/unresolved/youtube-nyfngnzjv3m-jp-combos.review.md
@@ -62,6 +62,22 @@ The following categories stay unresolved:
 - Whether observed damage values reproduce in-game under the same conditions.
 - Whether a future damage calculation engine has sufficient current-system data to compute the oracle values.
 
+## Combo Notation Contract Review
+
+The fixture candidates were re-reviewed against `contracts/combo-notation.md` on 2026-05-04.
+
+| Case | Contract verdict | Reason |
+|---|---|---|
+| `jp-basic-light-stribog-001` | keep enabled | Exact starter and route order are visible enough for the current fixture layer. The `>` separator is acceptable as observed hit/action order under the contract. |
+| `jp-basic-light-rush-extension-1482` | keep disabled | The overlay lists alternative branches and normalized notation is unresolved. Branch notation is allowed only for disabled candidates. |
+| `jp-basic-light-rush-extension-1527` | keep disabled | The route is likely a crouching-medium-punch branch, but the branch mapping is still inferred rather than reviewed as exact. |
+| `jp-mid-rush-triglav-1824` | keep disabled | `medium_normal` represents generic `中攻撃`. Generic starters are not precise enough for enabled damage-hidden eval. |
+| `jp-mid-rush-od-triglav-3260` | keep disabled | The route has generic starter context and inherited OD Triglav follow-up context. The full route-to-damage mapping is not reviewed. |
+| `jp-mid-corner-carry-rush-fhk-2763` | keep disabled | The route has generic starter context, corner-carry context, and delayed `Drive Rush 6HK` timing not yet representable as calculator input. |
+| `jp-mid-position-carry-1484` | keep disabled | The inspected frame has a visible damage label, but the route overlay is incomplete and position/carry context remains unresolved. |
+
+No additional disabled cases were enabled in this review. The next enabling step requires exact starter or branch review, not more video candidates.
+
 ## Review Notes
 
 - Observed damage is an eval oracle label only.
@@ -69,10 +85,11 @@ The following categories stay unresolved:
 - Do not use the fixture to answer public questions about JP combo damage unless a later calculation workflow and current-system authority path define that behavior.
 - Do not promote the fixture into `knowledge/curated/`.
 - `tests/validation/validate-combo-damage-fixtures.ps1` now checks the fixture boundary and enabled/disabled case fields.
+- `contracts/combo-notation.md` now explains why generic starters, inherited route context, unresolved branches, and timing ambiguity keep candidates disabled.
 
 ## Workflow Findings
 
 - `workflows/ingest-video.md` and `workflows/media-scratch-cache-policy.md` were enough for source metadata, observation, review, and cleanup boundaries.
 - The fixture introduces a new eval support surface under `evals/fixtures/combo-damage/`.
-- A future issue should define a combo notation contract before damage-hidden calculation evals depend on ambiguous notation.
+- `contracts/combo-notation.md` now defines the notation review boundary before damage-hidden calculation evals depend on ambiguous notation.
 - The coverage expansion confirms that route notation, not observed damage visibility, is the main blocker for enabling more damage-hidden eval cases.


### PR DESCRIPTION
## Summary
- re-review JP combo damage fixture candidates against `contracts/combo-notation.md`
- keep the existing high-confidence seed enabled
- keep all previously disabled candidates disabled with contract-specific blockers
- update the unresolved review note with a contract verdict table
- add a smoke report for the notation contract review

## Contract verdicts
- `jp-basic-light-stribog-001`: keep enabled
- `jp-basic-light-rush-extension-1482`: keep disabled, unresolved branch/normalized notation
- `jp-basic-light-rush-extension-1527`: keep disabled, inferred branch mapping
- `jp-mid-rush-triglav-1824`: keep disabled, generic `medium_normal` starter
- `jp-mid-rush-od-triglav-3260`: keep disabled, generic starter and inherited OD follow-up context
- `jp-mid-corner-carry-rush-fhk-2763`: keep disabled, generic starter/corner context/delayed timing
- `jp-mid-position-carry-1484`: keep disabled, incomplete route overlay and position/carry context

## Boundaries
- no new source video
- no new media observation
- no fixture case enabled except the existing seed remains enabled
- no damage calculator
- no damage-hidden eval runner
- no generated references changed
- no frame-current assets changed

## Verification
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-combo-damage-fixtures.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-ingest-artifacts.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1`
- `git diff --check`
- generated output status check: clean
- repo-local media/state scan: no hits
- changed-file sensitive-material scan: no hits

Closes #80