### PR TITLE
[v2.1] Define Japanese normalization alias surface

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -21,3 +21,8 @@ When `source_refs.path` points to a migrated legacy file, `source_revision` iden
 - `answer-intent.schema.json`: intent and answer-mode classification contract.
 - `evidence-card.schema.json`: evidence authority and source-boundary card contract.
 - `answer-plan.schema.json`: answer planning contract combining intent, evidence cards, web state, hold reasons, and response requirements.
+
+## Query Normalization Contracts
+
+- `normalization-aliases.schema.json`: query-normalization alias contract for mapping user language to structured lookup inputs.
+- `data/aliases/`: canonical query-normalization support, not exact current-fact authority. Exact current facts remain grounded in `data/exports/` and `data/roster/`.

--- a/contracts/normalization-aliases.schema.json
+++ b/contracts/normalization-aliases.schema.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sf6-knowledge-agent-kit.local/normalization-aliases.schema.json",
+  "title": "Normalization Aliases",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "kind",
+    "authority",
+    "not_current_fact_authority",
+    "entries"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "normalization-aliases/v1"
+    },
+    "kind": {
+      "type": "string",
+      "const": "query_normalization_aliases"
+    },
+    "authority": {
+      "type": "string",
+      "const": "query_normalization_only"
+    },
+    "not_current_fact_authority": {
+      "type": "boolean",
+      "const": true
+    },
+    "entries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "alias_kind",
+          "aliases",
+          "normalized"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "alias_kind": {
+            "type": "string",
+            "enum": [
+              "character",
+              "move_input",
+              "field",
+              "term",
+              "query_fixture"
+            ]
+          },
+          "aliases": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "normalized": {
+            "type": "object",
+            "additionalProperties": false,
+            "minProperties": 1,
+            "properties": {
+              "character_slug": {
+                "type": "string",
+                "minLength": 1
+              },
+              "move_input": {
+                "type": "string",
+                "minLength": 1
+              },
+              "field": {
+                "type": "string",
+                "minLength": 1
+              },
+              "term_key": {
+                "type": "string",
+                "minLength": 1
+              },
+              "question_text": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "notes": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/data/aliases/README.md
+++ b/data/aliases/README.md
@@ -1,0 +1,11 @@
+# Query Normalization Aliases
+
+`data/aliases/` is canonical query-normalization support for mapping user wording to structured lookup inputs.
+
+This directory is not exact current-fact authority. Exact current facts remain grounded in `data/exports/` and `data/roster/`, and runtime frame-current facts remain under `skills/sf6-agent/assets/frame-current/`.
+
+Future derived normalization runtime assets may be generated under `skills/sf6-agent/assets/normalization/`. That target must stay separate from `skills/sf6-agent/assets/frame-current/`; do not mix normalization assets into frame-current runtime assets.
+
+Normalization aliases can help map user language to fields such as character slugs, move inputs, and lookup field keys. They do not prove move data, frame values, damage, patch metadata, matchup judgments, or strategy claims.
+
+This surface currently contains minimal fixtures for validation. It does not attempt full roster move alias coverage.

--- a/data/aliases/ja-query-fixtures.json
+++ b/data/aliases/ja-query-fixtures.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "normalization-aliases/v1",
+  "kind": "query_normalization_aliases",
+  "authority": "query_normalization_only",
+  "not_current_fact_authority": true,
+  "entries": [
+    {
+      "id": "ja-character-ryu",
+      "alias_kind": "character",
+      "aliases": [
+        "リュウ",
+        "Ryu",
+        "ryu"
+      ],
+      "normalized": {
+        "character_slug": "ryu"
+      },
+      "notes": "Maps character names to a character slug for query routing."
+    },
+    {
+      "id": "ja-move-ryu-2mp",
+      "alias_kind": "move_input",
+      "aliases": [
+        "屈中P",
+        "しゃがみ中P",
+        "2中P",
+        "2MP",
+        "cr.MP"
+      ],
+      "normalized": {
+        "move_input": "2MP"
+      },
+      "notes": "Maps notation variants to an input token for query routing."
+    },
+    {
+      "id": "ja-field-block-adv",
+      "alias_kind": "field",
+      "aliases": [
+        "ガードで何F",
+        "ガード硬直差",
+        "ガード有利不利",
+        "on block"
+      ],
+      "normalized": {
+        "field": "block_adv"
+      },
+      "notes": "Maps user wording to the block advantage lookup field."
+    },
+    {
+      "id": "ja-query-ryu-2mp-block-adv",
+      "alias_kind": "query_fixture",
+      "aliases": [
+        "リュウの屈中Pってガードで何F？"
+      ],
+      "normalized": {
+        "character_slug": "ryu",
+        "move_input": "2MP",
+        "field": "block_adv"
+      },
+      "notes": "End-to-end query normalization fixture."
+    }
+  ]
+}

--- a/tests/validation/run-all.ps1
+++ b/tests/validation/run-all.ps1
@@ -37,6 +37,7 @@ $validationScripts = @(
   'tests/validation/validate-hermes-pack.ps1',
   'tests/validation/validate-v2-contracts.ps1',
   'tests/validation/validate-answer-orchestration-contracts.ps1',
+  'tests/validation/validate-normalization-aliases.ps1',
   'tests/validation/validate-knowledge-schema.ps1',
   'tests/validation/validate-ingest-artifacts.ps1',
   'tests/validation/validate-video-artifacts.ps1',

--- a/tests/validation/validate-normalization-aliases.ps1
+++ b/tests/validation/validate-normalization-aliases.ps1
@@ -1,0 +1,238 @@
+Set-StrictMode -Version Latest
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$aliasesRoot = 'data/aliases'
+$fixturePath = 'data/aliases/ja-query-fixtures.json'
+$schemaPath = 'contracts/normalization-aliases.schema.json'
+
+function Read-Json {
+  param([Parameter(Mandatory = $true)][string]$RelativePath)
+  return Get-Content -LiteralPath (Join-Path $repoRoot $RelativePath) -Raw -Encoding UTF8 | ConvertFrom-Json
+}
+
+function Test-Property {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name
+  )
+  return $null -ne $Object.PSObject.Properties[$Name]
+}
+
+function Assert-Property {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+  if (-not (Test-Property $Object $Name)) {
+    $Issues.Value += "$Context missing property: $Name"
+  }
+}
+
+function Get-RelativePath {
+  param(
+    [Parameter(Mandatory = $true)][string]$RootPath,
+    [Parameter(Mandatory = $true)][string]$FullPath
+  )
+
+  $root = (Resolve-Path $RootPath).Path.TrimEnd([char[]]@('\', '/'))
+  $relative = $FullPath.Substring($root.Length)
+  $relative = $relative -replace '^[\\/]+', ''
+  return $relative -replace '\\', '/'
+}
+
+$issues = @()
+$allowedAliasKinds = @('character', 'move_input', 'field', 'term', 'query_fixture')
+$expectedQuery = -join ([int[]]@(
+  0x30EA,
+  0x30E5,
+  0x30A6,
+  0x306E,
+  0x5C48,
+  0x4E2D,
+  0x0050,
+  0x3063,
+  0x3066,
+  0x30AC,
+  0x30FC,
+  0x30C9,
+  0x3067,
+  0x4F55,
+  0x0046,
+  0xFF1F
+) | ForEach-Object { [char]$_ })
+$forbiddenTokens = @(
+  'startup',
+  'active',
+  'recovery',
+  'hit_adv',
+  'block_adv_value',
+  'damage',
+  'frame_value',
+  'patch',
+  'tier',
+  'strategy',
+  'recommendation'
+)
+
+foreach ($relativePath in @('data/aliases/README.md', $schemaPath, $fixturePath)) {
+  if (-not (Test-Path -LiteralPath (Join-Path $repoRoot $relativePath) -PathType Leaf)) {
+    $issues += "Missing normalization alias file: $relativePath"
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot $schemaPath) -PathType Leaf) {
+  $schema = Read-Json $schemaPath
+  foreach ($field in @('$schema', '$id', 'title')) {
+    Assert-Property $schema $field $schemaPath ([ref]$issues)
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot 'data/aliases/README.md') -PathType Leaf) {
+  $readme = Get-Content -LiteralPath (Join-Path $repoRoot 'data/aliases/README.md') -Raw -Encoding UTF8
+  foreach ($needle in @(
+    'canonical query-normalization support',
+    'not exact current-fact authority',
+    'data/exports/',
+    'data/roster/',
+    'skills/sf6-agent/assets/normalization/',
+    'skills/sf6-agent/assets/frame-current/'
+  )) {
+    if ($readme -notmatch [regex]::Escape($needle)) {
+      $issues += "data/aliases/README.md missing boundary text: $needle"
+    }
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot $fixturePath) -PathType Leaf) {
+  $fixtureRaw = Get-Content -LiteralPath (Join-Path $repoRoot $fixturePath) -Raw -Encoding UTF8
+  $fixture = $fixtureRaw | ConvertFrom-Json
+
+  foreach ($field in @('schema_version', 'kind', 'authority', 'not_current_fact_authority', 'entries')) {
+    Assert-Property $fixture $field $fixturePath ([ref]$issues)
+  }
+
+  if ((Test-Property $fixture 'schema_version') -and $fixture.schema_version -ne 'normalization-aliases/v1') {
+    $issues += "$fixturePath must use schema_version normalization-aliases/v1"
+  }
+  if ((Test-Property $fixture 'kind') -and $fixture.kind -ne 'query_normalization_aliases') {
+    $issues += "$fixturePath must use kind query_normalization_aliases"
+  }
+  if ((Test-Property $fixture 'authority') -and $fixture.authority -ne 'query_normalization_only') {
+    $issues += "$fixturePath must use authority query_normalization_only"
+  }
+  if (
+    (Test-Property $fixture 'not_current_fact_authority') -and
+    ((-not ($fixture.not_current_fact_authority -is [bool])) -or $fixture.not_current_fact_authority -ne $true)
+  ) {
+    $issues += "$fixturePath must set not_current_fact_authority to boolean true"
+  }
+
+  foreach ($token in $forbiddenTokens) {
+    $escapedToken = [regex]::Escape($token)
+    if ($fixtureRaw -match ('(?i)"[^"]*' + $escapedToken + '[^"]*"')) {
+      $issues += "$fixturePath contains forbidden exact-current-fact token: $token"
+    }
+  }
+
+  if (Test-Property $fixture 'entries') {
+    $entries = @($fixture.entries)
+    if ($entries.Count -eq 0) {
+      $issues += "$fixturePath must include at least one alias entry"
+    }
+
+    foreach ($entry in $entries) {
+      $entryId = if (Test-Property $entry 'id') { [string]$entry.id } else { '<missing-id>' }
+      foreach ($field in @('id', 'alias_kind', 'aliases', 'normalized')) {
+        Assert-Property $entry $field "$fixturePath entry $entryId" ([ref]$issues)
+      }
+
+      if (Test-Property $entry 'alias_kind') {
+        $aliasKind = [string]$entry.alias_kind
+        if ($allowedAliasKinds -notcontains $aliasKind) {
+          $issues += "$fixturePath entry $entryId has invalid alias_kind: $aliasKind"
+        }
+      }
+
+      if ((Test-Property $entry 'aliases') -and @($entry.aliases).Count -eq 0) {
+        $issues += "$fixturePath entry $entryId must include aliases"
+      }
+
+      if (Test-Property $entry 'normalized') {
+        $normalizedProperties = @($entry.normalized.PSObject.Properties.Name)
+        if ($normalizedProperties.Count -eq 0) {
+          $issues += "$fixturePath entry $entryId must include normalized properties"
+        }
+        foreach ($propertyName in $normalizedProperties) {
+          if ($forbiddenTokens -contains $propertyName) {
+            $issues += "$fixturePath entry $entryId uses forbidden normalized property: $propertyName"
+          }
+        }
+      }
+    }
+
+    $queryFixture = @($entries | Where-Object {
+      (Test-Property $_ 'alias_kind') -and
+      $_.alias_kind -eq 'query_fixture' -and
+      (Test-Property $_ 'aliases') -and
+      @($_.aliases) -contains $expectedQuery
+    })
+
+    if ($queryFixture.Count -eq 0) {
+      $issues += "$fixturePath must include the expected Japanese Ryu 2MP block query fixture"
+    } else {
+      $normalized = $queryFixture[0].normalized
+      $expectedNormalized = @{
+        character_slug = 'ryu'
+        move_input = '2MP'
+        field = 'block_adv'
+      }
+      foreach ($propertyName in $expectedNormalized.Keys) {
+        if (-not (Test-Property $normalized $propertyName)) {
+          $issues += "query fixture missing normalized property: $propertyName"
+        } elseif ([string]$normalized.$propertyName -ne $expectedNormalized[$propertyName]) {
+          $issues += "query fixture must map $propertyName to $($expectedNormalized[$propertyName])"
+        }
+      }
+    }
+  }
+}
+
+$aliasesPath = Join-Path $repoRoot $aliasesRoot
+if (Test-Path -LiteralPath $aliasesPath -PathType Container) {
+  foreach ($item in Get-ChildItem -LiteralPath $aliasesPath -Recurse -Force) {
+    $relativePath = Get-RelativePath $aliasesPath $item.FullName
+    $relativePathLower = $relativePath.ToLowerInvariant()
+    if (
+      $relativePathLower -like '*generated*' -or
+      $relativePathLower -like '*runtime*' -or
+      $relativePathLower -like '*compiled*' -or
+      $relativePathLower -like '*.bundle*' -or
+      $relativePathLower -like '*.min.json'
+    ) {
+      $issues += "data/aliases contains generated-runtime-looking path: $relativePath"
+    }
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot 'skills/sf6-agent/assets/normalization')) {
+  $issues += 'skills/sf6-agent/assets/normalization/ must not be created by this issue'
+}
+
+if (Get-Command git -ErrorAction SilentlyContinue) {
+  $frameCurrentStatus = @(& git -C $repoRoot status --porcelain -- 'skills/sf6-agent/assets/frame-current')
+  if ($LASTEXITCODE -ne 0) {
+    $issues += 'Unable to inspect frame-current status'
+  } elseif ($frameCurrentStatus.Count -gt 0) {
+    $issues += 'skills/sf6-agent/assets/frame-current/ has residual diff'
+  }
+} else {
+  Write-Host 'WARNING: git is unavailable; skipping frame-current status check'
+}
+
+if ($issues.Count -gt 0) {
+  throw ($issues -join '; ')
+}
+
+Write-Host 'Normalization aliases OK'

--- a/tests/validation/validate-normalization-aliases.ps1
+++ b/tests/validation/validate-normalization-aliases.ps1
@@ -44,6 +44,13 @@ function Get-RelativePath {
 
 $issues = @()
 $allowedAliasKinds = @('character', 'move_input', 'field', 'term', 'query_fixture')
+$allowedNormalizedProperties = @(
+  'character_slug',
+  'move_input',
+  'field',
+  'term_key',
+  'question_text'
+)
 $expectedQuery = -join ([int[]]@(
   0x30EA,
   0x30E5,
@@ -165,6 +172,9 @@ if (Test-Path -LiteralPath (Join-Path $repoRoot $fixturePath) -PathType Leaf) {
           $issues += "$fixturePath entry $entryId must include normalized properties"
         }
         foreach ($propertyName in $normalizedProperties) {
+          if ($allowedNormalizedProperties -notcontains $propertyName) {
+            $issues += "$fixturePath entry $entryId has invalid normalized property: $propertyName"
+          }
           if ($forbiddenTokens -contains $propertyName) {
             $issues += "$fixturePath entry $entryId uses forbidden normalized property: $propertyName"
           }

--- a/tests/validation/validate-v2-contracts.ps1
+++ b/tests/validation/validate-v2-contracts.ps1
@@ -11,7 +11,8 @@ $requiredJsonSchemas = @(
   'contracts/video-observation.schema.json',
   'contracts/answer-intent.schema.json',
   'contracts/evidence-card.schema.json',
-  'contracts/answer-plan.schema.json'
+  'contracts/answer-plan.schema.json',
+  'contracts/normalization-aliases.schema.json'
 )
 
 $requiredDocs = @(


### PR DESCRIPTION
## Summary

- Define `data/aliases/` as the canonical query-normalization support surface.
- Add `contracts/normalization-aliases.schema.json` and a minimal Japanese query fixture.
- Add `validate-normalization-aliases.ps1` and wire it into v2 contract validation and `run-all.ps1`.

Closes #88.

## Scope

This PR implements Issue #88 only:

- `data/aliases/README.md` documents the alias surface and authority boundary.
- `data/aliases/ja-query-fixtures.json` contains minimal fixture data for `リュウの屈中Pってガードで何F？` -> `ryu / 2MP / block_adv`.
- `contracts/normalization-aliases.schema.json` defines query-normalization alias shape.
- `tests/validation/validate-normalization-aliases.ps1` validates the alias fixture, authority boundary, and runtime-generation guardrails.

## Non-goals

- This PR does not implement full roster alias coverage or full move alias coverage.
- Aliases are query-normalization support, not exact current-fact authority.
- Runtime normalization assets are not generated.
- `skills/sf6-agent/assets/normalization/` is not created.
- `skills/sf6-agent/assets/frame-current/`, generated outputs, public `sf6-agent` behavior, and historical smoke reports are not changed.
- This PR does not add Hermes prompts, retrieval/lookup code, or article/video ingest wrappers.

## Validation

- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-normalization-aliases.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-v2-contracts.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-answer-orchestration-contracts.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-architecture-markers.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-hermes-pack.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1`
- `git diff --check`

Windows PowerShell reports git-unavailable warnings during derived-output status checks in `run-all.ps1`. I separately verified with WSL `git status --porcelain` that generated references, `.dist`, `skills/sf6-agent/assets/frame-current/`, and `skills/sf6-agent/assets/normalization/` have no residual diff.

## Review notes

Read-only subagent reviews passed for schema, boundary, scope, and validator behavior after tightening `not_current_fact_authority` to require boolean `true` rather than truthy coercion.
