### PR TITLE
[v2.2] Track maintainer agent toolchain freshness

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -26,3 +26,8 @@ When `source_refs.path` points to a migrated legacy file, `source_revision` iden
 
 - `normalization-aliases.schema.json`: query-normalization alias contract for mapping user language to structured lookup inputs.
 - `data/aliases/`: canonical query-normalization support, not exact current-fact authority. Exact current facts remain grounded in `data/exports/` and `data/roster/`.
+
+## Maintainer Toolchain Contracts
+
+- `agent-toolchain.schema.json`: maintainer agent toolchain policy contract for reviewed capabilities and freshness expectations.
+- `data/toolchain/`: canonical maintainer-toolchain policy data, not SF6 gameplay knowledge or exact current-fact authority.

--- a/contracts/agent-toolchain.schema.json
+++ b/contracts/agent-toolchain.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sf6-knowledge-agent-kit.local/agent-toolchain.schema.json",
+  "title": "Agent Toolchain",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "last_reviewed",
+    "tools",
+    "boundaries"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "agent-toolchain/v1"
+    },
+    "last_reviewed": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+    "tools": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "role",
+          "recommended_channel",
+          "known_good_version",
+          "required_capabilities",
+          "planned_capabilities",
+          "version_command",
+          "version_command_review_note",
+          "update_guidance",
+          "freshness_review_cadence"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "enum": [
+              "codex-cli",
+              "hermes-cli"
+            ]
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "repo_implementation_executor",
+              "repo_local_growth_engine"
+            ]
+          },
+          "recommended_channel": {
+            "type": "string",
+            "enum": [
+              "latest_stable",
+              "known_good",
+              "manual_review_required"
+            ]
+          },
+          "known_good_version": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "required_capabilities": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "uniqueItems": true
+          },
+          "planned_capabilities": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "uniqueItems": true
+          },
+          "version_command": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "version_command_review_note": {
+            "type": "string",
+            "minLength": 1
+          },
+          "update_guidance": {
+            "type": "string",
+            "minLength": 1
+          },
+          "freshness_review_cadence": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "boundaries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/data/toolchain/README.md
+++ b/data/toolchain/README.md
@@ -1,0 +1,13 @@
+# Maintainer Agent Toolchain Policy Data
+
+`data/toolchain/` is canonical maintainer-toolchain policy data.
+
+It is not SF6 gameplay knowledge. It is not exact current-fact authority.
+Exact current facts remain grounded in `data/exports/` and `data/roster/`.
+
+This directory must not contain local installed versions, local configs,
+credentials, sessions, caches, logs, tokens, or secrets. It must not be used to
+require Codex CLI or Hermes CLI for public `sf6-agent` users.
+
+The policy files in this directory record reviewed expectations and
+required/planned maintainer capabilities, not local machine state.

--- a/data/toolchain/maintainer-agent-toolchain.json
+++ b/data/toolchain/maintainer-agent-toolchain.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": "agent-toolchain/v1",
+  "last_reviewed": "2026-05-10",
+  "tools": [
+    {
+      "id": "codex-cli",
+      "role": "repo_implementation_executor",
+      "recommended_channel": "latest_stable",
+      "known_good_version": null,
+      "required_capabilities": [
+        "repo_file_editing",
+        "validator_execution",
+        "draft_pr_creation"
+      ],
+      "planned_capabilities": [],
+      "version_command": null,
+      "version_command_review_note": "Record only if verified from official OpenAI Codex CLI docs.",
+      "update_guidance": "Use official OpenAI Codex CLI docs.",
+      "freshness_review_cadence": "before_v2_2_prs"
+    },
+    {
+      "id": "hermes-cli",
+      "role": "repo_local_growth_engine",
+      "recommended_channel": "latest_stable",
+      "known_good_version": null,
+      "required_capabilities": [
+        "repo_local_orchestration",
+        "subagent_review",
+        "local_skill_operations"
+      ],
+      "planned_capabilities": [
+        "curator",
+        "session_search",
+        "goal_checkpoints",
+        "cron_freshness_audits"
+      ],
+      "version_command": null,
+      "version_command_review_note": "Confirm from official Hermes CLI docs before pinning this command.",
+      "update_guidance": "Use official Hermes release or install documentation.",
+      "freshness_review_cadence": "before_growth_workflows"
+    }
+  ],
+  "boundaries": [
+    "toolchain policy is not SF6 gameplay knowledge",
+    "local tool state is non-canonical",
+    "CI must not call the internet for latest-version checks"
+  ]
+}

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -6,6 +6,7 @@ Architecture docs define the v2 source-of-truth model.
 - [decisions/](./decisions/README.md)
 - [hermes-v2.1-roadmap.md](./hermes-v2.1-roadmap.md)
 - [hermes-growth-harness-map.md](./hermes-growth-harness-map.md)
+- [agent-toolchain-freshness.md](./agent-toolchain-freshness.md)
 - [language-policy.md](./language-policy.md)
 - [harness-and-distribution-roles.md](./harness-and-distribution-roles.md)
 - [japanese-maintainer-docs-policy.md](./japanese-maintainer-docs-policy.md)

--- a/docs/architecture/agent-toolchain-freshness.md
+++ b/docs/architecture/agent-toolchain-freshness.md
@@ -1,0 +1,68 @@
+# Agent Toolchain Freshness
+
+## Purpose
+
+This document defines how the SF6 repo tracks maintainer agent toolchain
+freshness for v2.2 Hermes Growth Operations.
+
+Toolchain freshness tracking is for maintainer operations only. It records
+reviewed expectations, required capabilities, planned capabilities, and review
+cadence for local maintainer tools. It does not record local installed
+versions or local machine inventory.
+
+## Roles
+
+Codex CLI is the normal repo implementation executor. It is used for
+issue-scoped edits, validators, contracts, docs, packaging changes, GitHub
+workflow operations, commits, pushes, and draft PR creation.
+
+Hermes CLI is the repo-local growth engine when a configured maintainer profile
+is available. Hermes may support knowledge-growth and maintainer-growth work
+such as subagent review, local procedural skill operations, session recall,
+Curator review, goal/checkpoint handling, and future freshness audits.
+
+End users do not need Codex CLI or Hermes CLI to use `skills/sf6-agent/`.
+
+## Authority Boundary
+
+Toolchain policy is not SF6 gameplay knowledge. It is not exact current-fact
+authority. Exact current facts remain grounded in `data/exports/` and
+`data/roster/`.
+
+Local tool state is non-canonical. Do not store local installed versions,
+local config, local sessions, caches, logs, credentials, tokens, or secrets in
+the repo.
+
+The canonical maintainer-toolchain policy data lives under `data/toolchain/`.
+That data records reviewed expectations and required/planned capabilities, not
+the state of any maintainer machine.
+
+## Freshness Policy
+
+The repo tracks reviewed freshness, not newest-at-any-cost freshness.
+
+Use these concepts:
+
+- `recommended_channel`: the review target, such as `latest_stable`.
+- `known_good_version`: a reviewed version when pinned; otherwise `null`.
+- `required_capabilities`: capabilities expected for current v2.2 workflows.
+- `planned_capabilities`: capabilities expected to matter for later v2.2 work.
+- `last_reviewed`: when the policy was last reviewed.
+- `freshness_review_cadence`: when maintainers should revisit the tool entry.
+
+Newest versions should be reviewed before being treated as known-good. Version
+and update commands should be recorded only when verified from official docs or
+release sources. If a command is not verified, leave it nullable and include a
+review note.
+
+CI validators must not perform online latest-version checks. Online checks are
+manual workflow steps or future reporting tasks only.
+
+## Verification
+
+`tests/validation/validate-agent-toolchain.ps1` verifies the contract, policy
+manifest, documentation boundaries, and forbidden local-state paths. It does
+not call the internet.
+
+Future Hermes cron may report tool freshness, but it must not auto-update
+tools and must not mutate canonical repo surfaces.

--- a/tests/validation/run-all.ps1
+++ b/tests/validation/run-all.ps1
@@ -36,6 +36,7 @@ $validationScripts = @(
   'tests/validation/validate-architecture-markers.ps1',
   'tests/validation/validate-hermes-pack.ps1',
   'tests/validation/validate-v2-contracts.ps1',
+  'tests/validation/validate-agent-toolchain.ps1',
   'tests/validation/validate-answer-orchestration-contracts.ps1',
   'tests/validation/validate-normalization-aliases.ps1',
   'tests/validation/validate-knowledge-schema.ps1',

--- a/tests/validation/validate-agent-toolchain.ps1
+++ b/tests/validation/validate-agent-toolchain.ps1
@@ -45,6 +45,32 @@ function Get-ToolchainRelativePath {
   return "$toolchainRootRelative/$($relative -replace '\\', '/')"
 }
 
+function Get-JsonPropertyNames {
+  param([AllowNull()][object]$Object)
+
+  if ($null -eq $Object) {
+    return
+  }
+
+  if ($Object -is [pscustomobject]) {
+    foreach ($property in $Object.PSObject.Properties) {
+      $property.Name
+      if ($null -ne $property.Value) {
+        Get-JsonPropertyNames $property.Value
+      }
+    }
+    return
+  }
+
+  if ($Object -is [System.Collections.IEnumerable] -and -not ($Object -is [string])) {
+    foreach ($item in $Object) {
+      if ($null -ne $item) {
+        Get-JsonPropertyNames $item
+      }
+    }
+  }
+}
+
 $issues = @()
 $requiredFiles = @(
   'docs/architecture/agent-toolchain-freshness.md',
@@ -53,7 +79,37 @@ $requiredFiles = @(
   $manifestPath,
   'workflows/check-agent-toolchain-freshness.md'
 )
+$allowedRootProperties = @(
+  'schema_version',
+  'last_reviewed',
+  'tools',
+  'boundaries'
+)
+$allowedToolProperties = @(
+  'id',
+  'role',
+  'recommended_channel',
+  'known_good_version',
+  'required_capabilities',
+  'planned_capabilities',
+  'version_command',
+  'version_command_review_note',
+  'update_guidance',
+  'freshness_review_cadence'
+)
+$allowedToolIds = @('codex-cli', 'hermes-cli')
+$allowedRoles = @('repo_implementation_executor', 'repo_local_growth_engine')
+$allowedRecommendedChannels = @('latest_stable', 'known_good', 'manual_review_required')
 $forbiddenManifestFields = @(
+  'secret',
+  'token',
+  'credential',
+  'session',
+  'cache',
+  'log',
+  'config',
+  'local_state',
+  'local_path',
   'local_installed_version',
   'installed_version',
   'current_version',
@@ -102,6 +158,12 @@ if (Test-Path -LiteralPath (Join-Path $repoRoot $manifestPath) -PathType Leaf) {
   $manifestRaw = Get-Content -LiteralPath (Join-Path $repoRoot $manifestPath) -Raw -Encoding UTF8
   $manifest = $manifestRaw | ConvertFrom-Json
 
+  foreach ($propertyName in @($manifest.PSObject.Properties.Name)) {
+    if ($allowedRootProperties -notcontains $propertyName) {
+      $issues += "$manifestPath contains unsupported root property: $propertyName"
+    }
+  }
+
   foreach ($field in @('schema_version', 'last_reviewed', 'tools', 'boundaries')) {
     Assert-Property $manifest $field $manifestPath ([ref]$issues)
   }
@@ -110,9 +172,13 @@ if (Test-Path -LiteralPath (Join-Path $repoRoot $manifestPath) -PathType Leaf) {
     $issues += "$manifestPath must use schema_version agent-toolchain/v1"
   }
 
-  foreach ($field in $forbiddenManifestFields) {
-    if ($manifestRaw -match ('"(?i:' + [regex]::Escape($field) + ')"\s*:')) {
-      $issues += "$manifestPath contains forbidden local-state field: $field"
+  foreach ($propertyName in @(Get-JsonPropertyNames $manifest)) {
+    $propertyNameLower = $propertyName.ToLowerInvariant()
+    foreach ($field in $forbiddenManifestFields) {
+      if ($propertyNameLower.Contains($field)) {
+        $issues += "$manifestPath contains forbidden local-state or secret-like property: $propertyName"
+        break
+      }
     }
   }
 
@@ -147,6 +213,11 @@ if (Test-Path -LiteralPath (Join-Path $repoRoot $manifestPath) -PathType Leaf) {
 
     foreach ($tool in $tools) {
       $toolId = if (Test-Property $tool 'id') { [string]$tool.id } else { '<missing-id>' }
+      foreach ($propertyName in @($tool.PSObject.Properties.Name)) {
+        if ($allowedToolProperties -notcontains $propertyName) {
+          $issues += "$manifestPath tool $toolId contains unsupported property: $propertyName"
+        }
+      }
       foreach ($field in @(
         'recommended_channel',
         'known_good_version',
@@ -160,6 +231,15 @@ if (Test-Path -LiteralPath (Join-Path $repoRoot $manifestPath) -PathType Leaf) {
         Assert-Property $tool $field "$manifestPath tool $toolId" ([ref]$issues)
       }
 
+      if ((Test-Property $tool 'id') -and $allowedToolIds -notcontains [string]$tool.id) {
+        $issues += "$manifestPath tool $toolId has unsupported id: $($tool.id)"
+      }
+      if ((Test-Property $tool 'role') -and $allowedRoles -notcontains [string]$tool.role) {
+        $issues += "$manifestPath tool $toolId has unsupported role: $($tool.role)"
+      }
+      if ((Test-Property $tool 'recommended_channel') -and $allowedRecommendedChannels -notcontains [string]$tool.recommended_channel) {
+        $issues += "$manifestPath tool $toolId has unsupported recommended_channel: $($tool.recommended_channel)"
+      }
       if ((Test-Property $tool 'required_capabilities') -and @($tool.required_capabilities).Count -eq 0) {
         $issues += "$manifestPath tool $toolId must include required_capabilities"
       }

--- a/tests/validation/validate-agent-toolchain.ps1
+++ b/tests/validation/validate-agent-toolchain.ps1
@@ -1,0 +1,258 @@
+Set-StrictMode -Version Latest
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$toolchainRootRelative = 'data/toolchain'
+$toolchainRoot = Join-Path $repoRoot $toolchainRootRelative
+$schemaPath = 'contracts/agent-toolchain.schema.json'
+$manifestPath = 'data/toolchain/maintainer-agent-toolchain.json'
+
+function Read-Json {
+  param([Parameter(Mandatory = $true)][string]$RelativePath)
+  return Get-Content -LiteralPath (Join-Path $repoRoot $RelativePath) -Raw -Encoding UTF8 | ConvertFrom-Json
+}
+
+function Read-Text {
+  param([Parameter(Mandatory = $true)][string]$RelativePath)
+  return Get-Content -LiteralPath (Join-Path $repoRoot $RelativePath) -Raw -Encoding UTF8
+}
+
+function Test-Property {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name
+  )
+  return $null -ne $Object.PSObject.Properties[$Name]
+}
+
+function Assert-Property {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+  if (-not (Test-Property $Object $Name)) {
+    $Issues.Value += "$Context missing property: $Name"
+  }
+}
+
+function Get-ToolchainRelativePath {
+  param([Parameter(Mandatory = $true)][string]$FullPath)
+
+  $root = (Resolve-Path $toolchainRoot).Path.TrimEnd([char[]]@('\', '/'))
+  $relative = $FullPath.Substring($root.Length)
+  $relative = $relative -replace '^[\\/]+', ''
+  return "$toolchainRootRelative/$($relative -replace '\\', '/')"
+}
+
+$issues = @()
+$requiredFiles = @(
+  'docs/architecture/agent-toolchain-freshness.md',
+  $schemaPath,
+  'data/toolchain/README.md',
+  $manifestPath,
+  'workflows/check-agent-toolchain-freshness.md'
+)
+$forbiddenManifestFields = @(
+  'local_installed_version',
+  'installed_version',
+  'current_version',
+  'local_version',
+  'detected_version',
+  'home_path',
+  'config_path',
+  'cache_path',
+  'session_path',
+  'log_path'
+)
+
+foreach ($relativePath in $requiredFiles) {
+  if (-not (Test-Path -LiteralPath (Join-Path $repoRoot $relativePath) -PathType Leaf)) {
+    $issues += "Missing agent toolchain file: $relativePath"
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot $schemaPath) -PathType Leaf) {
+  $schema = Read-Json $schemaPath
+  foreach ($field in @('$schema', '$id', 'title')) {
+    Assert-Property $schema $field $schemaPath ([ref]$issues)
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot 'data/toolchain/README.md') -PathType Leaf) {
+  $readme = Read-Text 'data/toolchain/README.md'
+  foreach ($needle in @(
+    'not SF6 gameplay knowledge',
+    'not exact current-fact authority',
+    'local installed versions',
+    'credentials',
+    'secrets',
+    'local configs',
+    'sessions',
+    'caches',
+    'logs'
+  )) {
+    if ($readme -notmatch [regex]::Escape($needle)) {
+      $issues += "data/toolchain/README.md missing boundary text: $needle"
+    }
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot $manifestPath) -PathType Leaf) {
+  $manifestRaw = Get-Content -LiteralPath (Join-Path $repoRoot $manifestPath) -Raw -Encoding UTF8
+  $manifest = $manifestRaw | ConvertFrom-Json
+
+  foreach ($field in @('schema_version', 'last_reviewed', 'tools', 'boundaries')) {
+    Assert-Property $manifest $field $manifestPath ([ref]$issues)
+  }
+
+  if ((Test-Property $manifest 'schema_version') -and $manifest.schema_version -ne 'agent-toolchain/v1') {
+    $issues += "$manifestPath must use schema_version agent-toolchain/v1"
+  }
+
+  foreach ($field in $forbiddenManifestFields) {
+    if ($manifestRaw -match ('"(?i:' + [regex]::Escape($field) + ')"\s*:')) {
+      $issues += "$manifestPath contains forbidden local-state field: $field"
+    }
+  }
+
+  if (Test-Property $manifest 'tools') {
+    $tools = @($manifest.tools)
+    $toolsById = @{}
+    foreach ($tool in $tools) {
+      if (Test-Property $tool 'id') {
+        $toolsById[[string]$tool.id] = $tool
+      }
+    }
+
+    foreach ($toolId in @('codex-cli', 'hermes-cli')) {
+      if (-not $toolsById.ContainsKey($toolId)) {
+        $issues += "$manifestPath missing tool entry: $toolId"
+      }
+    }
+
+    if ($toolsById.ContainsKey('codex-cli')) {
+      $codex = $toolsById['codex-cli']
+      if ((Test-Property $codex 'role') -and $codex.role -ne 'repo_implementation_executor') {
+        $issues += 'codex-cli must use role repo_implementation_executor'
+      }
+    }
+
+    if ($toolsById.ContainsKey('hermes-cli')) {
+      $hermes = $toolsById['hermes-cli']
+      if ((Test-Property $hermes 'role') -and $hermes.role -ne 'repo_local_growth_engine') {
+        $issues += 'hermes-cli must use role repo_local_growth_engine'
+      }
+    }
+
+    foreach ($tool in $tools) {
+      $toolId = if (Test-Property $tool 'id') { [string]$tool.id } else { '<missing-id>' }
+      foreach ($field in @(
+        'recommended_channel',
+        'known_good_version',
+        'required_capabilities',
+        'planned_capabilities',
+        'version_command',
+        'version_command_review_note',
+        'update_guidance',
+        'freshness_review_cadence'
+      )) {
+        Assert-Property $tool $field "$manifestPath tool $toolId" ([ref]$issues)
+      }
+
+      if ((Test-Property $tool 'required_capabilities') -and @($tool.required_capabilities).Count -eq 0) {
+        $issues += "$manifestPath tool $toolId must include required_capabilities"
+      }
+      if ((Test-Property $tool 'version_command') -and $null -ne $tool.version_command) {
+        if (-not (Test-Property $tool 'version_command_review_note') -or [string]::IsNullOrWhiteSpace([string]$tool.version_command_review_note)) {
+          $issues += "$manifestPath tool $toolId with version_command must include version_command_review_note"
+        }
+      }
+    }
+
+    if ($toolsById.ContainsKey('hermes-cli')) {
+      $hermes = $toolsById['hermes-cli']
+      $capabilities = @()
+      if (Test-Property $hermes 'required_capabilities') {
+        $capabilities += @($hermes.required_capabilities)
+      }
+      if (Test-Property $hermes 'planned_capabilities') {
+        $capabilities += @($hermes.planned_capabilities)
+      }
+      $capabilityText = (($capabilities | ForEach-Object { [string]$_ }) -join ' ').ToLowerInvariant()
+
+      $capabilityChecks = @{
+        'subagents or delegation' = @('subagent', 'delegation')
+        'local skills' = @('skill')
+        'Curator' = @('curator')
+        'session search' = @('session_search', 'session search')
+        '/goal or checkpoints' = @('goal', 'checkpoint')
+        'cron or freshness audits' = @('cron', 'freshness')
+      }
+
+      foreach ($label in $capabilityChecks.Keys) {
+        $found = $false
+        foreach ($needle in $capabilityChecks[$label]) {
+          if ($capabilityText.Contains($needle)) {
+            $found = $true
+          }
+        }
+        if (-not $found) {
+          $issues += "hermes-cli capabilities must include $label"
+        }
+      }
+    }
+  }
+
+  if (Test-Property $manifest 'boundaries') {
+    $boundaryText = (@($manifest.boundaries) -join ' ')
+    foreach ($needle in @(
+      'toolchain policy is not SF6 gameplay knowledge',
+      'local tool state is non-canonical',
+      'CI must not call the internet for latest-version checks'
+    )) {
+      if ($boundaryText -notmatch [regex]::Escape($needle)) {
+        $issues += "$manifestPath missing boundary: $needle"
+      }
+    }
+  }
+}
+
+if (-not (Test-Path -LiteralPath $toolchainRoot -PathType Container)) {
+  $issues += "Missing toolchain root: $toolchainRootRelative"
+} else {
+  foreach ($item in Get-ChildItem -LiteralPath $toolchainRoot -Force -Recurse -File) {
+    $name = $item.Name.ToLowerInvariant()
+    $relativePath = Get-ToolchainRelativePath $item.FullName
+    $relativePathLower = $relativePath.ToLowerInvariant()
+
+    if (
+      $name -eq '.env' -or
+      $name -like '.env.*' -or
+      $name -eq '.envrc' -or
+      $name -like '*secret*' -or
+      $name -like '*token*' -or
+      $name -like '*credential*' -or
+      $name -like '*session*' -or
+      $name -like '*cache*' -or
+      $name -like '*log*' -or
+      $relativePathLower -like '*/.env' -or
+      $relativePathLower -like '*/.env.*' -or
+      $relativePathLower -like '*/.envrc' -or
+      $relativePathLower -like '*secret*' -or
+      $relativePathLower -like '*token*' -or
+      $relativePathLower -like '*credential*' -or
+      $relativePathLower -like '*session*' -or
+      $relativePathLower -like '*cache*' -or
+      $relativePathLower -like '*log*'
+    ) {
+      $issues += "Forbidden toolchain local-state or secret-like file: $relativePath"
+    }
+  }
+}
+
+if ($issues.Count -gt 0) {
+  throw ($issues -join '; ')
+}
+
+Write-Host 'Agent toolchain OK'

--- a/tests/validation/validate-v2-contracts.ps1
+++ b/tests/validation/validate-v2-contracts.ps1
@@ -12,7 +12,8 @@ $requiredJsonSchemas = @(
   'contracts/answer-intent.schema.json',
   'contracts/evidence-card.schema.json',
   'contracts/answer-plan.schema.json',
-  'contracts/normalization-aliases.schema.json'
+  'contracts/normalization-aliases.schema.json',
+  'contracts/agent-toolchain.schema.json'
 )
 
 $requiredDocs = @(

--- a/workflows/check-agent-toolchain-freshness.md
+++ b/workflows/check-agent-toolchain-freshness.md
@@ -1,0 +1,50 @@
+# Check Agent Toolchain Freshness
+
+## Purpose
+
+Use this workflow to manually review maintainer agent toolchain freshness for
+Codex CLI and Hermes CLI.
+
+This workflow does not make local tool state canonical. The canonical policy
+surface is `data/toolchain/maintainer-agent-toolchain.json`, which records
+reviewed expectations and capabilities, not local installed versions.
+
+## Manual Review Steps
+
+1. Read `data/toolchain/README.md`.
+2. Read `data/toolchain/maintainer-agent-toolchain.json`.
+3. Review the official documentation or release source for each tool.
+4. Check whether the local tool can provide the required or planned
+   capabilities needed for current maintainer work.
+5. Record policy changes only when they are reviewed and useful to future
+   maintainers.
+
+Version and update commands should be used only when verified from official
+docs or release sources. If a command is not verified, keep the command field
+nullable in the manifest and include a review note.
+
+## Boundaries
+
+- Do not store local installed versions in canonical policy data.
+- Do not commit local configs, sessions, logs, caches, tokens, credentials, or
+  secrets.
+- Do not use this workflow to require Codex CLI or Hermes CLI for public
+  `sf6-agent` users.
+- CI validators must not perform online latest-version checks.
+- Future Hermes cron may report freshness, but it must not auto-update tools
+  or mutate canonical repo surfaces.
+
+## Validation
+
+After editing toolchain policy data, run:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-agent-toolchain.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-v2-contracts.ps1
+```
+
+Before opening a PR, also run the full validation suite:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1
+```


### PR DESCRIPTION
## Summary

- Add maintainer agent toolchain freshness policy surfaces for #96.
- Add `contracts/agent-toolchain.schema.json`, `data/toolchain/maintainer-agent-toolchain.json`, and `tests/validation/validate-agent-toolchain.ps1`.
- Add workflow guidance for manual toolchain freshness review and wire the validator into the v2 validation suite.

## Scope

This implements Issue #96 only.

It records reviewed toolchain expectations and required/planned capabilities for:
- Codex CLI as the repo implementation executor.
- Hermes CLI as the repo-local growth engine when configured.

Closes #96.

## Validation

- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-agent-toolchain.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-v2-contracts.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- WSL git-visible check confirmed no residual diff under `skills/sf6-agent/references`, `.dist`, `skills/sf6-agent/assets/frame-current`, or `skills/sf6-agent/assets/normalization`.

Windows PowerShell reported expected git-unavailable warnings during generated-surface status checks; those were separately checked from WSL.

## Not included

- #97+ are not implemented.
- No online CI checks were added.
- No local tool state, local installed versions, credentials, logs, caches, sessions, tokens, or secrets were committed.
- No Hermes prompts were added.
- No runtime config was added.
- No Codex-to-Hermes delegation workflow or Hermes growth workflow was added.
- No normalization runtime assets were added.
- No generated outputs, frame-current assets, historical smoke reports, `.dist`, or public `sf6-agent` behavior were changed.
