### PR TITLE
[v2.1] Add Hermes pack skeleton and boundary validator

### DIFF
--- a/packs/hermes-sf6/README.md
+++ b/packs/hermes-sf6/README.md
@@ -2,16 +2,23 @@
 
 This pack is repo-local orchestration support for Hermes.
 
-Hermes is the primary repo-local orchestration harness when a configured maintainer profile is available. Hermes is not a canonical knowledge surface, not canonical memory, and not required for public distribution. Canonical maintainer procedures live in [workflows](../../workflows/). Public agent behavior lives in the single `sf6-agent` adapter.
+Hermes is the primary repo-local orchestration harness when a configured maintainer profile is available. Hermes is not a canonical knowledge surface, not canonical memory, and not required for public distribution. Hermes state is non-canonical. This pack is not public answer behavior and does not replace skills/sf6-agent. Canonical maintainer procedures live in [workflows](../../workflows/). Public agent behavior lives in the single `sf6-agent` adapter.
 
 When Hermes is unavailable, Codex, humans, or other agents may still follow the same canonical workflows as fallback executors.
 
 ## Contents
 
 - `hermes.example.json`: example harness configuration shape.
+- `prompts/`: boundary guidance for future prompt wrappers.
+- `profiles/`: markdown profile guidance only; not executable profile config.
+- `guards/`: boundary guidance for future guard checks.
+- `reports/`: boundary guidance for future report templates.
 
 ## Rules
 
+- Hermes wrappers must follow canonical workflows and canonical contracts.
+- Operational prompt bodies belong to later work after answer contracts and evidence gate policy.
+- Reusable output must be committed as repo artifacts, not stored in Hermes state.
 - Do not commit Hermes memory state.
 - Do not commit cron state.
 - Do not commit secrets.
@@ -21,5 +28,3 @@ When Hermes is unavailable, Codex, humans, or other agents may still follow the 
 ## Usage
 
 Install or build the `sf6-agent` adapter using the canonical distribution docs under [docs/distribution/agents](../../docs/distribution/agents/). Use this pack only to point Hermes at the adapter and at [workflows](../../workflows/) for repo-local orchestration tasks.
-
-This pack does not yet define prompt, profile, guard, or report skeletons. Those belong to the follow-up Hermes pack skeleton work.

--- a/packs/hermes-sf6/guards/README.md
+++ b/packs/hermes-sf6/guards/README.md
@@ -1,0 +1,11 @@
+# Hermes Guard Guidance
+
+This directory is repo-local orchestration support for future Hermes guard guidance.
+
+Files here are not public answer behavior. This directory does not replace skills/sf6-agent. Public SF6 answer behavior remains in the single `skills/sf6-agent/` adapter.
+
+Hermes guards must follow canonical workflows and canonical contracts. Reusable output must be committed as repo artifacts, not stored in Hermes state.
+
+Hermes memory, sessions, profile state, browser state, cron state, local managed skills, local config, secrets, and chat transcripts are non-canonical.
+
+This directory does not define operational prompt bodies. Operational prompt bodies belong to later work after answer contracts and evidence gate policy.

--- a/packs/hermes-sf6/profiles/README.md
+++ b/packs/hermes-sf6/profiles/README.md
@@ -1,0 +1,11 @@
+# Hermes Profile Guidance
+
+This directory is repo-local orchestration support for future Hermes profile guidance.
+
+Files here are not public answer behavior. This directory does not replace skills/sf6-agent. Public SF6 answer behavior remains in the single `skills/sf6-agent/` adapter.
+
+Hermes profile guidance must follow canonical workflows and canonical contracts. Reusable output must be committed as repo artifacts, not stored in Hermes state.
+
+Hermes memory, sessions, profile state, browser state, cron state, local managed skills, local config, secrets, and chat transcripts are non-canonical.
+
+Profile files in this issue are markdown guidance only, not executable profile config. Do not add `.json` profile config unless a Hermes profile schema is explicitly defined.

--- a/packs/hermes-sf6/profiles/ingest-profile-guidance.md
+++ b/packs/hermes-sf6/profiles/ingest-profile-guidance.md
@@ -1,0 +1,13 @@
+# Ingest Profile Guidance
+
+This file is repo-local orchestration support for future Hermes ingest profile guidance.
+
+It is not public answer behavior and does not replace skills/sf6-agent. Public SF6 answer behavior remains in the single `skills/sf6-agent/` adapter.
+
+Hermes ingest guidance must follow canonical workflows and canonical contracts, including the relevant article, video, and source review workflows under `workflows/`.
+
+Reusable output must be committed as repo artifacts, not stored in Hermes state. Source metadata, claims, observations, review notes, and smoke evidence belong in their canonical repository surfaces.
+
+Hermes memory, sessions, profile state, browser state, cron state, local managed skills, local config, secrets, and chat transcripts are non-canonical.
+
+This is markdown guidance only, not executable profile config. Operational prompt bodies belong to later work after answer contracts and evidence gate policy.

--- a/packs/hermes-sf6/profiles/smoke-profile-guidance.md
+++ b/packs/hermes-sf6/profiles/smoke-profile-guidance.md
@@ -1,0 +1,13 @@
+# Smoke Profile Guidance
+
+This file is repo-local orchestration support for future Hermes smoke profile guidance.
+
+It is not public answer behavior and does not replace skills/sf6-agent. Public SF6 answer behavior remains in the single `skills/sf6-agent/` adapter.
+
+Hermes smoke guidance must follow canonical workflows and canonical contracts, especially validator and smoke-run procedures under `workflows/` and `tests/validation/`.
+
+Reusable output must be committed as repo artifacts, not stored in Hermes state. Smoke reports are workflow execution evidence, not SF6 gameplay knowledge authority.
+
+Hermes memory, sessions, profile state, browser state, cron state, local managed skills, local config, secrets, and chat transcripts are non-canonical.
+
+This is markdown guidance only, not executable profile config. Operational prompt bodies belong to later work after answer contracts and evidence gate policy.

--- a/packs/hermes-sf6/prompts/README.md
+++ b/packs/hermes-sf6/prompts/README.md
@@ -1,0 +1,11 @@
+# Hermes Prompt Wrapper Guidance
+
+This directory is repo-local orchestration support for future Hermes prompt wrappers.
+
+Files here are not public answer behavior. This directory does not replace skills/sf6-agent. Public SF6 answer behavior remains in the single `skills/sf6-agent/` adapter.
+
+Hermes prompt wrappers must follow canonical workflows and canonical contracts. Reusable output must be committed as repo artifacts, not stored in Hermes state.
+
+Hermes memory, sessions, profile state, browser state, cron state, local managed skills, local config, secrets, and chat transcripts are non-canonical.
+
+Operational prompt bodies belong to later work after answer contracts and evidence gate policy. This issue intentionally adds boundary guidance only.

--- a/packs/hermes-sf6/reports/README.md
+++ b/packs/hermes-sf6/reports/README.md
@@ -1,0 +1,11 @@
+# Hermes Report Guidance
+
+This directory is repo-local orchestration support for future Hermes report guidance.
+
+Files here are not public answer behavior. This directory does not replace skills/sf6-agent. Public SF6 answer behavior remains in the single `skills/sf6-agent/` adapter.
+
+Hermes report guidance must follow canonical workflows and canonical contracts. Reusable output must be committed as repo artifacts, not stored in Hermes state.
+
+Hermes memory, sessions, profile state, browser state, cron state, local managed skills, local config, secrets, and chat transcripts are non-canonical.
+
+Reports produced by Hermes-assisted workflows must be committed as repo artifacts in the canonical destination for that workflow. This directory does not define operational prompt bodies. Operational prompt bodies belong to later work after answer contracts and evidence gate policy.

--- a/tests/validation/run-all.ps1
+++ b/tests/validation/run-all.ps1
@@ -34,6 +34,7 @@ $preflightScripts = @(
 $validationScripts = @(
   'tests/validation/validate-v2-surfaces.ps1',
   'tests/validation/validate-architecture-markers.ps1',
+  'tests/validation/validate-hermes-pack.ps1',
   'tests/validation/validate-v2-contracts.ps1',
   'tests/validation/validate-knowledge-schema.ps1',
   'tests/validation/validate-ingest-artifacts.ps1',

--- a/tests/validation/validate-hermes-pack.ps1
+++ b/tests/validation/validate-hermes-pack.ps1
@@ -102,19 +102,37 @@ if (-not (Test-Path -LiteralPath $packRoot -PathType Container)) {
   foreach ($item in Get-ChildItem -LiteralPath $packRoot -Force -Recurse -File) {
     $name = $item.Name.ToLowerInvariant()
     $relativePath = Get-PackRelativePath $item.FullName
+    $relativePathLower = $relativePath.ToLowerInvariant()
 
     if (
       $name -eq '.env' -or
+      $name -like '.env.*' -or
+      $name -eq '.envrc' -or
       $name -like '*secret*' -or
       $name -like '*token*' -or
       $name -like '*credential*' -or
       $name -like '*session*' -or
+      $name -like '*sessions*' -or
       $name -like '*memory*' -or
       $name -like '*cron*' -or
       $name -like 'browser-state*' -or
       $name -like 'profile-state*' -or
       $name -like '*.sqlite' -or
-      $name -like '*.db'
+      $name -like '*.db' -or
+      $relativePathLower -like '*/.env' -or
+      $relativePathLower -like '*/.env.*' -or
+      $relativePathLower -like '*/.envrc' -or
+      $relativePathLower -like '*secret*' -or
+      $relativePathLower -like '*token*' -or
+      $relativePathLower -like '*credential*' -or
+      $relativePathLower -like '*session*' -or
+      $relativePathLower -like '*sessions*' -or
+      $relativePathLower -like '*memory*' -or
+      $relativePathLower -like '*cron*' -or
+      $relativePathLower -like '*browser-state*' -or
+      $relativePathLower -like '*profile-state*' -or
+      $relativePathLower -like '*.sqlite' -or
+      $relativePathLower -like '*.db'
     ) {
       $issues += "Forbidden Hermes local-state or secret-like file under pack: $relativePath"
     }

--- a/tests/validation/validate-hermes-pack.ps1
+++ b/tests/validation/validate-hermes-pack.ps1
@@ -1,0 +1,139 @@
+Set-StrictMode -Version Latest
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$packRootRelative = 'packs/hermes-sf6'
+$packRoot = Join-Path $repoRoot $packRootRelative
+
+function Read-Text {
+  param([Parameter(Mandatory = $true)][string]$RelativePath)
+  return Get-Content -LiteralPath (Join-Path $repoRoot $RelativePath) -Raw -Encoding UTF8
+}
+
+function Assert-TextContains {
+  param(
+    [Parameter(Mandatory = $true)][string]$RelativePath,
+    [Parameter(Mandatory = $true)][string[]]$Phrases,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  $text = Read-Text $RelativePath
+  foreach ($phrase in $Phrases) {
+    if ($text -notmatch [regex]::Escape($phrase)) {
+      $Issues.Value += "$RelativePath missing boundary phrase: $phrase"
+    }
+  }
+}
+
+function Get-PackRelativePath {
+  param([Parameter(Mandatory = $true)][string]$FullPath)
+
+  $root = (Resolve-Path $packRoot).Path.TrimEnd([char[]]@('\', '/'))
+  $relative = $FullPath.Substring($root.Length)
+  $relative = $relative -replace '^[\\/]+', ''
+  return "$packRootRelative/$($relative -replace '\\', '/')"
+}
+
+$requiredFiles = @(
+  'packs/hermes-sf6/README.md',
+  'packs/hermes-sf6/prompts/README.md',
+  'packs/hermes-sf6/profiles/README.md',
+  'packs/hermes-sf6/profiles/ingest-profile-guidance.md',
+  'packs/hermes-sf6/profiles/smoke-profile-guidance.md',
+  'packs/hermes-sf6/guards/README.md',
+  'packs/hermes-sf6/reports/README.md'
+)
+
+$commonBoundaryPhrases = @(
+  'repo-local orchestration support',
+  'not public answer behavior',
+  'does not replace skills/sf6-agent',
+  'canonical workflows',
+  'canonical contracts',
+  'non-canonical',
+  'repo artifacts'
+)
+
+$issues = @()
+
+foreach ($relativePath in $requiredFiles) {
+  if (-not (Test-Path -LiteralPath (Join-Path $repoRoot $relativePath) -PathType Leaf)) {
+    $issues += "Missing Hermes pack skeleton file: $relativePath"
+  }
+}
+
+if ($issues.Count -eq 0) {
+  foreach ($relativePath in $requiredFiles) {
+    Assert-TextContains $relativePath $commonBoundaryPhrases ([ref]$issues)
+  }
+
+  foreach ($relativePath in @(
+    'packs/hermes-sf6/profiles/README.md',
+    'packs/hermes-sf6/profiles/ingest-profile-guidance.md',
+    'packs/hermes-sf6/profiles/smoke-profile-guidance.md'
+  )) {
+    Assert-TextContains $relativePath @('not executable profile config') ([ref]$issues)
+  }
+
+  foreach ($relativePath in @(
+    'packs/hermes-sf6/README.md',
+    'packs/hermes-sf6/prompts/README.md',
+    'packs/hermes-sf6/profiles/ingest-profile-guidance.md',
+    'packs/hermes-sf6/profiles/smoke-profile-guidance.md',
+    'packs/hermes-sf6/guards/README.md',
+    'packs/hermes-sf6/reports/README.md'
+  )) {
+    Assert-TextContains $relativePath @('operational prompt bodies belong to later work') ([ref]$issues)
+  }
+}
+
+if (-not (Test-Path -LiteralPath $packRoot -PathType Container)) {
+  $issues += "Missing Hermes pack root: $packRootRelative"
+} else {
+  $forbiddenOperationalPromptNames = @(
+    'answer-intent-router.md',
+    'evidence-gate.md',
+    'answer-composer.md',
+    'ingest-router.md',
+    'article-ingest.md',
+    'video-observation.md',
+    'review-promotion.md'
+  )
+
+  foreach ($item in Get-ChildItem -LiteralPath $packRoot -Force -Recurse -File) {
+    $name = $item.Name.ToLowerInvariant()
+    $relativePath = Get-PackRelativePath $item.FullName
+
+    if (
+      $name -eq '.env' -or
+      $name -like '*secret*' -or
+      $name -like '*token*' -or
+      $name -like '*credential*' -or
+      $name -like '*session*' -or
+      $name -like '*memory*' -or
+      $name -like '*cron*' -or
+      $name -like 'browser-state*' -or
+      $name -like 'profile-state*' -or
+      $name -like '*.sqlite' -or
+      $name -like '*.db'
+    ) {
+      $issues += "Forbidden Hermes local-state or secret-like file under pack: $relativePath"
+    }
+
+    if ($forbiddenOperationalPromptNames -contains $name) {
+      $issues += "Operational Hermes prompt file belongs to later work: $relativePath"
+    }
+  }
+
+  $profileRoot = Join-Path $packRoot 'profiles'
+  if (Test-Path -LiteralPath $profileRoot -PathType Container) {
+    foreach ($item in Get-ChildItem -LiteralPath $profileRoot -Force -Recurse -File -Filter '*.json') {
+      $issues += "JSON Hermes profile config requires an explicit profile schema: $(Get-PackRelativePath $item.FullName)"
+    }
+  }
+}
+
+if ($issues.Count -gt 0) {
+  throw ($issues -join '; ')
+}
+
+Write-Host 'Hermes pack OK'


### PR DESCRIPTION
## Summary
- Add boundary-only Hermes pack skeleton docs for prompts, profiles, guards, and reports.
- Add markdown-only ingest and smoke profile guidance without executable profile config.
- Add `validate-hermes-pack.ps1` and wire it into `run-all.ps1` after the v2 surface and architecture marker validators.

## Scope
Closes #86.

This PR implements only the Hermes pack skeleton and boundary validator. It keeps `packs/hermes-sf6/` as repo-local orchestration support, not public answer behavior, and does not replace `skills/sf6-agent/`.

## Validation
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-hermes-pack.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-architecture-markers.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-v2-surfaces.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1`
- `git diff --check`

`run-all.ps1` was executed through Windows PowerShell. That environment printed git-unavailable warnings during derived-output status checks, so I separately verified from WSL git that generated references, frame-current assets, and `.dist` have no residual diff.

## Not included
- #87 and #88 are not implemented.
- No operational prompts or answer router/evidence gate prompt bodies were added.
- No JSON profile config was added.
- No executable Hermes runtime config was added beyond existing example guidance.
- No normalization aliases, `data/aliases/`, or `skills/sf6-agent/assets/normalization/` were added.
- No article/video ingest wrappers were added.
- No public answer behavior was defined.
- No `skills/sf6-agent/SKILL.md`, generated outputs, frame-current assets, `.dist`, or historical smoke reports were changed.