### PR TITLE
[v2.1] Define answer orchestration contracts and evidence gate/web policy

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -11,5 +11,13 @@ When `source_refs.path` points to a migrated legacy file, `source_revision` iden
 ## Human-Readable Contracts
 
 - `combo-notation.md`: notation rules for `evals/fixtures/combo-damage/*.yaml`.
+- `evidence-gate.md`: answer evidence authority boundaries for current facts, review claims, observations, and Hermes state.
 - `frame-current-runtime-assets.md`: runtime asset boundary for generated frame-current payloads.
 - `video-observation.md`: timestamped video observation artifact contract.
+- `web-research-policy.md`: web source ranking, freshness, and current-fact conflict policy.
+
+## Answer Orchestration Schemas
+
+- `answer-intent.schema.json`: intent and answer-mode classification contract.
+- `evidence-card.schema.json`: evidence authority and source-boundary card contract.
+- `answer-plan.schema.json`: answer planning contract combining intent, evidence cards, web state, hold reasons, and response requirements.

--- a/contracts/answer-intent.schema.json
+++ b/contracts/answer-intent.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sf6-knowledge-agent-kit.local/answer-intent.schema.json",
+  "title": "Answer Intent",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "question_text",
+    "intent_kind",
+    "answer_mode",
+    "entities"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "answer-intent/v1"
+    },
+    "question_text": {
+      "type": "string",
+      "minLength": 1
+    },
+    "normalized_question_text": {
+      "type": "string"
+    },
+    "intent_kind": {
+      "type": "string",
+      "enum": [
+        "current_fact",
+        "stable_concept",
+        "strategy",
+        "observation",
+        "hold",
+        "web_needed"
+      ]
+    },
+    "answer_mode": {
+      "type": "string",
+      "enum": [
+        "current_fact",
+        "stable_concept",
+        "strategy",
+        "observation",
+        "hold",
+        "web_needed"
+      ]
+    },
+    "entities": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "character_slug": {
+          "type": "string"
+        },
+        "move_input": {
+          "type": "string"
+        },
+        "move_ref": {
+          "type": "string"
+        },
+        "requested_field": {
+          "type": "string"
+        },
+        "matchup": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "player_character_slug": {
+              "type": "string"
+            },
+            "opponent_character_slug": {
+              "type": "string"
+            }
+          }
+        },
+        "strategy_context": {
+          "type": "string"
+        },
+        "media_context": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "source_id": {
+              "type": "string"
+            },
+            "timestamp": {
+              "type": "string"
+            },
+            "segment_id": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "notes": {
+      "type": "string"
+    }
+  }
+}

--- a/contracts/answer-plan.schema.json
+++ b/contracts/answer-plan.schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sf6-knowledge-agent-kit.local/answer-plan.schema.json",
+  "title": "Answer Plan",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "plan_id",
+    "answer_mode",
+    "intent",
+    "evidence_cards",
+    "web_research",
+    "hold_reasons",
+    "response_requirements"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "answer-plan/v1"
+    },
+    "plan_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "answer_mode": {
+      "type": "string",
+      "enum": [
+        "current_fact",
+        "stable_concept",
+        "strategy",
+        "observation",
+        "hold",
+        "web_needed"
+      ]
+    },
+    "intent": {
+      "$ref": "answer-intent.schema.json"
+    },
+    "evidence_cards": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "evidence-card.schema.json"
+      }
+    },
+    "web_research": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "web_required",
+        "web_allowed",
+        "web_used",
+        "web_forbidden_for_current_fact_override",
+        "conflict_requires_hold"
+      ],
+      "properties": {
+        "web_required": {
+          "type": "boolean"
+        },
+        "web_allowed": {
+          "type": "boolean"
+        },
+        "web_used": {
+          "type": "boolean"
+        },
+        "web_forbidden_for_current_fact_override": {
+          "type": "boolean"
+        },
+        "conflict_requires_hold": {
+          "type": "boolean"
+        },
+        "required_source_authority": {
+          "type": "string",
+          "enum": [
+            "none",
+            "official_sources_required",
+            "supplemental_sources_allowed"
+          ]
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    },
+    "hold_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "response_requirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "cite_evidence",
+        "state_authority_boundary",
+        "state_confidence",
+        "boundary_notes"
+      ],
+      "properties": {
+        "cite_evidence": {
+          "type": "boolean"
+        },
+        "state_authority_boundary": {
+          "type": "boolean"
+        },
+        "state_confidence": {
+          "type": "boolean"
+        },
+        "boundary_notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/contracts/evidence-card.schema.json
+++ b/contracts/evidence-card.schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sf6-knowledge-agent-kit.local/evidence-card.schema.json",
+  "title": "Evidence Card",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "evidence_family",
+    "authority_role",
+    "canonicality",
+    "source_ref",
+    "supports_exact_current_fact",
+    "may_override_official_raw",
+    "limitations"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "evidence_family": {
+      "type": "string",
+      "enum": [
+        "frame_current_official_raw",
+        "frame_current_derived_metrics",
+        "generated_curated_reference",
+        "review_claim",
+        "video_observation",
+        "official_web",
+        "third_party_community_web",
+        "hermes_memory_session_profile_state",
+        "repo_policy",
+        "unknown"
+      ]
+    },
+    "authority_role": {
+      "type": "string",
+      "enum": [
+        "primary_current_fact_authority",
+        "derived_current_fact_support",
+        "stable_concept_support",
+        "strategy_support",
+        "observation_only",
+        "review_only",
+        "official_metadata",
+        "supplemental_context",
+        "forbidden_non_canonical",
+        "unresolved_context"
+      ]
+    },
+    "canonicality": {
+      "type": "string",
+      "enum": [
+        "canonical_repo_source",
+        "packaged_runtime_authority",
+        "derived_reference",
+        "review_only",
+        "observation_only",
+        "supplemental",
+        "non_canonical",
+        "forbidden"
+      ]
+    },
+    "source_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "label"
+      ],
+      "properties": {
+        "label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "path": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "source_revision": {
+          "type": "string"
+        }
+      }
+    },
+    "supports_exact_current_fact": {
+      "type": "boolean"
+    },
+    "may_override_official_raw": {
+      "type": "boolean"
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "limitations": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "notes": {
+      "type": "string"
+    }
+  }
+}

--- a/contracts/evidence-gate.md
+++ b/contracts/evidence-gate.md
@@ -1,0 +1,25 @@
+# Evidence Gate Contract
+
+This contract defines evidence boundaries for answer orchestration. It is a repo-level policy surface, not an operational Hermes prompt.
+
+## Current Facts
+
+Exact current move facts must be grounded in packaged frame-current authority. The primary exact current fact surface is `skills/sf6-agent/assets/frame-current/published/*/official_raw.json`, which is derived from `data/exports/` and `data/roster/`.
+
+`derived_metrics` may support calculations only when the route is anchored to `official_raw`. Derived metrics are not an independent source for exact current move facts.
+
+Generated concept references must not be used as exact current frame-value authority. They may support stable concepts, terminology, and strategy context after their source boundary is respected.
+
+## Review And Observation Boundaries
+
+Review claims and video observations must not become final answer authority without review and promotion through the canonical repository workflow.
+
+Video observations are observation-only evidence. They must not be used to infer exact move IDs, exact frame values, matchup verdicts, combo verdicts, or coaching conclusions beyond the observation contract.
+
+Hermes memory, sessions, profile state, browser state, cron state, local managed skills, local config, secrets, and chat transcripts must not be answer evidence.
+
+## Hold Behavior
+
+Hold or unresolved mode is required when evidence is missing, ambiguous, stale, unsupported, outside authority, or conflicting across authority boundaries.
+
+When current fact evidence is unavailable, the answer plan must hold rather than fill the gap with generated references, review notes, video observations, Hermes state, or third-party web summaries.

--- a/contracts/web-research-policy.md
+++ b/contracts/web-research-policy.md
@@ -1,0 +1,21 @@
+# Web Research Policy
+
+This policy defines how answer orchestration may use web sources. It is a repo-level policy surface, not an operational Hermes prompt.
+
+## Allowed Uses
+
+Web research may be used for discovery, freshness checks, patch metadata, strategy or meta context, and source ingest support.
+
+Official web sources are required for patch or current metadata when that metadata is used in reports or user-facing summaries.
+
+Web-derived strategy or meta analysis must state freshness, source quality, confidence, and patch-sensitivity boundaries.
+
+## Current Fact Boundary
+
+Web sources must not override packaged frame-current `official_raw`.
+
+Third-party and community web sources are not final authority for exact current facts. They may be used as discovery or supplemental context, but not as the source of truth for exact current move values.
+
+If web sources conflict with packaged current facts, the answer plan must hold the exact value, report the conflict, or route the work to the frame-data refresh workflow. It must not silently replace packaged `official_raw`.
+
+Web research that finds possible stale packaged data is an update signal for the frame-data refresh workflow, not direct permission to change answer authority.

--- a/tests/fixtures/answer-orchestration/current-fact.json
+++ b/tests/fixtures/answer-orchestration/current-fact.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": "answer-plan/v1",
+  "plan_id": "fixture-current-fact-ryu-2mp-block",
+  "answer_mode": "current_fact",
+  "intent": {
+    "schema_version": "answer-intent/v1",
+    "question_text": "リュウの2MPはガードで何F？",
+    "normalized_question_text": "Ryu 2MP block advantage current fact",
+    "intent_kind": "current_fact",
+    "answer_mode": "current_fact",
+    "entities": {
+      "character_slug": "ryu",
+      "move_input": "2MP",
+      "requested_field": "block_adv"
+    }
+  },
+  "evidence_cards": [
+    {
+      "id": "ryu-official-raw-2mp",
+      "evidence_family": "frame_current_official_raw",
+      "authority_role": "primary_current_fact_authority",
+      "canonicality": "packaged_runtime_authority",
+      "source_ref": {
+        "label": "Ryu packaged official_raw",
+        "path": "skills/sf6-agent/assets/frame-current/published/ryu/official_raw.json"
+      },
+      "supports_exact_current_fact": true,
+      "may_override_official_raw": false,
+      "confidence": 1,
+      "limitations": [
+        "Only answers packaged current fact fields present in official_raw."
+      ]
+    }
+  ],
+  "web_research": {
+    "web_required": false,
+    "web_allowed": false,
+    "web_used": false,
+    "web_forbidden_for_current_fact_override": true,
+    "conflict_requires_hold": true,
+    "required_source_authority": "none"
+  },
+  "hold_reasons": [],
+  "response_requirements": {
+    "cite_evidence": true,
+    "state_authority_boundary": true,
+    "state_confidence": true,
+    "boundary_notes": [
+      "Use packaged official_raw as exact current fact authority."
+    ]
+  }
+}

--- a/tests/fixtures/answer-orchestration/hold.json
+++ b/tests/fixtures/answer-orchestration/hold.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": "answer-plan/v1",
+  "plan_id": "fixture-hold-ambiguous-current-fact",
+  "answer_mode": "hold",
+  "intent": {
+    "schema_version": "answer-intent/v1",
+    "question_text": "この技は今何F有利？",
+    "normalized_question_text": "Ambiguous current fact request",
+    "intent_kind": "hold",
+    "answer_mode": "hold",
+    "entities": {
+      "requested_field": "frame_advantage"
+    },
+    "notes": "Character and move are unresolved."
+  },
+  "evidence_cards": [
+    {
+      "id": "missing-current-fact-authority",
+      "evidence_family": "unknown",
+      "authority_role": "unresolved_context",
+      "canonicality": "non_canonical",
+      "source_ref": {
+        "label": "No usable authority found"
+      },
+      "supports_exact_current_fact": false,
+      "may_override_official_raw": false,
+      "confidence": 0,
+      "limitations": [
+        "Missing character and move identity; no packaged official_raw lookup can be selected."
+      ]
+    }
+  ],
+  "web_research": {
+    "web_required": false,
+    "web_allowed": false,
+    "web_used": false,
+    "web_forbidden_for_current_fact_override": true,
+    "conflict_requires_hold": true,
+    "required_source_authority": "none"
+  },
+  "hold_reasons": [
+    "character unresolved",
+    "move unresolved",
+    "exact current fact authority cannot be selected"
+  ],
+  "response_requirements": {
+    "cite_evidence": false,
+    "state_authority_boundary": true,
+    "state_confidence": true,
+    "boundary_notes": [
+      "Ask for clarification or hold rather than guessing current frame values."
+    ]
+  }
+}

--- a/tests/fixtures/answer-orchestration/observation.json
+++ b/tests/fixtures/answer-orchestration/observation.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": "answer-plan/v1",
+  "plan_id": "fixture-observation-video-segment",
+  "answer_mode": "observation",
+  "intent": {
+    "schema_version": "answer-intent/v1",
+    "question_text": "この動画のこの場面で何が見える？",
+    "normalized_question_text": "Describe a video segment observation",
+    "intent_kind": "observation",
+    "answer_mode": "observation",
+    "entities": {
+      "media_context": {
+        "source_id": "youtube-example",
+        "timestamp": "00:42",
+        "segment_id": "seg-0042"
+      }
+    }
+  },
+  "evidence_cards": [
+    {
+      "id": "video-observation-seg-0042",
+      "evidence_family": "video_observation",
+      "authority_role": "observation_only",
+      "canonicality": "observation_only",
+      "source_ref": {
+        "label": "Video observation artifact",
+        "path": "knowledge/evidence/video-observations/example.observations.md"
+      },
+      "supports_exact_current_fact": false,
+      "may_override_official_raw": false,
+      "confidence": 0.65,
+      "limitations": [
+        "Observation-only evidence cannot become match verdict, combo verdict, or exact current fact authority."
+      ]
+    }
+  ],
+  "web_research": {
+    "web_required": false,
+    "web_allowed": false,
+    "web_used": false,
+    "web_forbidden_for_current_fact_override": true,
+    "conflict_requires_hold": true,
+    "required_source_authority": "none"
+  },
+  "hold_reasons": [],
+  "response_requirements": {
+    "cite_evidence": true,
+    "state_authority_boundary": true,
+    "state_confidence": true,
+    "boundary_notes": [
+      "Describe only visible observations and avoid inferred exact move facts."
+    ]
+  }
+}

--- a/tests/fixtures/answer-orchestration/stable-concept.json
+++ b/tests/fixtures/answer-orchestration/stable-concept.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": "answer-plan/v1",
+  "plan_id": "fixture-stable-concept-shimmy",
+  "answer_mode": "stable_concept",
+  "intent": {
+    "schema_version": "answer-intent/v1",
+    "question_text": "シミーって何？",
+    "normalized_question_text": "Explain shimmy as a stable SF6 concept",
+    "intent_kind": "stable_concept",
+    "answer_mode": "stable_concept",
+    "entities": {
+      "strategy_context": "general concept explanation"
+    }
+  },
+  "evidence_cards": [
+    {
+      "id": "generated-concepts-shimmy",
+      "evidence_family": "generated_curated_reference",
+      "authority_role": "stable_concept_support",
+      "canonicality": "derived_reference",
+      "source_ref": {
+        "label": "Generated concepts reference",
+        "path": "skills/sf6-agent/references/generated-concepts.md"
+      },
+      "supports_exact_current_fact": false,
+      "may_override_official_raw": false,
+      "confidence": 0.85,
+      "limitations": [
+        "Generated concept references support stable concept prose, not exact current frame values."
+      ]
+    }
+  ],
+  "web_research": {
+    "web_required": false,
+    "web_allowed": false,
+    "web_used": false,
+    "web_forbidden_for_current_fact_override": true,
+    "conflict_requires_hold": true,
+    "required_source_authority": "none"
+  },
+  "hold_reasons": [],
+  "response_requirements": {
+    "cite_evidence": true,
+    "state_authority_boundary": true,
+    "state_confidence": true,
+    "boundary_notes": [
+      "Do not use generated concepts as exact current fact authority."
+    ]
+  }
+}

--- a/tests/fixtures/answer-orchestration/strategy.json
+++ b/tests/fixtures/answer-orchestration/strategy.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "answer-plan/v1",
+  "plan_id": "fixture-strategy-ryu-fireball",
+  "answer_mode": "strategy",
+  "intent": {
+    "schema_version": "answer-intent/v1",
+    "question_text": "リュウの波動拳にどう対応する？",
+    "normalized_question_text": "Strategy response to Ryu fireball",
+    "intent_kind": "strategy",
+    "answer_mode": "strategy",
+    "entities": {
+      "character_slug": "ryu",
+      "strategy_context": "fireball counterplay"
+    }
+  },
+  "evidence_cards": [
+    {
+      "id": "strategy-curated-fireball",
+      "evidence_family": "generated_curated_reference",
+      "authority_role": "strategy_support",
+      "canonicality": "derived_reference",
+      "source_ref": {
+        "label": "Generated concept strategy reference",
+        "path": "skills/sf6-agent/references/generated-concepts.md"
+      },
+      "supports_exact_current_fact": false,
+      "may_override_official_raw": false,
+      "confidence": 0.7,
+      "limitations": [
+        "Strategy guidance should state assumptions and patch sensitivity."
+      ]
+    },
+    {
+      "id": "ryu-frame-context",
+      "evidence_family": "frame_current_official_raw",
+      "authority_role": "primary_current_fact_authority",
+      "canonicality": "packaged_runtime_authority",
+      "source_ref": {
+        "label": "Ryu packaged official_raw",
+        "path": "skills/sf6-agent/assets/frame-current/published/ryu/official_raw.json"
+      },
+      "supports_exact_current_fact": true,
+      "may_override_official_raw": false,
+      "confidence": 1,
+      "limitations": [
+        "Use only for exact packaged fields; strategy conclusions still require boundary notes."
+      ]
+    }
+  ],
+  "web_research": {
+    "web_required": false,
+    "web_allowed": true,
+    "web_used": false,
+    "web_forbidden_for_current_fact_override": true,
+    "conflict_requires_hold": true,
+    "required_source_authority": "supplemental_sources_allowed",
+    "notes": "Recent meta context may supplement strategy if freshness and confidence are stated."
+  },
+  "hold_reasons": [],
+  "response_requirements": {
+    "cite_evidence": true,
+    "state_authority_boundary": true,
+    "state_confidence": true,
+    "boundary_notes": [
+      "State assumptions and confidence boundaries for strategy advice.",
+      "Do not let web strategy sources override official_raw exact current facts."
+    ]
+  }
+}

--- a/tests/fixtures/answer-orchestration/web-needed.json
+++ b/tests/fixtures/answer-orchestration/web-needed.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": "answer-plan/v1",
+  "plan_id": "fixture-web-needed-patch-metadata",
+  "answer_mode": "web_needed",
+  "intent": {
+    "schema_version": "answer-intent/v1",
+    "question_text": "最新パッチでこの技は変わった？",
+    "normalized_question_text": "Latest patch metadata freshness check",
+    "intent_kind": "web_needed",
+    "answer_mode": "web_needed",
+    "entities": {
+      "character_slug": "ryu",
+      "move_input": "2MP",
+      "requested_field": "patch_metadata"
+    }
+  },
+  "evidence_cards": [
+    {
+      "id": "official-web-patch-required",
+      "evidence_family": "official_web",
+      "authority_role": "official_metadata",
+      "canonicality": "supplemental",
+      "source_ref": {
+        "label": "Official patch source required",
+        "url": "https://www.streetfighter.com/6/"
+      },
+      "supports_exact_current_fact": false,
+      "may_override_official_raw": false,
+      "confidence": 0.6,
+      "limitations": [
+        "Official web may confirm patch metadata but cannot silently override packaged official_raw."
+      ]
+    }
+  ],
+  "web_research": {
+    "web_required": true,
+    "web_allowed": true,
+    "web_used": false,
+    "web_forbidden_for_current_fact_override": true,
+    "conflict_requires_hold": true,
+    "required_source_authority": "official_sources_required",
+    "notes": "Use official sources for patch/current metadata and route conflicts to frame-data refresh."
+  },
+  "hold_reasons": [
+    "freshness check requires official web source before user-facing patch metadata summary"
+  ],
+  "response_requirements": {
+    "cite_evidence": true,
+    "state_authority_boundary": true,
+    "state_confidence": true,
+    "boundary_notes": [
+      "Web may be used for freshness and patch metadata only.",
+      "Web must not override packaged official_raw exact current facts."
+    ]
+  }
+}

--- a/tests/validation/run-all.ps1
+++ b/tests/validation/run-all.ps1
@@ -36,6 +36,7 @@ $validationScripts = @(
   'tests/validation/validate-architecture-markers.ps1',
   'tests/validation/validate-hermes-pack.ps1',
   'tests/validation/validate-v2-contracts.ps1',
+  'tests/validation/validate-answer-orchestration-contracts.ps1',
   'tests/validation/validate-knowledge-schema.ps1',
   'tests/validation/validate-ingest-artifacts.ps1',
   'tests/validation/validate-video-artifacts.ps1',

--- a/tests/validation/validate-answer-orchestration-contracts.ps1
+++ b/tests/validation/validate-answer-orchestration-contracts.ps1
@@ -61,6 +61,15 @@ $requiredFixtures = @(
   'web-needed.json'
 )
 
+$expectedFixtureModes = @{
+  'current-fact.json' = 'current_fact'
+  'stable-concept.json' = 'stable_concept'
+  'strategy.json' = 'strategy'
+  'observation.json' = 'observation'
+  'hold.json' = 'hold'
+  'web-needed.json' = 'web_needed'
+}
+
 $answerModes = @(
   'current_fact',
   'stable_concept',
@@ -138,6 +147,7 @@ foreach ($relativePath in $requiredDocs) {
 
 foreach ($fileName in $requiredFixtures) {
   $relativePath = "$fixtureRoot/$fileName"
+  $expectedMode = $expectedFixtureModes[$fileName]
   $path = Join-Path $repoRoot $relativePath
   if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
     $issues += "Missing answer orchestration fixture: $relativePath"
@@ -155,6 +165,9 @@ foreach ($fileName in $requiredFixtures) {
 
   if (Test-Property $fixture 'answer_mode') {
     Assert-ValueIn $fixture.answer_mode $answerModes "$relativePath answer_mode" ([ref]$issues)
+    if ([string]$fixture.answer_mode -ne $expectedMode) {
+      $issues += "$relativePath answer_mode must be $expectedMode"
+    }
   }
 
   if (Test-Property $fixture 'intent') {
@@ -166,9 +179,15 @@ foreach ($fileName in $requiredFixtures) {
     }
     if (Test-Property $fixture.intent 'intent_kind') {
       Assert-ValueIn $fixture.intent.intent_kind $answerModes "$relativePath intent_kind" ([ref]$issues)
+      if ([string]$fixture.intent.intent_kind -ne $expectedMode) {
+        $issues += "$relativePath intent_kind must be $expectedMode"
+      }
     }
     if (Test-Property $fixture.intent 'answer_mode') {
       Assert-ValueIn $fixture.intent.answer_mode $answerModes "$relativePath intent answer_mode" ([ref]$issues)
+      if ([string]$fixture.intent.answer_mode -ne $expectedMode) {
+        $issues += "$relativePath intent answer_mode must be $expectedMode"
+      }
     }
   }
 
@@ -199,6 +218,10 @@ foreach ($fileName in $requiredFixtures) {
 
       $supportsExact = (Test-Property $card 'supports_exact_current_fact') -and [bool]$card.supports_exact_current_fact
       $mayOverride = (Test-Property $card 'may_override_official_raw') -and [bool]$card.may_override_official_raw
+
+      if ($supportsExact -and $family -ne 'frame_current_official_raw') {
+        $issues += "$relativePath allows non-official_raw evidence to support exact current facts: $family"
+      }
 
       if ($family -eq 'hermes_memory_session_profile_state') {
         if ($canonicality -notin @('non_canonical', 'forbidden')) {
@@ -258,6 +281,21 @@ foreach ($fileName in $requiredFixtures) {
     })
     if ($officialRawCards.Count -eq 0) {
       $issues += 'current-fact fixture must contain existing packaged frame-current official_raw evidence'
+    }
+
+    if (Test-Property $fixture 'web_research') {
+      if ([bool]$fixture.web_research.web_required) {
+        $issues += 'current-fact fixture must not require web research'
+      }
+      if ([bool]$fixture.web_research.web_used) {
+        $issues += 'current-fact fixture must not use web research'
+      }
+      if (-not [bool]$fixture.web_research.web_forbidden_for_current_fact_override) {
+        $issues += 'current-fact fixture must forbid web current-fact override'
+      }
+      if (-not [bool]$fixture.web_research.conflict_requires_hold) {
+        $issues += 'current-fact fixture must hold on web/current-fact conflict'
+      }
     }
   }
 

--- a/tests/validation/validate-answer-orchestration-contracts.ps1
+++ b/tests/validation/validate-answer-orchestration-contracts.ps1
@@ -1,0 +1,283 @@
+Set-StrictMode -Version Latest
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$fixtureRoot = 'tests/fixtures/answer-orchestration'
+
+function Read-Json {
+  param([Parameter(Mandatory = $true)][string]$RelativePath)
+  return Get-Content -LiteralPath (Join-Path $repoRoot $RelativePath) -Raw -Encoding UTF8 | ConvertFrom-Json
+}
+
+function Test-Property {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name
+  )
+  return $null -ne $Object.PSObject.Properties[$Name]
+}
+
+function Assert-Property {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+  if (-not (Test-Property $Object $Name)) {
+    $Issues.Value += "$Context missing property: $Name"
+  }
+}
+
+function Assert-ValueIn {
+  param(
+    [Parameter(Mandatory = $true)][object]$Value,
+    [Parameter(Mandatory = $true)][string[]]$AllowedValues,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  if ($AllowedValues -notcontains [string]$Value) {
+    $Issues.Value += "$Context has invalid value: $Value"
+  }
+}
+
+$requiredSchemas = @(
+  'contracts/answer-intent.schema.json',
+  'contracts/evidence-card.schema.json',
+  'contracts/answer-plan.schema.json'
+)
+
+$requiredDocs = @(
+  'contracts/evidence-gate.md',
+  'contracts/web-research-policy.md'
+)
+
+$requiredFixtures = @(
+  'current-fact.json',
+  'stable-concept.json',
+  'strategy.json',
+  'observation.json',
+  'hold.json',
+  'web-needed.json'
+)
+
+$answerModes = @(
+  'current_fact',
+  'stable_concept',
+  'strategy',
+  'observation',
+  'hold',
+  'web_needed'
+)
+
+$evidenceFamilies = @(
+  'frame_current_official_raw',
+  'frame_current_derived_metrics',
+  'generated_curated_reference',
+  'review_claim',
+  'video_observation',
+  'official_web',
+  'third_party_community_web',
+  'hermes_memory_session_profile_state',
+  'repo_policy',
+  'unknown'
+)
+
+$authorityRoles = @(
+  'primary_current_fact_authority',
+  'derived_current_fact_support',
+  'stable_concept_support',
+  'strategy_support',
+  'observation_only',
+  'review_only',
+  'official_metadata',
+  'supplemental_context',
+  'forbidden_non_canonical',
+  'unresolved_context'
+)
+
+$canonicalityValues = @(
+  'canonical_repo_source',
+  'packaged_runtime_authority',
+  'derived_reference',
+  'review_only',
+  'observation_only',
+  'supplemental',
+  'non_canonical',
+  'forbidden'
+)
+
+$sourceAuthorityValues = @(
+  'none',
+  'official_sources_required',
+  'supplemental_sources_allowed'
+)
+
+$issues = @()
+
+foreach ($relativePath in $requiredSchemas) {
+  $path = Join-Path $repoRoot $relativePath
+  if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+    $issues += "Missing answer orchestration schema: $relativePath"
+    continue
+  }
+
+  $schema = Read-Json $relativePath
+  foreach ($field in @('$schema', '$id', 'title')) {
+    if (-not (Test-Property $schema $field)) {
+      $issues += "$relativePath missing schema field: $field"
+    }
+  }
+}
+
+foreach ($relativePath in $requiredDocs) {
+  if (-not (Test-Path -LiteralPath (Join-Path $repoRoot $relativePath) -PathType Leaf)) {
+    $issues += "Missing answer orchestration policy doc: $relativePath"
+  }
+}
+
+foreach ($fileName in $requiredFixtures) {
+  $relativePath = "$fixtureRoot/$fileName"
+  $path = Join-Path $repoRoot $relativePath
+  if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+    $issues += "Missing answer orchestration fixture: $relativePath"
+    continue
+  }
+
+  $fixture = Read-Json $relativePath
+  foreach ($field in @('schema_version', 'plan_id', 'answer_mode', 'intent', 'evidence_cards', 'web_research', 'hold_reasons', 'response_requirements')) {
+    Assert-Property $fixture $field $relativePath ([ref]$issues)
+  }
+
+  if ((Test-Property $fixture 'schema_version') -and $fixture.schema_version -ne 'answer-plan/v1') {
+    $issues += "$relativePath must use schema_version answer-plan/v1"
+  }
+
+  if (Test-Property $fixture 'answer_mode') {
+    Assert-ValueIn $fixture.answer_mode $answerModes "$relativePath answer_mode" ([ref]$issues)
+  }
+
+  if (Test-Property $fixture 'intent') {
+    foreach ($field in @('schema_version', 'question_text', 'intent_kind', 'answer_mode', 'entities')) {
+      Assert-Property $fixture.intent $field "$relativePath intent" ([ref]$issues)
+    }
+    if ((Test-Property $fixture.intent 'schema_version') -and $fixture.intent.schema_version -ne 'answer-intent/v1') {
+      $issues += "$relativePath intent must use schema_version answer-intent/v1"
+    }
+    if (Test-Property $fixture.intent 'intent_kind') {
+      Assert-ValueIn $fixture.intent.intent_kind $answerModes "$relativePath intent_kind" ([ref]$issues)
+    }
+    if (Test-Property $fixture.intent 'answer_mode') {
+      Assert-ValueIn $fixture.intent.answer_mode $answerModes "$relativePath intent answer_mode" ([ref]$issues)
+    }
+  }
+
+  if (Test-Property $fixture 'evidence_cards') {
+    $evidenceCards = @($fixture.evidence_cards)
+    if ($evidenceCards.Count -eq 0) {
+      $issues += "$relativePath must include at least one evidence card"
+    }
+
+    foreach ($card in $evidenceCards) {
+      foreach ($field in @('id', 'evidence_family', 'authority_role', 'canonicality', 'source_ref', 'supports_exact_current_fact', 'may_override_official_raw', 'limitations')) {
+        Assert-Property $card $field "$relativePath evidence card" ([ref]$issues)
+      }
+
+      $family = if (Test-Property $card 'evidence_family') { [string]$card.evidence_family } else { '' }
+      if ($family) {
+        Assert-ValueIn $family $evidenceFamilies "$relativePath evidence_family" ([ref]$issues)
+      }
+
+      if (Test-Property $card 'authority_role') {
+        Assert-ValueIn $card.authority_role $authorityRoles "$relativePath authority_role" ([ref]$issues)
+      }
+
+      $canonicality = if (Test-Property $card 'canonicality') { [string]$card.canonicality } else { '' }
+      if ($canonicality) {
+        Assert-ValueIn $canonicality $canonicalityValues "$relativePath canonicality" ([ref]$issues)
+      }
+
+      $supportsExact = (Test-Property $card 'supports_exact_current_fact') -and [bool]$card.supports_exact_current_fact
+      $mayOverride = (Test-Property $card 'may_override_official_raw') -and [bool]$card.may_override_official_raw
+
+      if ($family -eq 'hermes_memory_session_profile_state') {
+        if ($canonicality -notin @('non_canonical', 'forbidden')) {
+          $issues += "$relativePath treats Hermes state as canonical evidence"
+        }
+        if ($supportsExact) {
+          $issues += "$relativePath allows Hermes state to support exact current facts"
+        }
+      }
+
+      if ($family -in @('official_web', 'third_party_community_web')) {
+        if ($supportsExact) {
+          $issues += "$relativePath allows web evidence to support exact current facts"
+        }
+        if ($mayOverride) {
+          $issues += "$relativePath allows web evidence to override packaged official_raw"
+        }
+      }
+
+      if ($mayOverride) {
+        $issues += "$relativePath contains evidence that may override official_raw"
+      }
+    }
+  }
+
+  if (Test-Property $fixture 'web_research') {
+    foreach ($field in @('web_required', 'web_allowed', 'web_used', 'web_forbidden_for_current_fact_override', 'conflict_requires_hold')) {
+      Assert-Property $fixture.web_research $field "$relativePath web_research" ([ref]$issues)
+    }
+
+    if (Test-Property $fixture.web_research 'required_source_authority') {
+      Assert-ValueIn $fixture.web_research.required_source_authority $sourceAuthorityValues "$relativePath required_source_authority" ([ref]$issues)
+    }
+
+    if ((Test-Property $fixture.web_research 'web_forbidden_for_current_fact_override') -and -not [bool]$fixture.web_research.web_forbidden_for_current_fact_override) {
+      $issues += "$relativePath must forbid web current-fact override"
+    }
+
+    if ((Test-Property $fixture.web_research 'conflict_requires_hold') -and -not [bool]$fixture.web_research.conflict_requires_hold) {
+      $issues += "$relativePath must hold on web/current-fact conflict"
+    }
+  }
+
+  if (Test-Property $fixture 'response_requirements') {
+    foreach ($field in @('cite_evidence', 'state_authority_boundary', 'state_confidence', 'boundary_notes')) {
+      Assert-Property $fixture.response_requirements $field "$relativePath response_requirements" ([ref]$issues)
+    }
+  }
+
+  if ($fileName -eq 'current-fact.json') {
+    $officialRawCards = @($fixture.evidence_cards | Where-Object {
+      $sourcePath = if (Test-Property $_.source_ref 'path') { [string]$_.source_ref.path } else { '' }
+      $_.evidence_family -eq 'frame_current_official_raw' -and
+      $_.supports_exact_current_fact -eq $true -and
+      $sourcePath -match '^skills/sf6-agent/assets/frame-current/published/.+/official_raw\.json$' -and
+      (Test-Path -LiteralPath (Join-Path $repoRoot $sourcePath) -PathType Leaf)
+    })
+    if ($officialRawCards.Count -eq 0) {
+      $issues += 'current-fact fixture must contain existing packaged frame-current official_raw evidence'
+    }
+  }
+
+  if ($fileName -eq 'hold.json') {
+    if (-not (Test-Property $fixture 'hold_reasons') -or @($fixture.hold_reasons).Count -eq 0) {
+      $issues += 'hold fixture must include hold reasons'
+    }
+  }
+
+  if ($fileName -eq 'web-needed.json') {
+    $webRequired = (Test-Property $fixture.web_research 'web_required') -and [bool]$fixture.web_research.web_required
+    $webAllowed = (Test-Property $fixture.web_research 'web_allowed') -and [bool]$fixture.web_research.web_allowed
+    if (-not ($webRequired -or $webAllowed)) {
+      $issues += 'web-needed fixture must mark web required or web allowed'
+    }
+  }
+}
+
+if ($issues.Count -gt 0) {
+  throw ($issues -join '; ')
+}
+
+Write-Host 'Answer orchestration contracts OK'

--- a/tests/validation/validate-v2-contracts.ps1
+++ b/tests/validation/validate-v2-contracts.ps1
@@ -8,12 +8,17 @@ $requiredJsonSchemas = @(
   'contracts/knowledge-page.schema.json',
   'contracts/generated-surface.schema.json',
   'contracts/eval-case.schema.json',
-  'contracts/video-observation.schema.json'
+  'contracts/video-observation.schema.json',
+  'contracts/answer-intent.schema.json',
+  'contracts/evidence-card.schema.json',
+  'contracts/answer-plan.schema.json'
 )
 
 $requiredDocs = @(
   'contracts/frame-current-runtime-assets.md',
-  'contracts/video-observation.md'
+  'contracts/video-observation.md',
+  'contracts/evidence-gate.md',
+  'contracts/web-research-policy.md'
 )
 
 foreach ($relativePath in $requiredJsonSchemas) {


### PR DESCRIPTION
## Summary
- Add answer orchestration JSON schemas for intent classification, evidence cards, and answer plans.
- Add evidence gate and web research policy docs for current-fact authority, review/observation boundaries, web use, and hold behavior.
- Add six answer-plan fixtures covering current fact, stable concept, strategy, observation, hold, and web-needed paths.
- Add `validate-answer-orchestration-contracts.ps1`, require the new contracts in `validate-v2-contracts.ps1`, and wire the new validator into `run-all.ps1`.

## Scope
Closes #87.

This PR implements the contract and policy layer needed before Hermes answer orchestration prompts are written. It does not add prompt bodies, retrieval code, lookup code, or normalization surfaces.

## Validation
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-v2-contracts.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-answer-orchestration-contracts.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-architecture-markers.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-hermes-pack.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1`
- `git diff --check`

`run-all.ps1` was executed through Windows PowerShell. That environment printed git-unavailable warnings during derived-output status checks, so I separately verified from WSL git that generated references, frame-current assets, and `.dist` have no residual diff.

## Not included
- #88 is not implemented.
- No Hermes answer prompts or operational prompt bodies were added.
- No retrieval code or lookup code was added.
- No normalization aliases, `data/aliases/`, or `skills/sf6-agent/assets/normalization/` were added.
- No public `sf6-agent` behavior or `skills/sf6-agent/SKILL.md` changes were made.
- No generated outputs, frame-current assets, `.dist`, article/video ingest wrappers, or historical smoke reports were changed.

## Review notes
- Read-only schema, evidence/web policy, validator, and scope-guard subagents reviewed this diff.
- The validator was tightened after review to check required answer-plan root fields, enum-like values, and existing packaged `official_raw` paths for current-fact fixtures.
