### PR TITLE
[v2.2] Map harness engineering patterns to SF6 Hermes Growth Operations

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -5,6 +5,7 @@ Architecture docs define the v2 source-of-truth model.
 - [v2-architecture.md](./v2-architecture.md)
 - [decisions/](./decisions/README.md)
 - [hermes-v2.1-roadmap.md](./hermes-v2.1-roadmap.md)
+- [hermes-growth-harness-map.md](./hermes-growth-harness-map.md)
 - [language-policy.md](./language-policy.md)
 - [harness-and-distribution-roles.md](./harness-and-distribution-roles.md)
 - [japanese-maintainer-docs-policy.md](./japanese-maintainer-docs-policy.md)

--- a/docs/architecture/hermes-growth-harness-map.md
+++ b/docs/architecture/hermes-growth-harness-map.md
@@ -1,0 +1,99 @@
+# Hermes Growth Harness Map
+
+## Purpose
+
+This document maps harness engineering concepts to SF6 repo maintainer
+operations for v2.2.
+
+External harness engineering material is reference input only. It is not
+canonical SF6 repo authority. SF6 repo architecture decisions, contracts,
+workflows, validators, GitHub issues, pull requests, and reviewed repository
+artifacts remain authoritative.
+
+v2.2 uses this map to keep Hermes Growth Operations concrete. Hermes is the
+repo-local growth engine when a configured maintainer profile is available,
+while Codex remains the normal repo implementation executor and
+`skills/sf6-agent/` remains the public answer adapter.
+
+## Boundary
+
+The maintainer harness is repo-local. It coordinates implementation,
+knowledge-growth, review, validation, and handoff work.
+
+The public answer surface is still `skills/sf6-agent/`. End users do not need
+Hermes, Codex, local Hermes memory, local skills, Curator output, Kanban
+workers, or checkpoints to use the public adapter.
+
+Hermes-generated drafts, local Hermes skills, session memory, Curator output,
+and other local state are not canonical until promoted through reviewed
+repository artifacts.
+
+## Harness Subsystem Map
+
+| Harness subsystem | Existing SF6 repo surfaces | Missing or weak surfaces | v2.2 issue mapping | Deferred items and reason |
+|---|---|---|---|---|
+| Instructions | `AGENTS.md`; `README.md`; `docs/architecture/*`; `docs/architecture/decisions/*`; `workflows/*`; issue bodies with scope and non-goals | A consolidated harness map for v2.2 growth operations | #95 maps current instructions and gaps | Operational Hermes prompt bodies remain deferred until contracts, boundaries, and smoke surfaces are ready |
+| State | GitHub issues and milestones; PR bodies; PR comments; roadmap docs; reviewed repository artifacts; smoke reports when created by workflow | Explicit maintainer session state rules; clean handoff template; guidance against always-changing root progress files | #97 defines session lifecycle and handoff | A root `progress.md` or feature-list file is deferred because GitHub issues and PRs are the primary progress state and root churn should be avoided |
+| Verification | `tests/validation/run-all.ps1`; focused validators under `tests/validation/`; JSON schemas in `contracts/*`; GitHub Actions; `git diff --check`; scope guard review | Toolchain freshness validator; answer smoke fixture validator; normalization runtime asset validator; planning prerequisites for article/video validators | #96, #100, and #101 add concrete validators; #102 and #103 plan future ingest validators | Online latest-version checks in CI remain deferred because CI should not depend on network freshness checks |
+| Scope | Issue scope, non-goals, acceptance, dependencies, labels, and milestone; ADR invariants; contracts; `AGENTS.md` operating lanes | Explicit Codex-to-Hermes request/response boundaries; local skill promotion path; repeated restatement of target issue acceptance before implementation | #98 defines delegation scope; #99 defines skill promotion boundaries; #97 requires target issue scope restatement | Runtime answer behavior changes remain deferred until assets, smoke, and adapter changes are separately reviewed |
+| Session lifecycle / handoff | The v2.1 issue-to-PR pattern; PR validation sections; final implementation summaries; clean worktree checks in practice | A canonical workflow for start-of-session checks, during-session state, end-of-session handoff, warnings, unresolved items, and next action | #97 defines `workflows/maintainer-agent-session.md` | Durable Kanban, cron reminders, and checkpoint policy remain deferred until local state and promotion boundaries are documented |
+
+## Gap To Issue Mapping
+
+| Gap | Why it matters | v2.2 issue |
+|---|---|---|
+| Harness map for Hermes Growth Operations | Prevents v2.2 from becoming a loose collection of Hermes usage ideas | #95 |
+| Maintainer toolchain freshness policy | Tracks required/planned Codex and Hermes capabilities without storing local machine state | #96 |
+| Session lifecycle and clean handoff | Makes multi-session agent work restartable and reviewable | #97 |
+| Codex-to-Hermes delegation request/response shape | Turns Hermes Growth Lane delegation into a structured handoff instead of oral convention | #98 |
+| Hermes local skill self-improvement promotion path | Allows procedural learning while preventing automatic canonicalization | #99 |
+| Normalization runtime generation and packaging | Converts canonical alias data into derived runtime assets without changing answer behavior | #100 |
+| Contract-level answer smoke skeleton | Adds fixture-level smoke coverage before operational prompt execution | #101 |
+| Article ingest planning | Separates source metadata, candidate claims, review, copyright, and future wrapper work | #102 |
+| Video observation planning | Separates observation-only media artifacts from exact current facts and coaching conclusions | #103 |
+
+## Authority Model
+
+The map keeps three lanes separate:
+
+- Repo implementation lane: Codex implements issue-scoped PRs, validators,
+  contracts, docs, packaging changes, and GitHub workflow operations.
+- Hermes growth lane: Hermes may assist with source analysis, claim
+  decomposition, observation drafting, review drafting, smoke drafting,
+  workflow learning, validator-pattern learning, and procedural skill
+  self-improvement when configured.
+- Public user lane: users consume `skills/sf6-agent/`; Hermes is optional and
+  not required for public answering.
+
+Hermes output is draft material until reviewed. It may become a repository
+artifact only through the same repo review path as other maintainer work:
+issue scope, local edits, validators, PR, review, and merge.
+
+## Verification Principle
+
+Completion is based on verification results, not agent confidence.
+
+For v2.2 work, the relevant verification surface is usually a combination of:
+
+- targeted validators for the changed surface
+- `tests/validation/run-all.ps1`
+- `git diff --check`
+- scope guard review against the issue non-goals
+- clean worktree and handoff reporting
+
+When Windows PowerShell cannot see Git during generated-surface checks, the
+handoff should report that warning and separately verify from a git-visible
+environment that generated references, `.dist`, frame-current assets, and
+normalization runtime assets have no residual diff.
+
+## Deferred Harness Surfaces
+
+| Deferred surface | Reason |
+|---|---|
+| Hermes operational prompt bodies | Contracts, smoke skeletons, and delegation/promotion policy should precede prompt bodies |
+| Root progress file or always-changing feature list | GitHub issues and PRs are the primary progress state; root churn should require a later decision |
+| Production cron jobs | Cron may report freshness later, but automatic canonical promotion is not allowed |
+| MCP and gateway config | External tool bridges and notifications need separate authority and secret-handling policy |
+| Automatic Curator-to-repo promotion | Curator may manage local agent-created skills, but repo promotion requires PR review |
+| Runtime answer behavior changes for normalization assets | #100 may package assets for future use, but lookup, routing, and answer composition need separate review |
+

--- a/docs/architecture/hermes-growth-harness-map.md
+++ b/docs/architecture/hermes-growth-harness-map.md
@@ -7,8 +7,10 @@ operations for v2.2.
 
 External harness engineering material is reference input only. It is not
 canonical SF6 repo authority. SF6 repo architecture decisions, contracts,
-workflows, validators, GitHub issues, pull requests, and reviewed repository
-artifacts remain authoritative.
+workflows, validators, and reviewed repository artifacts remain authoritative
+for repository behavior and canonical surfaces. GitHub issues and pull
+requests are authoritative for task scope, progress state, review, and handoff;
+they are not canonical SF6 gameplay knowledge or exact current-fact authority.
 
 v2.2 uses this map to keep Hermes Growth Operations concrete. Hermes is the
 repo-local growth engine when a configured maintainer profile is available,

--- a/docs/architecture/hermes-growth-harness-map.md
+++ b/docs/architecture/hermes-growth-harness-map.md
@@ -96,4 +96,3 @@ normalization runtime assets have no residual diff.
 | MCP and gateway config | External tool bridges and notifications need separate authority and secret-handling policy |
 | Automatic Curator-to-repo promotion | Curator may manage local agent-created skills, but repo promotion requires PR review |
 | Runtime answer behavior changes for normalization assets | #100 may package assets for future use, but lookup, routing, and answer composition need separate review |
-


### PR DESCRIPTION
## Summary

- Add `docs/architecture/hermes-growth-harness-map.md` for #95.
- Map harness subsystems to current SF6 repo surfaces, v2.2 gaps, issue mappings, and deferred items.
- Link the new map from `docs/architecture/README.md`.

## Scope

This is documentation-only work for Issue #95.

The map covers:
- Instructions
- State
- Verification
- Scope
- Session lifecycle / handoff

It treats external harness engineering material as reference only. SF6 repo ADRs, contracts, workflows, validators, and reviewed repo artifacts remain authoritative for repository behavior and canonical surfaces. GitHub issues and PRs are authoritative for task scope, progress state, review, and handoff; they are not canonical SF6 gameplay knowledge or exact current-fact authority.

Closes #95.

## Validation

- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1`
- `git diff --check`
- WSL git-visible check confirmed no residual diff under `skills/sf6-agent/references`, `.dist`, `skills/sf6-agent/assets/frame-current`, or `skills/sf6-agent/assets/normalization`.

Windows PowerShell reported expected git-unavailable warnings during generated-surface status checks; those were separately checked from WSL.

## Not included

- #96+ are not implemented.
- No Hermes prompts were added.
- No runtime config was added.
- No ingest wrappers were added.
- No validators were added.
- No toolchain manifest was added.
- No normalization runtime assets were added.
- No generated outputs, frame-current assets, `.dist`, historical smoke reports, or public `sf6-agent` behavior were changed.
