### PR TITLE
[v2.2] Add normalization runtime asset generator and packaging integration

### DIFF
--- a/packages/skill-packaging/build-normalization-runtime-assets.ps1
+++ b/packages/skill-packaging/build-normalization-runtime-assets.ps1
@@ -1,0 +1,124 @@
+Set-StrictMode -Version Latest
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$sourceRootRelativePath = 'data/aliases'
+$assetRootRelativePath = 'skills/sf6-agent/assets/normalization'
+$generatorRelativePath = 'packages/skill-packaging/build-normalization-runtime-assets.ps1'
+$sourceRoot = Join-Path $repoRoot $sourceRootRelativePath
+$assetRoot = Join-Path $repoRoot $assetRootRelativePath
+$aliasesOutputPath = Join-Path $assetRoot 'aliases.json'
+$manifestOutputPath = Join-Path $assetRoot 'runtime_manifest.json'
+
+function ConvertTo-RepoRelativePath {
+  param([Parameter(Mandatory = $true)][string]$Path)
+
+  $resolved = (Resolve-Path -LiteralPath $Path).Path
+  if (-not $resolved.StartsWith($repoRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Path is outside repository root: $Path"
+  }
+
+  return $resolved.Substring($repoRoot.Length + 1).Replace('\', '/')
+}
+
+if (-not (Test-Path -LiteralPath $sourceRoot -PathType Container)) {
+  throw "Missing normalization alias source root: $sourceRootRelativePath"
+}
+
+if (Test-Path -LiteralPath $assetRoot) {
+  Remove-Item -LiteralPath $assetRoot -Recurse -Force
+}
+
+New-Item -ItemType Directory -Path $assetRoot -Force | Out-Null
+
+$sourceFiles = @(
+  Get-ChildItem -LiteralPath $sourceRoot -File -Filter '*.json' |
+    Sort-Object Name
+)
+
+if ($sourceFiles.Count -eq 0) {
+  throw "No normalization alias JSON files found under $sourceRootRelativePath"
+}
+
+$sourceRecords = @()
+$runtimeEntries = @()
+
+foreach ($sourceFile in $sourceFiles) {
+  $sourceRelativePath = ConvertTo-RepoRelativePath $sourceFile.FullName
+  $sourceRecords += [ordered]@{
+    path = $sourceRelativePath
+    sha256 = (Get-FileHash -LiteralPath $sourceFile.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+  }
+
+  $document = Get-Content -LiteralPath $sourceFile.FullName -Raw -Encoding UTF8 | ConvertFrom-Json
+  if ($document.schema_version -ne 'normalization-aliases/v1') {
+    throw "Unsupported normalization alias schema_version in $sourceRelativePath"
+  }
+  if ($document.kind -ne 'query_normalization_aliases') {
+    throw "Unsupported normalization alias kind in $sourceRelativePath"
+  }
+  if ($document.authority -ne 'query_normalization_only') {
+    throw "Normalization alias source must be query_normalization_only: $sourceRelativePath"
+  }
+  if ($document.not_current_fact_authority -ne $true) {
+    throw "Normalization alias source must set not_current_fact_authority true: $sourceRelativePath"
+  }
+
+  foreach ($entry in @($document.entries)) {
+    $normalized = [ordered]@{}
+    foreach ($property in @($entry.normalized.PSObject.Properties | Sort-Object Name)) {
+      $normalized[$property.Name] = $property.Value
+    }
+
+    $runtimeEntries += [ordered]@{
+      id = [string]$entry.id
+      alias_kind = [string]$entry.alias_kind
+      aliases = @($entry.aliases)
+      normalized = $normalized
+      source_path = $sourceRelativePath
+    }
+  }
+}
+
+$runtimeEntries = @($runtimeEntries | Sort-Object { $_.source_path }, { $_.id })
+
+$aliasesDocument = [ordered]@{
+  generated = $true
+  schema_version = 'normalization-runtime/v1'
+  kind = 'query_normalization_runtime_assets'
+  authority = 'query_normalization_only'
+  not_current_fact_authority = $true
+  generator = $generatorRelativePath
+  source_paths = @($sourceRecords.path)
+  target_path = "$assetRootRelativePath/aliases.json"
+  entries = $runtimeEntries
+}
+
+$utf8NoBom = New-Object System.Text.UTF8Encoding $false
+$aliasesJson = ((($aliasesDocument | ConvertTo-Json -Depth 10) -replace "`r`n", "`n").TrimEnd() + "`n")
+[System.IO.File]::WriteAllText($aliasesOutputPath, $aliasesJson, $utf8NoBom)
+
+$manifestDocument = [ordered]@{
+  generated = $true
+  schema_version = 'normalization-runtime-manifest/v1'
+  kind = 'query_normalization_runtime_manifest'
+  authority = 'query_normalization_only'
+  not_current_fact_authority = $true
+  generator = $generatorRelativePath
+  source_root = $sourceRootRelativePath
+  asset_root = $assetRootRelativePath
+  source_paths = $sourceRecords
+  target_path = "$assetRootRelativePath/runtime_manifest.json"
+  files = @(
+    [ordered]@{
+      target = 'aliases.json'
+      target_path = "$assetRootRelativePath/aliases.json"
+      source_paths = @($sourceRecords.path)
+      sha256 = (Get-FileHash -LiteralPath $aliasesOutputPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    }
+  )
+}
+
+$manifestJson = ((($manifestDocument | ConvertTo-Json -Depth 10) -replace "`r`n", "`n").TrimEnd() + "`n")
+[System.IO.File]::WriteAllText($manifestOutputPath, $manifestJson, $utf8NoBom)
+
+Write-Host 'Normalization runtime assets built'

--- a/packages/skill-packaging/build-release-bundle.ps1
+++ b/packages/skill-packaging/build-release-bundle.ps1
@@ -9,12 +9,15 @@ $stagingRoot = Join-Path $distRoot 'bundle-root'
 $bundlePath = Join-Path $distRoot 'sf6-agent-bundle.zip'
 $knowledgeGenerator = Join-Path $repoRoot 'packages/knowledge-generation/build-sf6-agent-knowledge.ps1'
 $frameAssetBuilder = Join-Path $repoRoot 'packages/skill-packaging/build-frame-current-runtime-assets.ps1'
+$normalizationAssetBuilder = Join-Path $repoRoot 'packages/skill-packaging/build-normalization-runtime-assets.ps1'
 $generatedValidator = Join-Path $repoRoot 'tests/validation/validate-generated-knowledge.ps1'
 $frameAssetValidator = Join-Path $repoRoot 'tests/validation/validate-frame-current-assets.ps1'
+$normalizationAssetValidator = Join-Path $repoRoot 'tests/validation/validate-normalization-runtime-assets.ps1'
 $derivedOutputPaths = @(
   'skills/sf6-agent/references/generated-knowledge-index.md',
   'skills/sf6-agent/references/generated-concepts.md',
-  'skills/sf6-agent/assets/frame-current'
+  'skills/sf6-agent/assets/frame-current',
+  'skills/sf6-agent/assets/normalization'
 )
 
 function Assert-NoDerivedOutputStatus {
@@ -38,7 +41,7 @@ if (-not (Test-Path -LiteralPath $agentRoot -PathType Container)) {
   throw 'Missing agent source: skills/sf6-agent'
 }
 
-foreach ($requiredScript in @($knowledgeGenerator, $frameAssetBuilder, $generatedValidator, $frameAssetValidator)) {
+foreach ($requiredScript in @($knowledgeGenerator, $frameAssetBuilder, $normalizationAssetBuilder, $generatedValidator, $frameAssetValidator, $normalizationAssetValidator)) {
   if (-not (Test-Path -LiteralPath $requiredScript -PathType Leaf)) {
     throw "Missing release preflight script: $requiredScript"
   }
@@ -48,8 +51,11 @@ foreach ($requiredScript in @($knowledgeGenerator, $frameAssetBuilder, $generate
 Assert-NoDerivedOutputStatus 'knowledge generation'
 & $frameAssetBuilder
 Assert-NoDerivedOutputStatus 'frame-current asset generation'
+& $normalizationAssetBuilder
+Assert-NoDerivedOutputStatus 'normalization asset generation'
 & $generatedValidator
 & $frameAssetValidator
+& $normalizationAssetValidator
 Assert-NoDerivedOutputStatus 'release preflight validation'
 
 if (Test-Path -LiteralPath $bundlePath) {

--- a/skills/sf6-agent/assets/normalization/aliases.json
+++ b/skills/sf6-agent/assets/normalization/aliases.json
@@ -1,0 +1,69 @@
+{
+    "generated":  true,
+    "schema_version":  "normalization-runtime/v1",
+    "kind":  "query_normalization_runtime_assets",
+    "authority":  "query_normalization_only",
+    "not_current_fact_authority":  true,
+    "generator":  "packages/skill-packaging/build-normalization-runtime-assets.ps1",
+    "source_paths":  [
+                         "data/aliases/ja-query-fixtures.json"
+                     ],
+    "target_path":  "skills/sf6-agent/assets/normalization/aliases.json",
+    "entries":  [
+                    {
+                        "id":  "ja-character-ryu",
+                        "alias_kind":  "character",
+                        "aliases":  [
+                                        "リュウ",
+                                        "Ryu",
+                                        "ryu"
+                                    ],
+                        "normalized":  {
+                                           "character_slug":  "ryu"
+                                       },
+                        "source_path":  "data/aliases/ja-query-fixtures.json"
+                    },
+                    {
+                        "id":  "ja-field-block-adv",
+                        "alias_kind":  "field",
+                        "aliases":  [
+                                        "ガードで何F",
+                                        "ガード硬直差",
+                                        "ガード有利不利",
+                                        "on block"
+                                    ],
+                        "normalized":  {
+                                           "field":  "block_adv"
+                                       },
+                        "source_path":  "data/aliases/ja-query-fixtures.json"
+                    },
+                    {
+                        "id":  "ja-move-ryu-2mp",
+                        "alias_kind":  "move_input",
+                        "aliases":  [
+                                        "屈中P",
+                                        "しゃがみ中P",
+                                        "2中P",
+                                        "2MP",
+                                        "cr.MP"
+                                    ],
+                        "normalized":  {
+                                           "move_input":  "2MP"
+                                       },
+                        "source_path":  "data/aliases/ja-query-fixtures.json"
+                    },
+                    {
+                        "id":  "ja-query-ryu-2mp-block-adv",
+                        "alias_kind":  "query_fixture",
+                        "aliases":  [
+                                        "リュウの屈中Pってガードで何F？"
+                                    ],
+                        "normalized":  {
+                                           "character_slug":  "ryu",
+                                           "field":  "block_adv",
+                                           "move_input":  "2MP"
+                                       },
+                        "source_path":  "data/aliases/ja-query-fixtures.json"
+                    }
+                ]
+}

--- a/skills/sf6-agent/assets/normalization/runtime_manifest.json
+++ b/skills/sf6-agent/assets/normalization/runtime_manifest.json
@@ -1,0 +1,27 @@
+{
+    "generated":  true,
+    "schema_version":  "normalization-runtime-manifest/v1",
+    "kind":  "query_normalization_runtime_manifest",
+    "authority":  "query_normalization_only",
+    "not_current_fact_authority":  true,
+    "generator":  "packages/skill-packaging/build-normalization-runtime-assets.ps1",
+    "source_root":  "data/aliases",
+    "asset_root":  "skills/sf6-agent/assets/normalization",
+    "source_paths":  [
+                         {
+                             "path":  "data/aliases/ja-query-fixtures.json",
+                             "sha256":  "21ead3e2f4a187010b2b6ee6e22741409d77542a45eb9ee924234ad35b5f633b"
+                         }
+                     ],
+    "target_path":  "skills/sf6-agent/assets/normalization/runtime_manifest.json",
+    "files":  [
+                  {
+                      "target":  "aliases.json",
+                      "target_path":  "skills/sf6-agent/assets/normalization/aliases.json",
+                      "source_paths":  [
+                                           "data/aliases/ja-query-fixtures.json"
+                                       ],
+                      "sha256":  "8f8b3588a4e1245263b2fce7943c16b3dada936d4392a634b9ffa86ce3897d24"
+                  }
+              ]
+}

--- a/tests/validation/run-all.ps1
+++ b/tests/validation/run-all.ps1
@@ -5,7 +5,8 @@ $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 $derivedOutputPaths = @(
   'skills/sf6-agent/references/generated-knowledge-index.md',
   'skills/sf6-agent/references/generated-concepts.md',
-  'skills/sf6-agent/assets/frame-current'
+  'skills/sf6-agent/assets/frame-current',
+  'skills/sf6-agent/assets/normalization'
 )
 
 function Assert-NoDerivedOutputStatus {
@@ -28,6 +29,7 @@ function Assert-NoDerivedOutputStatus {
 $preflightScripts = @(
   'packages/knowledge-generation/build-sf6-agent-knowledge.ps1',
   'packages/skill-packaging/build-frame-current-runtime-assets.ps1',
+  'packages/skill-packaging/build-normalization-runtime-assets.ps1',
   'packages/skill-packaging/build-release-bundle.ps1'
 )
 
@@ -39,6 +41,7 @@ $validationScripts = @(
   'tests/validation/validate-agent-toolchain.ps1',
   'tests/validation/validate-answer-orchestration-contracts.ps1',
   'tests/validation/validate-normalization-aliases.ps1',
+  'tests/validation/validate-normalization-runtime-assets.ps1',
   'tests/validation/validate-knowledge-schema.ps1',
   'tests/validation/validate-ingest-artifacts.ps1',
   'tests/validation/validate-video-artifacts.ps1',

--- a/tests/validation/validate-distribution.ps1
+++ b/tests/validation/validate-distribution.ps1
@@ -32,7 +32,9 @@ try {
     'sf6-agent/references/answer-policy.md',
     'sf6-agent/references/current-fact-policy.md',
     'sf6-agent/references/generated-knowledge-index.md',
-    'sf6-agent/assets/frame-current/runtime_manifest.json'
+    'sf6-agent/assets/frame-current/runtime_manifest.json',
+    'sf6-agent/assets/normalization/runtime_manifest.json',
+    'sf6-agent/assets/normalization/aliases.json'
   )) {
     if ($entries -notcontains $requiredEntry) {
       throw "Bundle missing required entry: $requiredEntry"

--- a/tests/validation/validate-normalization-aliases.ps1
+++ b/tests/validation/validate-normalization-aliases.ps1
@@ -226,10 +226,6 @@ if (Test-Path -LiteralPath $aliasesPath -PathType Container) {
   }
 }
 
-if (Test-Path -LiteralPath (Join-Path $repoRoot 'skills/sf6-agent/assets/normalization')) {
-  $issues += 'skills/sf6-agent/assets/normalization/ must not be created by this issue'
-}
-
 if (Get-Command git -ErrorAction SilentlyContinue) {
   $frameCurrentStatus = @(& git -C $repoRoot status --porcelain -- 'skills/sf6-agent/assets/frame-current')
   if ($LASTEXITCODE -ne 0) {

--- a/tests/validation/validate-normalization-runtime-assets.ps1
+++ b/tests/validation/validate-normalization-runtime-assets.ps1
@@ -7,6 +7,8 @@ $assetRoot = Join-Path $repoRoot $assetRootRelativePath
 $manifestRelativePath = "$assetRootRelativePath/runtime_manifest.json"
 $aliasesRelativePath = "$assetRootRelativePath/aliases.json"
 $generatorRelativePath = 'packages/skill-packaging/build-normalization-runtime-assets.ps1'
+$aliasesSourceRootRelativePath = 'data/aliases'
+$aliasesSourceRoot = [System.IO.Path]::GetFullPath((Join-Path $repoRoot $aliasesSourceRootRelativePath))
 
 function Read-Json {
   param([Parameter(Mandatory = $true)][string]$RelativePath)
@@ -30,6 +32,58 @@ function Assert-Property {
   )
   if (-not (Test-Property $Object $Name)) {
     $Issues.Value += "$Context missing property: $Name"
+  }
+}
+
+function Test-PathUnderDirectory {
+  param(
+    [Parameter(Mandatory = $true)][string]$CandidatePath,
+    [Parameter(Mandatory = $true)][string]$DirectoryPath
+  )
+
+  $resolvedCandidate = [System.IO.Path]::GetFullPath($CandidatePath)
+  $resolvedDirectory = [System.IO.Path]::GetFullPath($DirectoryPath).TrimEnd(
+    [System.IO.Path]::DirectorySeparatorChar,
+    [System.IO.Path]::AltDirectorySeparatorChar
+  )
+  $directoryPrefix = $resolvedDirectory + [System.IO.Path]::DirectorySeparatorChar
+
+  return (
+    $resolvedCandidate.Equals($resolvedDirectory, [System.StringComparison]::OrdinalIgnoreCase) -or
+    $resolvedCandidate.StartsWith($directoryPrefix, [System.StringComparison]::OrdinalIgnoreCase)
+  )
+}
+
+function Assert-DataAliasesSourcePath {
+  param(
+    [Parameter(Mandatory = $true)][string]$RelativePath,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues,
+    [AllowNull()][string]$ExpectedSha256 = $null
+  )
+
+  if ([System.IO.Path]::IsPathRooted($RelativePath)) {
+    $Issues.Value += "$Context source path must be repo-relative under data/aliases/: $RelativePath"
+    return
+  }
+
+  $candidatePath = [System.IO.Path]::GetFullPath((Join-Path $repoRoot $RelativePath))
+  if (-not (Test-PathUnderDirectory $candidatePath $aliasesSourceRoot)) {
+    $Issues.Value += "$Context source path must resolve under data/aliases/: $RelativePath"
+    return
+  }
+
+  if (-not (Test-Path -LiteralPath $candidatePath -PathType Leaf)) {
+    $Issues.Value += "$Context source path does not exist: $RelativePath"
+    return
+  }
+
+  if ($null -ne $ExpectedSha256 -and $ExpectedSha256 -ne '') {
+    $expectedHash = ([string]$ExpectedSha256).ToLowerInvariant()
+    $actualHash = (Get-FileHash -LiteralPath $candidatePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($expectedHash -ne $actualHash) {
+      $Issues.Value += "$Context source hash mismatch: $RelativePath"
+    }
   }
 }
 
@@ -122,11 +176,12 @@ if (Test-Path -LiteralPath (Join-Path $repoRoot $manifestRelativePath) -PathType
       foreach ($field in @('path', 'sha256')) {
         Assert-Property $sourcePathRecord $field "$manifestRelativePath source_paths entry" ([ref]$issues)
       }
-      if ((Test-Property $sourcePathRecord 'path') -and -not ([string]$sourcePathRecord.path).StartsWith('data/aliases/')) {
-        $issues += "$manifestRelativePath source path must point under data/aliases/: $($sourcePathRecord.path)"
-      }
-      if ((Test-Property $sourcePathRecord 'path') -and -not (Test-Path -LiteralPath (Join-Path $repoRoot $sourcePathRecord.path) -PathType Leaf)) {
-        $issues += "$manifestRelativePath source path does not exist: $($sourcePathRecord.path)"
+      if ((Test-Property $sourcePathRecord 'path') -and (Test-Property $sourcePathRecord 'sha256')) {
+        Assert-DataAliasesSourcePath `
+          -RelativePath ([string]$sourcePathRecord.path) `
+          -Context "$manifestRelativePath source_paths entry" `
+          -Issues ([ref]$issues) `
+          -ExpectedSha256 ([string]$sourcePathRecord.sha256)
       }
     }
   }
@@ -148,9 +203,10 @@ if (Test-Path -LiteralPath (Join-Path $repoRoot $manifestRelativePath) -PathType
       }
       if ((Test-Property $fileEntry 'source_paths')) {
         foreach ($sourcePath in @($fileEntry.source_paths)) {
-          if (-not ([string]$sourcePath).StartsWith('data/aliases/')) {
-            $issues += "$manifestRelativePath file source path must point under data/aliases/: $sourcePath"
-          }
+          Assert-DataAliasesSourcePath `
+            -RelativePath ([string]$sourcePath) `
+            -Context "$manifestRelativePath files entry" `
+            -Issues ([ref]$issues)
         }
       }
       if ((Test-Property $fileEntry 'sha256') -and (Test-Path -LiteralPath (Join-Path $repoRoot $aliasesRelativePath) -PathType Leaf)) {
@@ -211,9 +267,10 @@ if (Test-Path -LiteralPath (Join-Path $repoRoot $aliasesRelativePath) -PathType 
   }
   if (Test-Property $aliases 'source_paths') {
     foreach ($sourcePath in @($aliases.source_paths)) {
-      if (-not ([string]$sourcePath).StartsWith('data/aliases/')) {
-        $issues += "$aliasesRelativePath source path must point under data/aliases/: $sourcePath"
-      }
+      Assert-DataAliasesSourcePath `
+        -RelativePath ([string]$sourcePath) `
+        -Context $aliasesRelativePath `
+        -Issues ([ref]$issues)
     }
   }
   if ((Test-Property $aliases 'entries') -and @($aliases.entries).Count -eq 0) {

--- a/tests/validation/validate-normalization-runtime-assets.ps1
+++ b/tests/validation/validate-normalization-runtime-assets.ps1
@@ -87,7 +87,117 @@ function Assert-DataAliasesSourcePath {
   }
 }
 
+function ConvertTo-OrderedNormalizedObject {
+  param(
+    [Parameter(Mandatory = $true)][object]$Normalized,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  $orderedNormalized = [ordered]@{}
+  if ($Normalized -isnot [pscustomobject]) {
+    $Issues.Value += "$Context normalized must be an object"
+    return $orderedNormalized
+  }
+
+  foreach ($property in @($Normalized.PSObject.Properties | Sort-Object Name)) {
+    if ($allowedNormalizedProperties -notcontains $property.Name) {
+      $Issues.Value += "$Context normalized contains unsupported property: $($property.Name)"
+      continue
+    }
+    $orderedNormalized[$property.Name] = $property.Value
+  }
+
+  return $orderedNormalized
+}
+
+function ConvertTo-ComparableRuntimeEntry {
+  param(
+    [Parameter(Mandatory = $true)][object]$Entry,
+    [Parameter(Mandatory = $true)][string]$SourcePath,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues,
+    [switch]$RequireSourcePathProperty
+  )
+
+  $requiredFields = @('id', 'alias_kind', 'aliases', 'normalized')
+  if ($RequireSourcePathProperty) {
+    $requiredFields += 'source_path'
+  }
+
+  $hasRequiredFields = $true
+  foreach ($field in $requiredFields) {
+    if (-not (Test-Property $Entry $field)) {
+      $Issues.Value += "$Context missing property: $field"
+      $hasRequiredFields = $false
+    }
+  }
+  if (-not $hasRequiredFields) {
+    return $null
+  }
+
+  if ($allowedAliasKinds -notcontains ([string]$Entry.alias_kind)) {
+    $Issues.Value += "$Context has unsupported alias_kind: $($Entry.alias_kind)"
+  }
+
+  Assert-DataAliasesSourcePath `
+    -RelativePath $SourcePath `
+    -Context $Context `
+    -Issues $Issues
+
+  return [ordered]@{
+    id = [string]$Entry.id
+    alias_kind = [string]$Entry.alias_kind
+    aliases = @($Entry.aliases | ForEach-Object { [string]$_ })
+    normalized = ConvertTo-OrderedNormalizedObject `
+      -Normalized $Entry.normalized `
+      -Context $Context `
+      -Issues $Issues
+    source_path = $SourcePath
+  }
+}
+
+function ConvertTo-CompactJson {
+  param([Parameter(Mandatory = $true)][object]$Value)
+  return ConvertTo-Json -InputObject $Value -Depth 20 -Compress
+}
+
+function Assert-StringListEqual {
+  param(
+    [Parameter(Mandatory = $true)][string[]]$Expected,
+    [Parameter(Mandatory = $true)][object[]]$Actual,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  $actualList = @($Actual | ForEach-Object { [string]$_ })
+  if ($Expected.Count -ne $actualList.Count) {
+    $Issues.Value += "$Context must match data/aliases source path count"
+    return
+  }
+
+  for ($index = 0; $index -lt $Expected.Count; $index++) {
+    if ($Expected[$index] -ne $actualList[$index]) {
+      $Issues.Value += "$Context source path mismatch at index $index`: expected $($Expected[$index]), got $($actualList[$index])"
+    }
+  }
+}
+
 $issues = @()
+$allowedAliasKinds = @(
+  'character',
+  'move_input',
+  'field',
+  'term',
+  'query_fixture'
+)
+$allowedNormalizedProperties = @(
+  'character_slug',
+  'move_input',
+  'field',
+  'term_key',
+  'question_text'
+)
 $forbiddenTokens = @(
   'startup',
   'active',
@@ -101,6 +211,60 @@ $forbiddenTokens = @(
   'strategy',
   'recommendation'
 )
+
+$expectedSourcePaths = @()
+$expectedRuntimeEntries = @()
+
+if (-not (Test-Path -LiteralPath $aliasesSourceRoot -PathType Container)) {
+  $issues += "Missing normalization alias source root: $aliasesSourceRootRelativePath"
+} else {
+  $sourceFiles = @(
+    Get-ChildItem -LiteralPath $aliasesSourceRoot -File -Filter '*.json' |
+      Sort-Object Name
+  )
+
+  foreach ($sourceFile in $sourceFiles) {
+    $sourceRelativePath = $sourceFile.FullName.Substring($repoRoot.Length + 1).Replace('\', '/')
+    $expectedSourcePaths += $sourceRelativePath
+    $sourceDocument = Get-Content -LiteralPath $sourceFile.FullName -Raw -Encoding UTF8 | ConvertFrom-Json
+
+    foreach ($field in @(
+      'schema_version',
+      'kind',
+      'authority',
+      'not_current_fact_authority',
+      'entries'
+    )) {
+      Assert-Property $sourceDocument $field $sourceRelativePath ([ref]$issues)
+    }
+
+    if ((Test-Property $sourceDocument 'schema_version') -and $sourceDocument.schema_version -ne 'normalization-aliases/v1') {
+      $issues += "$sourceRelativePath must use schema_version normalization-aliases/v1"
+    }
+    if ((Test-Property $sourceDocument 'kind') -and $sourceDocument.kind -ne 'query_normalization_aliases') {
+      $issues += "$sourceRelativePath must use kind query_normalization_aliases"
+    }
+    if ((Test-Property $sourceDocument 'authority') -and $sourceDocument.authority -ne 'query_normalization_only') {
+      $issues += "$sourceRelativePath must use authority query_normalization_only"
+    }
+    if ((Test-Property $sourceDocument 'not_current_fact_authority') -and $sourceDocument.not_current_fact_authority -ne $true) {
+      $issues += "$sourceRelativePath must set not_current_fact_authority true"
+    }
+
+    if (Test-Property $sourceDocument 'entries') {
+      foreach ($entry in @($sourceDocument.entries)) {
+        $comparableEntry = ConvertTo-ComparableRuntimeEntry `
+          -Entry $entry `
+          -SourcePath $sourceRelativePath `
+          -Context "$sourceRelativePath entries entry" `
+          -Issues ([ref]$issues)
+        if ($null -ne $comparableEntry) {
+          $expectedRuntimeEntries += $comparableEntry
+        }
+      }
+    }
+  }
+}
 
 foreach ($relativePath in @($generatorRelativePath, $manifestRelativePath, $aliasesRelativePath)) {
   if (-not (Test-Path -LiteralPath (Join-Path $repoRoot $relativePath) -PathType Leaf)) {
@@ -184,6 +348,11 @@ if (Test-Path -LiteralPath (Join-Path $repoRoot $manifestRelativePath) -PathType
           -ExpectedSha256 ([string]$sourcePathRecord.sha256)
       }
     }
+    Assert-StringListEqual `
+      -Expected ([string[]]$expectedSourcePaths) `
+      -Actual @($manifest.source_paths | ForEach-Object { $_.path }) `
+      -Context "$manifestRelativePath source_paths" `
+      -Issues ([ref]$issues)
   }
 
   if (Test-Property $manifest 'files') {
@@ -272,9 +441,48 @@ if (Test-Path -LiteralPath (Join-Path $repoRoot $aliasesRelativePath) -PathType 
         -Context $aliasesRelativePath `
         -Issues ([ref]$issues)
     }
+    Assert-StringListEqual `
+      -Expected ([string[]]$expectedSourcePaths) `
+      -Actual @($aliases.source_paths) `
+      -Context "$aliasesRelativePath source_paths" `
+      -Issues ([ref]$issues)
   }
   if ((Test-Property $aliases 'entries') -and @($aliases.entries).Count -eq 0) {
     $issues += "$aliasesRelativePath must include runtime alias entries"
+  }
+  if (Test-Property $aliases 'entries') {
+    $actualRuntimeEntries = @()
+    foreach ($entry in @($aliases.entries)) {
+      $entrySourcePath = ''
+      if (Test-Property $entry 'source_path') {
+        $entrySourcePath = [string]$entry.source_path
+      }
+
+      $comparableEntry = ConvertTo-ComparableRuntimeEntry `
+        -Entry $entry `
+        -SourcePath $entrySourcePath `
+        -Context "$aliasesRelativePath entries entry" `
+        -Issues ([ref]$issues) `
+        -RequireSourcePathProperty
+      if ($null -ne $comparableEntry) {
+        $actualRuntimeEntries += $comparableEntry
+      }
+    }
+
+    $expectedSortedEntries = @(
+      $expectedRuntimeEntries |
+        Sort-Object @{ Expression = { $_['source_path'] } }, @{ Expression = { $_['id'] } }
+    )
+    $actualSortedEntries = @(
+      $actualRuntimeEntries |
+        Sort-Object @{ Expression = { $_['source_path'] } }, @{ Expression = { $_['id'] } }
+    )
+
+    $expectedEntriesJson = ConvertTo-CompactJson -Value @($expectedSortedEntries)
+    $actualEntriesJson = ConvertTo-CompactJson -Value @($actualSortedEntries)
+    if ($expectedEntriesJson -ne $actualEntriesJson) {
+      $issues += "$aliasesRelativePath entries must exactly match entries derived from data/aliases/"
+    }
   }
 
   foreach ($token in $forbiddenTokens) {

--- a/tests/validation/validate-normalization-runtime-assets.ps1
+++ b/tests/validation/validate-normalization-runtime-assets.ps1
@@ -1,0 +1,248 @@
+Set-StrictMode -Version Latest
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$assetRootRelativePath = 'skills/sf6-agent/assets/normalization'
+$frameCurrentRelativePath = 'skills/sf6-agent/assets/frame-current'
+$assetRoot = Join-Path $repoRoot $assetRootRelativePath
+$manifestRelativePath = "$assetRootRelativePath/runtime_manifest.json"
+$aliasesRelativePath = "$assetRootRelativePath/aliases.json"
+$generatorRelativePath = 'packages/skill-packaging/build-normalization-runtime-assets.ps1'
+
+function Read-Json {
+  param([Parameter(Mandatory = $true)][string]$RelativePath)
+  return Get-Content -LiteralPath (Join-Path $repoRoot $RelativePath) -Raw -Encoding UTF8 | ConvertFrom-Json
+}
+
+function Test-Property {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name
+  )
+  return $null -ne $Object.PSObject.Properties[$Name]
+}
+
+function Assert-Property {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+  if (-not (Test-Property $Object $Name)) {
+    $Issues.Value += "$Context missing property: $Name"
+  }
+}
+
+$issues = @()
+$forbiddenTokens = @(
+  'startup',
+  'active',
+  'recovery',
+  'hit_adv',
+  'block_adv_value',
+  'damage',
+  'frame_value',
+  'patch',
+  'tier',
+  'strategy',
+  'recommendation'
+)
+
+foreach ($relativePath in @($generatorRelativePath, $manifestRelativePath, $aliasesRelativePath)) {
+  if (-not (Test-Path -LiteralPath (Join-Path $repoRoot $relativePath) -PathType Leaf)) {
+    $issues += "Missing normalization runtime path: $relativePath"
+  }
+}
+
+if (-not (Test-Path -LiteralPath $assetRoot -PathType Container)) {
+  $issues += "Missing normalization runtime asset root: $assetRootRelativePath"
+}
+
+if (
+  (Test-Path -LiteralPath $assetRoot -PathType Container) -and
+  (Test-Path -LiteralPath (Join-Path $repoRoot $frameCurrentRelativePath) -PathType Container)
+) {
+  $normalizationResolved = (Resolve-Path -LiteralPath $assetRoot).Path
+  $frameCurrentResolved = (Resolve-Path -LiteralPath (Join-Path $repoRoot $frameCurrentRelativePath)).Path
+  if ($normalizationResolved.StartsWith($frameCurrentResolved, [System.StringComparison]::OrdinalIgnoreCase)) {
+    $issues += 'Normalization runtime assets must stay separate from frame-current assets'
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot $manifestRelativePath) -PathType Leaf) {
+  $manifestRaw = Get-Content -LiteralPath (Join-Path $repoRoot $manifestRelativePath) -Raw -Encoding UTF8
+  $manifest = $manifestRaw | ConvertFrom-Json
+
+  foreach ($field in @(
+    'generated',
+    'schema_version',
+    'kind',
+    'authority',
+    'not_current_fact_authority',
+    'generator',
+    'source_root',
+    'asset_root',
+    'source_paths',
+    'target_path',
+    'files'
+  )) {
+    Assert-Property $manifest $field $manifestRelativePath ([ref]$issues)
+  }
+
+  if ((Test-Property $manifest 'generated') -and $manifest.generated -ne $true) {
+    $issues += "$manifestRelativePath must include generated marker true"
+  }
+  if ((Test-Property $manifest 'schema_version') -and $manifest.schema_version -ne 'normalization-runtime-manifest/v1') {
+    $issues += "$manifestRelativePath must use schema_version normalization-runtime-manifest/v1"
+  }
+  if ((Test-Property $manifest 'kind') -and $manifest.kind -ne 'query_normalization_runtime_manifest') {
+    $issues += "$manifestRelativePath must use kind query_normalization_runtime_manifest"
+  }
+  if ((Test-Property $manifest 'authority') -and $manifest.authority -ne 'query_normalization_only') {
+    $issues += "$manifestRelativePath must use authority query_normalization_only"
+  }
+  if ((Test-Property $manifest 'not_current_fact_authority') -and $manifest.not_current_fact_authority -ne $true) {
+    $issues += "$manifestRelativePath must set not_current_fact_authority true"
+  }
+  if ((Test-Property $manifest 'generator') -and $manifest.generator -ne $generatorRelativePath) {
+    $issues += "$manifestRelativePath generator must be $generatorRelativePath"
+  }
+  if ((Test-Property $manifest 'source_root') -and $manifest.source_root -ne 'data/aliases') {
+    $issues += "$manifestRelativePath source_root must be data/aliases"
+  }
+  if ((Test-Property $manifest 'asset_root') -and $manifest.asset_root -ne $assetRootRelativePath) {
+    $issues += "$manifestRelativePath asset_root must be $assetRootRelativePath"
+  }
+  if ((Test-Property $manifest 'target_path') -and $manifest.target_path -ne $manifestRelativePath) {
+    $issues += "$manifestRelativePath target_path must be $manifestRelativePath"
+  }
+
+  if (Test-Property $manifest 'source_paths') {
+    foreach ($sourcePathRecord in @($manifest.source_paths)) {
+      foreach ($field in @('path', 'sha256')) {
+        Assert-Property $sourcePathRecord $field "$manifestRelativePath source_paths entry" ([ref]$issues)
+      }
+      if ((Test-Property $sourcePathRecord 'path') -and -not ([string]$sourcePathRecord.path).StartsWith('data/aliases/')) {
+        $issues += "$manifestRelativePath source path must point under data/aliases/: $($sourcePathRecord.path)"
+      }
+      if ((Test-Property $sourcePathRecord 'path') -and -not (Test-Path -LiteralPath (Join-Path $repoRoot $sourcePathRecord.path) -PathType Leaf)) {
+        $issues += "$manifestRelativePath source path does not exist: $($sourcePathRecord.path)"
+      }
+    }
+  }
+
+  if (Test-Property $manifest 'files') {
+    $files = @($manifest.files)
+    if ($files.Count -ne 1) {
+      $issues += "$manifestRelativePath must describe exactly one runtime aliases file"
+    }
+    foreach ($fileEntry in $files) {
+      foreach ($field in @('target', 'target_path', 'source_paths', 'sha256')) {
+        Assert-Property $fileEntry $field "$manifestRelativePath files entry" ([ref]$issues)
+      }
+      if ((Test-Property $fileEntry 'target') -and $fileEntry.target -ne 'aliases.json') {
+        $issues += "$manifestRelativePath file target must be aliases.json"
+      }
+      if ((Test-Property $fileEntry 'target_path') -and $fileEntry.target_path -ne $aliasesRelativePath) {
+        $issues += "$manifestRelativePath file target_path must be $aliasesRelativePath"
+      }
+      if ((Test-Property $fileEntry 'source_paths')) {
+        foreach ($sourcePath in @($fileEntry.source_paths)) {
+          if (-not ([string]$sourcePath).StartsWith('data/aliases/')) {
+            $issues += "$manifestRelativePath file source path must point under data/aliases/: $sourcePath"
+          }
+        }
+      }
+      if ((Test-Property $fileEntry 'sha256') -and (Test-Path -LiteralPath (Join-Path $repoRoot $aliasesRelativePath) -PathType Leaf)) {
+        $actualHash = (Get-FileHash -LiteralPath (Join-Path $repoRoot $aliasesRelativePath) -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($fileEntry.sha256 -ne $actualHash) {
+          $issues += "$manifestRelativePath aliases.json hash mismatch"
+        }
+      }
+    }
+  }
+
+  foreach ($token in $forbiddenTokens) {
+    $escapedToken = [regex]::Escape($token)
+    if ($manifestRaw -match ('(?i)"[^"]*' + $escapedToken + '[^"]*"')) {
+      $issues += "$manifestRelativePath contains forbidden exact-current-fact token: $token"
+    }
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot $aliasesRelativePath) -PathType Leaf) {
+  $aliasesRaw = Get-Content -LiteralPath (Join-Path $repoRoot $aliasesRelativePath) -Raw -Encoding UTF8
+  $aliases = $aliasesRaw | ConvertFrom-Json
+
+  foreach ($field in @(
+    'generated',
+    'schema_version',
+    'kind',
+    'authority',
+    'not_current_fact_authority',
+    'generator',
+    'source_paths',
+    'target_path',
+    'entries'
+  )) {
+    Assert-Property $aliases $field $aliasesRelativePath ([ref]$issues)
+  }
+
+  if ((Test-Property $aliases 'generated') -and $aliases.generated -ne $true) {
+    $issues += "$aliasesRelativePath must include generated marker true"
+  }
+  if ((Test-Property $aliases 'schema_version') -and $aliases.schema_version -ne 'normalization-runtime/v1') {
+    $issues += "$aliasesRelativePath must use schema_version normalization-runtime/v1"
+  }
+  if ((Test-Property $aliases 'kind') -and $aliases.kind -ne 'query_normalization_runtime_assets') {
+    $issues += "$aliasesRelativePath must use kind query_normalization_runtime_assets"
+  }
+  if ((Test-Property $aliases 'authority') -and $aliases.authority -ne 'query_normalization_only') {
+    $issues += "$aliasesRelativePath must use authority query_normalization_only"
+  }
+  if ((Test-Property $aliases 'not_current_fact_authority') -and $aliases.not_current_fact_authority -ne $true) {
+    $issues += "$aliasesRelativePath must set not_current_fact_authority true"
+  }
+  if ((Test-Property $aliases 'generator') -and $aliases.generator -ne $generatorRelativePath) {
+    $issues += "$aliasesRelativePath generator must be $generatorRelativePath"
+  }
+  if ((Test-Property $aliases 'target_path') -and $aliases.target_path -ne $aliasesRelativePath) {
+    $issues += "$aliasesRelativePath target_path must be $aliasesRelativePath"
+  }
+  if (Test-Property $aliases 'source_paths') {
+    foreach ($sourcePath in @($aliases.source_paths)) {
+      if (-not ([string]$sourcePath).StartsWith('data/aliases/')) {
+        $issues += "$aliasesRelativePath source path must point under data/aliases/: $sourcePath"
+      }
+    }
+  }
+  if ((Test-Property $aliases 'entries') -and @($aliases.entries).Count -eq 0) {
+    $issues += "$aliasesRelativePath must include runtime alias entries"
+  }
+
+  foreach ($token in $forbiddenTokens) {
+    $escapedToken = [regex]::Escape($token)
+    if ($aliasesRaw -match ('(?i)"[^"]*' + $escapedToken + '[^"]*"')) {
+      $issues += "$aliasesRelativePath contains forbidden exact-current-fact token: $token"
+    }
+  }
+}
+
+$actualInventory = @()
+if (Test-Path -LiteralPath $assetRoot -PathType Container) {
+  $actualInventory = @(
+    Get-ChildItem -LiteralPath $assetRoot -Recurse -File |
+      ForEach-Object { $_.FullName.Substring($assetRoot.Length + 1).Replace('\', '/') }
+  )
+}
+
+$expectedInventory = @('aliases.json', 'runtime_manifest.json')
+if (Compare-Object ($actualInventory | Sort-Object) ($expectedInventory | Sort-Object)) {
+  $issues += 'Normalization runtime inventory must contain only aliases.json and runtime_manifest.json'
+}
+
+if ($issues.Count -gt 0) {
+  throw ($issues -join '; ')
+}
+
+Write-Host 'Normalization runtime assets OK'


### PR DESCRIPTION
## Summary

Adds derived normalization runtime assets generated from `data/aliases/` and packages them with the public `sf6-agent` release bundle for future runtime use.

This PR also adds a dedicated runtime asset validator and keeps canonical alias-source validation focused on `data/aliases/`.

Closes #100

## Scope

- Added `packages/skill-packaging/build-normalization-runtime-assets.ps1`.
- Added generated runtime assets under `skills/sf6-agent/assets/normalization/`.
- Added `tests/validation/validate-normalization-runtime-assets.ps1`.
- Updated `tests/validation/run-all.ps1` to run the runtime validator after alias validation.
- Updated release bundle generation and distribution validation so the public `sf6-agent` bundle includes normalization runtime assets.

Generated normalization runtime assets are derived only from `data/aliases/`.

The assets are packaged for future runtime use, but this PR does not change answer behavior. It does not implement lookup, routing, answer composition, or public `sf6-agent` behavior changes.

#101 and later v2.2 issues are not implemented.

## Explicit Non-Changes

- No full roster alias coverage was added.
- No frame-current facts were changed.
- No frame values, damage values, patch values, strategy conclusions, or matchup judgments were added.
- No Hermes prompts were added.
- No runtime lookup, routing, or answer composition behavior was added.
- No answer smoke fixtures were added.
- No article/video planning docs were added.
- No generated knowledge outputs or historical smoke reports were changed.
- No public `sf6-agent` behavior changes were added.

## Validation

- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-normalization-aliases.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-normalization-runtime-assets.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File packages/skill-packaging/build-release-bundle.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-distribution.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1`
- `git diff --check`
- `git diff --check origin/main...HEAD`

Windows PowerShell reported the expected git-unavailable warnings during generated-surface checks. Generated references, `.dist`, `skills/sf6-agent/assets/frame-current/`, and `skills/sf6-agent/assets/normalization/` were separately checked from a git-visible environment for residual unintended diff.