### PR TITLE
[v2.2] Add answer smoke skeleton

### DIFF
--- a/docs/testing/smoke-runs/answer-smoke-template.md
+++ b/docs/testing/smoke-runs/answer-smoke-template.md
@@ -1,0 +1,47 @@
+# Answer Smoke Run Template
+
+This file is a template, not an executed smoke report.
+
+It does not represent live Hermes execution. It does not represent live web research.
+It is for recording future contract-level or fixture-level answer smoke runs
+after the fixture set and validators are selected.
+
+## Fixture Set
+
+- Fixture directory:
+- Fixture revision or PR:
+- Covered modes:
+- Japanese normalization fixture:
+
+## Validators Run
+
+- `tests/validation/validate-answer-smoke-fixtures.ps1`:
+- `tests/validation/run-all.ps1`:
+- `git diff --check`:
+- `git diff --check origin/main...HEAD`:
+
+## Warnings
+
+- Windows PowerShell git visibility warnings:
+- Generated-surface warnings:
+- Authority-boundary warnings:
+
+## Unresolved Items
+
+- 
+
+## Generated-Surface Status
+
+Record whether these surfaces had residual unintended diff after validation:
+
+- `skills/sf6-agent/references/`:
+- `.dist`:
+- `skills/sf6-agent/assets/frame-current/`:
+- `skills/sf6-agent/assets/normalization/`:
+
+## Intentionally Not Done
+
+- No live Hermes execution.
+- No live web research.
+- No operational answer prompt body changes.
+- No public `sf6-agent` behavior changes.

--- a/docs/testing/smoke-runs/answer-smoke-template.md
+++ b/docs/testing/smoke-runs/answer-smoke-template.md
@@ -28,7 +28,7 @@ after the fixture set and validators are selected.
 
 ## Unresolved Items
 
-- 
+- TBD
 
 ## Generated-Surface Status
 

--- a/tests/fixtures/answer-smoke/current-fact-official-raw.json
+++ b/tests/fixtures/answer-smoke/current-fact-official-raw.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": "answer-smoke-fixture/v1",
+  "fixture_id": "smoke-current-fact-official-raw",
+  "coverage": "current_fact",
+  "smoke_level": "contract_fixture",
+  "execution": {
+    "requires_live_hermes": false,
+    "requires_live_web_research": false,
+    "is_executed_answer": false
+  },
+  "answer_plan": {
+    "schema_version": "answer-plan/v1",
+    "plan_id": "smoke-current-fact-ryu-2mp-block",
+    "answer_mode": "current_fact",
+    "intent": {
+      "schema_version": "answer-intent/v1",
+      "question_text": "リュウの2MPはガードで何F？",
+      "normalized_question_text": "Ryu 2MP block advantage current fact",
+      "intent_kind": "current_fact",
+      "answer_mode": "current_fact",
+      "entities": {
+        "character_slug": "ryu",
+        "move_input": "2MP",
+        "requested_field": "block_adv"
+      }
+    },
+    "evidence_cards": [
+      {
+        "id": "ryu-official-raw-2mp-smoke",
+        "evidence_family": "frame_current_official_raw",
+        "authority_role": "primary_current_fact_authority",
+        "canonicality": "packaged_runtime_authority",
+        "source_ref": {
+          "label": "Ryu packaged official_raw",
+          "path": "skills/sf6-agent/assets/frame-current/published/ryu/official_raw.json"
+        },
+        "supports_exact_current_fact": true,
+        "may_override_official_raw": false,
+        "confidence": 1,
+        "limitations": [
+          "Smoke fixture checks authority routing only; it does not include an answer value."
+        ]
+      }
+    ],
+    "web_research": {
+      "web_required": false,
+      "web_allowed": false,
+      "web_used": false,
+      "web_forbidden_for_current_fact_override": true,
+      "conflict_requires_hold": true,
+      "required_source_authority": "none"
+    },
+    "hold_reasons": [],
+    "response_requirements": {
+      "cite_evidence": true,
+      "state_authority_boundary": true,
+      "state_confidence": true,
+      "boundary_notes": [
+        "Exact current facts must use packaged official_raw."
+      ]
+    }
+  },
+  "smoke_expectations": {
+    "must_use_packaged_official_raw": true,
+    "must_not_use_live_web": true,
+    "must_not_include_answer_value": true
+  }
+}

--- a/tests/fixtures/answer-smoke/hold-ambiguous-current-fact.json
+++ b/tests/fixtures/answer-smoke/hold-ambiguous-current-fact.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "answer-smoke-fixture/v1",
+  "fixture_id": "smoke-hold-ambiguous-current-fact",
+  "coverage": "hold",
+  "smoke_level": "contract_fixture",
+  "execution": {
+    "requires_live_hermes": false,
+    "requires_live_web_research": false,
+    "is_executed_answer": false
+  },
+  "answer_plan": {
+    "schema_version": "answer-plan/v1",
+    "plan_id": "smoke-hold-ambiguous-current-fact",
+    "answer_mode": "hold",
+    "intent": {
+      "schema_version": "answer-intent/v1",
+      "question_text": "この技は今何F有利？",
+      "normalized_question_text": "Ambiguous current fact request",
+      "intent_kind": "hold",
+      "answer_mode": "hold",
+      "entities": {
+        "requested_field": "frame_advantage"
+      },
+      "notes": "Character and move are unresolved."
+    },
+    "evidence_cards": [
+      {
+        "id": "missing-current-fact-authority-smoke",
+        "evidence_family": "unknown",
+        "authority_role": "unresolved_context",
+        "canonicality": "non_canonical",
+        "source_ref": {
+          "label": "No usable packaged authority selected"
+        },
+        "supports_exact_current_fact": false,
+        "may_override_official_raw": false,
+        "confidence": 0,
+        "limitations": [
+          "Missing character and move identity; no packaged official_raw lookup can be selected."
+        ]
+      }
+    ],
+    "web_research": {
+      "web_required": false,
+      "web_allowed": false,
+      "web_used": false,
+      "web_forbidden_for_current_fact_override": true,
+      "conflict_requires_hold": true,
+      "required_source_authority": "none"
+    },
+    "hold_reasons": [
+      "character unresolved",
+      "move unresolved",
+      "exact current fact authority cannot be selected"
+    ],
+    "response_requirements": {
+      "cite_evidence": false,
+      "state_authority_boundary": true,
+      "state_confidence": true,
+      "boundary_notes": [
+        "Hold rather than guessing current frame values."
+      ]
+    }
+  },
+  "smoke_expectations": {
+    "must_hold": true,
+    "must_not_guess_current_fact": true
+  }
+}

--- a/tests/fixtures/answer-smoke/ja-query-normalization-structured-inputs.json
+++ b/tests/fixtures/answer-smoke/ja-query-normalization-structured-inputs.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": "answer-smoke-fixture/v1",
+  "fixture_id": "smoke-ja-query-normalization-structured-inputs",
+  "coverage": "japanese_query_normalization",
+  "smoke_level": "contract_fixture",
+  "execution": {
+    "requires_live_hermes": false,
+    "requires_live_web_research": false,
+    "is_executed_answer": false
+  },
+  "normalization": {
+    "source_manifest": "skills/sf6-agent/assets/normalization/runtime_manifest.json",
+    "source_asset": "skills/sf6-agent/assets/normalization/aliases.json",
+    "runtime_authority": "query_normalization_only",
+    "not_current_fact_authority": true,
+    "structured_inputs": {
+      "character_slug": "ryu",
+      "move_input": "2MP",
+      "requested_field": "block_adv"
+    }
+  },
+  "answer_plan": {
+    "schema_version": "answer-plan/v1",
+    "plan_id": "smoke-ja-normalized-current-fact-boundary",
+    "answer_mode": "current_fact",
+    "intent": {
+      "schema_version": "answer-intent/v1",
+      "question_text": "リュウの屈中Pってガードで何F？",
+      "normalized_question_text": "Ryu 2MP block advantage current fact",
+      "intent_kind": "current_fact",
+      "answer_mode": "current_fact",
+      "entities": {
+        "character_slug": "ryu",
+        "move_input": "2MP",
+        "requested_field": "block_adv"
+      },
+      "notes": "Japanese query normalization maps wording to structured inputs; it does not provide exact current facts."
+    },
+    "evidence_cards": [
+      {
+        "id": "ja-normalized-official-raw-smoke",
+        "evidence_family": "frame_current_official_raw",
+        "authority_role": "primary_current_fact_authority",
+        "canonicality": "packaged_runtime_authority",
+        "source_ref": {
+          "label": "Ryu packaged official_raw",
+          "path": "skills/sf6-agent/assets/frame-current/published/ryu/official_raw.json"
+        },
+        "supports_exact_current_fact": true,
+        "may_override_official_raw": false,
+        "confidence": 1,
+        "limitations": [
+          "Normalization selects structured inputs; official_raw remains exact current-fact authority."
+        ]
+      }
+    ],
+    "web_research": {
+      "web_required": false,
+      "web_allowed": false,
+      "web_used": false,
+      "web_forbidden_for_current_fact_override": true,
+      "conflict_requires_hold": true,
+      "required_source_authority": "none"
+    },
+    "hold_reasons": [],
+    "response_requirements": {
+      "cite_evidence": true,
+      "state_authority_boundary": true,
+      "state_confidence": true,
+      "boundary_notes": [
+        "Normalization runtime assets are query-normalization support, not exact current-fact authority."
+      ]
+    }
+  },
+  "smoke_expectations": {
+    "must_reference_normalization_runtime_assets": true,
+    "normalization_exact_current_fact_authority": false,
+    "structured_inputs_expected": true
+  }
+}

--- a/tests/fixtures/answer-smoke/ja-query-normalization-structured-inputs.json
+++ b/tests/fixtures/answer-smoke/ja-query-normalization-structured-inputs.json
@@ -16,7 +16,7 @@
     "structured_inputs": {
       "character_slug": "ryu",
       "move_input": "2MP",
-      "requested_field": "block_adv"
+      "field": "block_adv"
     }
   },
   "answer_plan": {
@@ -34,7 +34,7 @@
         "move_input": "2MP",
         "requested_field": "block_adv"
       },
-      "notes": "Japanese query normalization maps wording to structured inputs; it does not provide exact current facts."
+      "notes": "Japanese query normalization maps runtime field to answer intent requested_field; it does not provide exact current facts."
     },
     "evidence_cards": [
       {
@@ -75,6 +75,7 @@
   "smoke_expectations": {
     "must_reference_normalization_runtime_assets": true,
     "normalization_exact_current_fact_authority": false,
-    "structured_inputs_expected": true
+    "structured_inputs_expected": true,
+    "normalization_field_maps_to_requested_field": true
   }
 }

--- a/tests/fixtures/answer-smoke/stable-concept-generated-reference.json
+++ b/tests/fixtures/answer-smoke/stable-concept-generated-reference.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": "answer-smoke-fixture/v1",
+  "fixture_id": "smoke-stable-concept-generated-reference",
+  "coverage": "stable_concept",
+  "smoke_level": "contract_fixture",
+  "execution": {
+    "requires_live_hermes": false,
+    "requires_live_web_research": false,
+    "is_executed_answer": false
+  },
+  "answer_plan": {
+    "schema_version": "answer-plan/v1",
+    "plan_id": "smoke-stable-concept-shimmy",
+    "answer_mode": "stable_concept",
+    "intent": {
+      "schema_version": "answer-intent/v1",
+      "question_text": "シミーって何？",
+      "normalized_question_text": "Explain shimmy as a stable concept",
+      "intent_kind": "stable_concept",
+      "answer_mode": "stable_concept",
+      "entities": {
+        "strategy_context": "general concept explanation"
+      }
+    },
+    "evidence_cards": [
+      {
+        "id": "generated-concepts-shimmy-smoke",
+        "evidence_family": "generated_curated_reference",
+        "authority_role": "stable_concept_support",
+        "canonicality": "derived_reference",
+        "source_ref": {
+          "label": "Generated concepts reference",
+          "path": "skills/sf6-agent/references/generated-concepts.md"
+        },
+        "supports_exact_current_fact": false,
+        "may_override_official_raw": false,
+        "confidence": 0.85,
+        "limitations": [
+          "Generated references support durable concepts only; they are not exact current-fact authority."
+        ]
+      }
+    ],
+    "web_research": {
+      "web_required": false,
+      "web_allowed": false,
+      "web_used": false,
+      "web_forbidden_for_current_fact_override": true,
+      "conflict_requires_hold": true,
+      "required_source_authority": "none"
+    },
+    "hold_reasons": [],
+    "response_requirements": {
+      "cite_evidence": true,
+      "state_authority_boundary": true,
+      "state_confidence": true,
+      "boundary_notes": [
+        "Generated references are concept support, not exact current-fact authority."
+      ]
+    }
+  },
+  "smoke_expectations": {
+    "must_use_generated_reference": true,
+    "generated_reference_exact_current_fact_authority": false,
+    "must_not_include_answer_value": true
+  }
+}

--- a/tests/fixtures/answer-smoke/strategy-assumptions-boundaries.json
+++ b/tests/fixtures/answer-smoke/strategy-assumptions-boundaries.json
@@ -1,0 +1,75 @@
+{
+  "schema_version": "answer-smoke-fixture/v1",
+  "fixture_id": "smoke-strategy-assumptions-boundaries",
+  "coverage": "strategy",
+  "smoke_level": "contract_fixture",
+  "execution": {
+    "requires_live_hermes": false,
+    "requires_live_web_research": false,
+    "is_executed_answer": false
+  },
+  "answer_plan": {
+    "schema_version": "answer-plan/v1",
+    "plan_id": "smoke-strategy-ryu-fireball",
+    "answer_mode": "strategy",
+    "intent": {
+      "schema_version": "answer-intent/v1",
+      "question_text": "リュウの波動拳にどう対応する？",
+      "normalized_question_text": "Strategy response boundary for Ryu fireball",
+      "intent_kind": "strategy",
+      "answer_mode": "strategy",
+      "entities": {
+        "character_slug": "ryu",
+        "strategy_context": "fireball counterplay assumptions"
+      }
+    },
+    "evidence_cards": [
+      {
+        "id": "generated-strategy-context-smoke",
+        "evidence_family": "generated_curated_reference",
+        "authority_role": "strategy_support",
+        "canonicality": "derived_reference",
+        "source_ref": {
+          "label": "Generated concepts reference",
+          "path": "skills/sf6-agent/references/generated-concepts.md"
+        },
+        "supports_exact_current_fact": false,
+        "may_override_official_raw": false,
+        "confidence": 0.7,
+        "limitations": [
+          "Strategy smoke checks assumptions and confidence boundaries, not final matchup advice."
+        ]
+      }
+    ],
+    "web_research": {
+      "web_required": false,
+      "web_allowed": true,
+      "web_used": false,
+      "web_forbidden_for_current_fact_override": true,
+      "conflict_requires_hold": true,
+      "required_source_authority": "supplemental_sources_allowed",
+      "notes": "Supplemental sources may be allowed later, but this smoke fixture does not run web research."
+    },
+    "hold_reasons": [],
+    "response_requirements": {
+      "cite_evidence": true,
+      "state_authority_boundary": true,
+      "state_confidence": true,
+      "boundary_notes": [
+        "State assumptions before giving strategy guidance.",
+        "Do not present strategy guidance as exact current-fact authority."
+      ]
+    }
+  },
+  "smoke_expectations": {
+    "assumptions": [
+      "The user asks for general counterplay, not a guaranteed matchup verdict.",
+      "Exact move data is outside this smoke fixture unless separately grounded in official_raw."
+    ],
+    "confidence_boundaries": [
+      "Strategy guidance must state confidence and patch sensitivity.",
+      "Strategy support must not override packaged current facts."
+    ],
+    "strategy_conclusion_as_authority": false
+  }
+}

--- a/tests/fixtures/answer-smoke/web-needed-official-raw-boundary.json
+++ b/tests/fixtures/answer-smoke/web-needed-official-raw-boundary.json
@@ -1,0 +1,88 @@
+{
+  "schema_version": "answer-smoke-fixture/v1",
+  "fixture_id": "smoke-web-needed-official-raw-boundary",
+  "coverage": "web_needed",
+  "smoke_level": "contract_fixture",
+  "execution": {
+    "requires_live_hermes": false,
+    "requires_live_web_research": false,
+    "is_executed_answer": false
+  },
+  "answer_plan": {
+    "schema_version": "answer-plan/v1",
+    "plan_id": "smoke-web-needed-official-boundary",
+    "answer_mode": "web_needed",
+    "intent": {
+      "schema_version": "answer-intent/v1",
+      "question_text": "公式の最新情報確認が必要？",
+      "normalized_question_text": "Official freshness metadata check needed",
+      "intent_kind": "web_needed",
+      "answer_mode": "web_needed",
+      "entities": {
+        "character_slug": "ryu",
+        "move_input": "2MP",
+        "requested_field": "official_freshness_metadata"
+      }
+    },
+    "evidence_cards": [
+      {
+        "id": "official-web-freshness-required-smoke",
+        "evidence_family": "official_web",
+        "authority_role": "official_metadata",
+        "canonicality": "supplemental",
+        "source_ref": {
+          "label": "Official source required before metadata summary"
+        },
+        "supports_exact_current_fact": false,
+        "may_override_official_raw": false,
+        "confidence": 0.6,
+        "limitations": [
+          "Official web may be used as freshness metadata only; it must not override packaged official_raw."
+        ]
+      },
+      {
+        "id": "packaged-official-raw-conflict-boundary-smoke",
+        "evidence_family": "frame_current_official_raw",
+        "authority_role": "primary_current_fact_authority",
+        "canonicality": "packaged_runtime_authority",
+        "source_ref": {
+          "label": "Ryu packaged official_raw",
+          "path": "skills/sf6-agent/assets/frame-current/published/ryu/official_raw.json"
+        },
+        "supports_exact_current_fact": true,
+        "may_override_official_raw": false,
+        "confidence": 1,
+        "limitations": [
+          "If web metadata conflicts with packaged official_raw, route to hold or refresh workflow."
+        ]
+      }
+    ],
+    "web_research": {
+      "web_required": true,
+      "web_allowed": true,
+      "web_used": false,
+      "web_forbidden_for_current_fact_override": true,
+      "conflict_requires_hold": true,
+      "required_source_authority": "official_sources_required",
+      "notes": "This smoke fixture marks web as needed but does not run live web research."
+    },
+    "hold_reasons": [
+      "official freshness metadata requires source review before user-facing summary"
+    ],
+    "response_requirements": {
+      "cite_evidence": true,
+      "state_authority_boundary": true,
+      "state_confidence": true,
+      "boundary_notes": [
+        "Web may be used for freshness metadata only.",
+        "Web must not override packaged official_raw exact current facts."
+      ]
+    }
+  },
+  "smoke_expectations": {
+    "web_needed": true,
+    "web_used": false,
+    "web_must_not_override_official_raw": true,
+    "conflict_requires_hold": true
+  }
+}

--- a/tests/validation/run-all.ps1
+++ b/tests/validation/run-all.ps1
@@ -40,6 +40,7 @@ $validationScripts = @(
   'tests/validation/validate-v2-contracts.ps1',
   'tests/validation/validate-agent-toolchain.ps1',
   'tests/validation/validate-answer-orchestration-contracts.ps1',
+  'tests/validation/validate-answer-smoke-fixtures.ps1',
   'tests/validation/validate-normalization-aliases.ps1',
   'tests/validation/validate-normalization-runtime-assets.ps1',
   'tests/validation/validate-knowledge-schema.ps1',

--- a/tests/validation/validate-answer-smoke-fixtures.ps1
+++ b/tests/validation/validate-answer-smoke-fixtures.ps1
@@ -65,6 +65,19 @@ function Get-StringArray {
   return @($Value | ForEach-Object { [string]$_ })
 }
 
+function Test-NormalizedValue {
+  param(
+    [Parameter(Mandatory = $true)][object]$Normalized,
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][string]$Expected
+  )
+
+  return (
+    (Test-Property $Normalized $Name) -and
+    [string]$Normalized.$Name -eq $Expected
+  )
+}
+
 $requiredCoverage = @(
   'current_fact',
   'stable_concept',
@@ -172,6 +185,10 @@ if (-not (Test-Path -LiteralPath (Join-Path $repoRoot $templateRelativePath) -Pa
 
 Assert-PathExists $normalizationManifestRelativePath 'Japanese normalization smoke' ([ref]$issues)
 Assert-PathExists $normalizationAssetRelativePath 'Japanese normalization smoke' ([ref]$issues)
+$normalizationRuntimeAssets = $null
+if (Test-Path -LiteralPath (Join-Path $repoRoot $normalizationAssetRelativePath) -PathType Leaf) {
+  $normalizationRuntimeAssets = Read-Json $normalizationAssetRelativePath
+}
 
 if (Test-Path -LiteralPath $fixtureRoot -PathType Container) {
   $fixtureFiles = @(
@@ -408,17 +425,44 @@ if (Test-Path -LiteralPath $fixtureRoot -PathType Container) {
       }
       if (Test-Property $fixture.normalization 'structured_inputs') {
         $structured = $fixture.normalization.structured_inputs
-        foreach ($field in @('character_slug', 'move_input', 'requested_field')) {
+        foreach ($field in @('character_slug', 'move_input', 'field')) {
           Assert-Property $structured $field "$relativePath structured_inputs" ([ref]$issues)
         }
         if ((Test-Property $plan 'intent') -and (Test-Property $plan.intent 'entities')) {
-          foreach ($field in @('character_slug', 'move_input', 'requested_field')) {
+          foreach ($field in @('character_slug', 'move_input')) {
             if ((Test-Property $structured $field) -and (Test-Property $plan.intent.entities $field)) {
               if ([string]$structured.$field -ne [string]$plan.intent.entities.$field) {
                 $issues += "$relativePath structured input mismatch for $field"
               }
             }
           }
+          if (
+            (Test-Property $structured 'field') -and
+            (Test-Property $plan.intent.entities 'requested_field') -and
+            [string]$structured.field -ne [string]$plan.intent.entities.requested_field
+          ) {
+            $issues += "$relativePath normalization field must map to intent requested_field"
+          }
+        }
+      }
+      if (
+        (Test-Property $plan 'intent') -and
+        (Test-Property $plan.intent 'question_text') -and
+        (Test-Property $fixture.normalization 'structured_inputs') -and
+        $null -ne $normalizationRuntimeAssets -and
+        (Test-Property $normalizationRuntimeAssets 'entries')
+      ) {
+        $structured = $fixture.normalization.structured_inputs
+        $runtimeMatches = @($normalizationRuntimeAssets.entries | Where-Object {
+          $_.alias_kind -eq 'query_fixture' -and
+          @($_.aliases) -contains [string]$plan.intent.question_text -and
+          (Test-Property $_ 'normalized') -and
+          (Test-NormalizedValue $_.normalized 'character_slug' ([string]$structured.character_slug)) -and
+          (Test-NormalizedValue $_.normalized 'move_input' ([string]$structured.move_input)) -and
+          (Test-NormalizedValue $_.normalized 'field' ([string]$structured.field))
+        })
+        if ($runtimeMatches.Count -eq 0) {
+          $issues += "$relativePath must match a query_fixture entry in $normalizationAssetRelativePath"
         }
       }
     }

--- a/tests/validation/validate-answer-smoke-fixtures.ps1
+++ b/tests/validation/validate-answer-smoke-fixtures.ps1
@@ -1,0 +1,438 @@
+Set-StrictMode -Version Latest
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$fixtureRootRelativePath = 'tests/fixtures/answer-smoke'
+$fixtureRoot = Join-Path $repoRoot $fixtureRootRelativePath
+$templateRelativePath = 'docs/testing/smoke-runs/answer-smoke-template.md'
+$normalizationManifestRelativePath = 'skills/sf6-agent/assets/normalization/runtime_manifest.json'
+$normalizationAssetRelativePath = 'skills/sf6-agent/assets/normalization/aliases.json'
+
+function Read-Json {
+  param([Parameter(Mandatory = $true)][string]$RelativePath)
+  return Get-Content -LiteralPath (Join-Path $repoRoot $RelativePath) -Raw -Encoding UTF8 | ConvertFrom-Json
+}
+
+function Test-Property {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name
+  )
+  return $null -ne $Object.PSObject.Properties[$Name]
+}
+
+function Assert-Property {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+  if (-not (Test-Property $Object $Name)) {
+    $Issues.Value += "$Context missing property: $Name"
+  }
+}
+
+function Assert-ValueIn {
+  param(
+    [Parameter(Mandatory = $true)][object]$Value,
+    [Parameter(Mandatory = $true)][string[]]$AllowedValues,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  if ($AllowedValues -notcontains [string]$Value) {
+    $Issues.Value += "$Context has invalid value: $Value"
+  }
+}
+
+function Assert-PathExists {
+  param(
+    [Parameter(Mandatory = $true)][string]$RelativePath,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  if (-not (Test-Path -LiteralPath (Join-Path $repoRoot $RelativePath) -PathType Leaf)) {
+    $Issues.Value += "$Context path does not exist: $RelativePath"
+  }
+}
+
+function Get-StringArray {
+  param([AllowNull()][object]$Value)
+  if ($null -eq $Value) {
+    return @()
+  }
+  return @($Value | ForEach-Object { [string]$_ })
+}
+
+$requiredCoverage = @(
+  'current_fact',
+  'stable_concept',
+  'strategy',
+  'hold',
+  'web_needed',
+  'japanese_query_normalization'
+)
+
+$allowedCoverage = $requiredCoverage
+$allowedSmokeLevel = 'contract_fixture'
+$answerModes = @(
+  'current_fact',
+  'stable_concept',
+  'strategy',
+  'observation',
+  'hold',
+  'web_needed'
+)
+$evidenceFamilies = @(
+  'frame_current_official_raw',
+  'frame_current_derived_metrics',
+  'generated_curated_reference',
+  'review_claim',
+  'video_observation',
+  'official_web',
+  'third_party_community_web',
+  'hermes_memory_session_profile_state',
+  'repo_policy',
+  'unknown'
+)
+$authorityRoles = @(
+  'primary_current_fact_authority',
+  'derived_current_fact_support',
+  'stable_concept_support',
+  'strategy_support',
+  'observation_only',
+  'review_only',
+  'official_metadata',
+  'supplemental_context',
+  'forbidden_non_canonical',
+  'unresolved_context'
+)
+$canonicalityValues = @(
+  'canonical_repo_source',
+  'packaged_runtime_authority',
+  'derived_reference',
+  'review_only',
+  'observation_only',
+  'supplemental',
+  'non_canonical',
+  'forbidden'
+)
+$sourceAuthorityValues = @(
+  'none',
+  'official_sources_required',
+  'supplemental_sources_allowed'
+)
+$forbiddenRawPatterns = @(
+  '"startup"\s*:',
+  '"active"\s*:',
+  '"recovery"\s*:',
+  '"hit_adv"\s*:',
+  '"block_adv_value"\s*:',
+  '"damage"\s*:',
+  '"frame_value"\s*:',
+  '"patch_value"\s*:',
+  '"tier"\s*:',
+  '"matchup_judgment"\s*:',
+  '"matchup_verdict"\s*:',
+  '"strategy_conclusion_authority"\s*:\s*true',
+  '"answer_text"\s*:',
+  '"executed_output"\s*:'
+)
+
+$issues = @()
+$coverageSeen = @{}
+foreach ($coverage in $requiredCoverage) {
+  $coverageSeen[$coverage] = $false
+}
+
+if (-not (Test-Path -LiteralPath $fixtureRoot -PathType Container)) {
+  $issues += "Missing answer smoke fixture directory: $fixtureRootRelativePath"
+}
+
+if (-not (Test-Path -LiteralPath (Join-Path $repoRoot $templateRelativePath) -PathType Leaf)) {
+  $issues += "Missing answer smoke template: $templateRelativePath"
+} else {
+  $templateText = Get-Content -LiteralPath (Join-Path $repoRoot $templateRelativePath) -Raw -Encoding UTF8
+  foreach ($requiredText in @(
+    'template, not an executed smoke report',
+    'does not represent live Hermes execution',
+    'does not represent live web research',
+    'Fixture Set',
+    'Validators Run',
+    'Warnings',
+    'Unresolved Items',
+    'Generated-Surface Status'
+  )) {
+    if ($templateText -notmatch [regex]::Escape($requiredText)) {
+      $issues += "$templateRelativePath must mention: $requiredText"
+    }
+  }
+}
+
+Assert-PathExists $normalizationManifestRelativePath 'Japanese normalization smoke' ([ref]$issues)
+Assert-PathExists $normalizationAssetRelativePath 'Japanese normalization smoke' ([ref]$issues)
+
+if (Test-Path -LiteralPath $fixtureRoot -PathType Container) {
+  $fixtureFiles = @(
+    Get-ChildItem -LiteralPath $fixtureRoot -Filter '*.json' -File |
+      Sort-Object Name
+  )
+
+  if ($fixtureFiles.Count -eq 0) {
+    $issues += "$fixtureRootRelativePath must include answer smoke JSON fixtures"
+  }
+
+  foreach ($fixtureFile in $fixtureFiles) {
+    $relativePath = $fixtureFile.FullName.Substring($repoRoot.Length + 1).Replace('\', '/')
+    $raw = Get-Content -LiteralPath $fixtureFile.FullName -Raw -Encoding UTF8
+    $fixture = $raw | ConvertFrom-Json
+
+    foreach ($pattern in $forbiddenRawPatterns) {
+      if ($raw -match $pattern) {
+        $issues += "$relativePath contains forbidden executed-output or exact-current-fact field pattern: $pattern"
+      }
+    }
+
+    foreach ($field in @('schema_version', 'fixture_id', 'coverage', 'smoke_level', 'execution', 'answer_plan', 'smoke_expectations')) {
+      Assert-Property $fixture $field $relativePath ([ref]$issues)
+    }
+
+    if ((Test-Property $fixture 'schema_version') -and $fixture.schema_version -ne 'answer-smoke-fixture/v1') {
+      $issues += "$relativePath must use schema_version answer-smoke-fixture/v1"
+    }
+    if ((Test-Property $fixture 'smoke_level') -and $fixture.smoke_level -ne $allowedSmokeLevel) {
+      $issues += "$relativePath must use smoke_level $allowedSmokeLevel"
+    }
+    if (Test-Property $fixture 'coverage') {
+      Assert-ValueIn $fixture.coverage $allowedCoverage "$relativePath coverage" ([ref]$issues)
+      if ($coverageSeen.ContainsKey([string]$fixture.coverage)) {
+        $coverageSeen[[string]$fixture.coverage] = $true
+      }
+    }
+
+    if (Test-Property $fixture 'execution') {
+      foreach ($field in @('requires_live_hermes', 'requires_live_web_research', 'is_executed_answer')) {
+        Assert-Property $fixture.execution $field "$relativePath execution" ([ref]$issues)
+      }
+      if ((Test-Property $fixture.execution 'requires_live_hermes') -and [bool]$fixture.execution.requires_live_hermes) {
+        $issues += "$relativePath must not require live Hermes execution"
+      }
+      if ((Test-Property $fixture.execution 'requires_live_web_research') -and [bool]$fixture.execution.requires_live_web_research) {
+        $issues += "$relativePath must not require live web research"
+      }
+      if ((Test-Property $fixture.execution 'is_executed_answer') -and [bool]$fixture.execution.is_executed_answer) {
+        $issues += "$relativePath must be a fixture skeleton, not an executed answer"
+      }
+    }
+
+    if (-not (Test-Property $fixture 'answer_plan')) {
+      continue
+    }
+
+    $plan = $fixture.answer_plan
+    foreach ($field in @('schema_version', 'plan_id', 'answer_mode', 'intent', 'evidence_cards', 'web_research', 'hold_reasons', 'response_requirements')) {
+      Assert-Property $plan $field "$relativePath answer_plan" ([ref]$issues)
+    }
+    if ((Test-Property $plan 'schema_version') -and $plan.schema_version -ne 'answer-plan/v1') {
+      $issues += "$relativePath answer_plan must use schema_version answer-plan/v1"
+    }
+    if (Test-Property $plan 'answer_mode') {
+      Assert-ValueIn $plan.answer_mode $answerModes "$relativePath answer_mode" ([ref]$issues)
+    }
+
+    if (Test-Property $plan 'intent') {
+      foreach ($field in @('schema_version', 'question_text', 'intent_kind', 'answer_mode', 'entities')) {
+        Assert-Property $plan.intent $field "$relativePath intent" ([ref]$issues)
+      }
+      if ((Test-Property $plan.intent 'schema_version') -and $plan.intent.schema_version -ne 'answer-intent/v1') {
+        $issues += "$relativePath intent must use schema_version answer-intent/v1"
+      }
+      if (Test-Property $plan.intent 'intent_kind') {
+        Assert-ValueIn $plan.intent.intent_kind $answerModes "$relativePath intent_kind" ([ref]$issues)
+      }
+      if (Test-Property $plan.intent 'answer_mode') {
+        Assert-ValueIn $plan.intent.answer_mode $answerModes "$relativePath intent answer_mode" ([ref]$issues)
+      }
+    }
+
+    $evidenceCards = @()
+    if (Test-Property $plan 'evidence_cards') {
+      $evidenceCards = @($plan.evidence_cards)
+      if ($evidenceCards.Count -eq 0) {
+        $issues += "$relativePath answer_plan must include at least one evidence card"
+      }
+      foreach ($card in $evidenceCards) {
+        foreach ($field in @('id', 'evidence_family', 'authority_role', 'canonicality', 'source_ref', 'supports_exact_current_fact', 'may_override_official_raw', 'limitations')) {
+          Assert-Property $card $field "$relativePath evidence card" ([ref]$issues)
+        }
+
+        $family = if (Test-Property $card 'evidence_family') { [string]$card.evidence_family } else { '' }
+        $canonicality = if (Test-Property $card 'canonicality') { [string]$card.canonicality } else { '' }
+        if ($family) {
+          Assert-ValueIn $family $evidenceFamilies "$relativePath evidence_family" ([ref]$issues)
+        }
+        if (Test-Property $card 'authority_role') {
+          Assert-ValueIn $card.authority_role $authorityRoles "$relativePath authority_role" ([ref]$issues)
+        }
+        if ($canonicality) {
+          Assert-ValueIn $canonicality $canonicalityValues "$relativePath canonicality" ([ref]$issues)
+        }
+
+        $supportsExact = (Test-Property $card 'supports_exact_current_fact') -and [bool]$card.supports_exact_current_fact
+        $mayOverride = (Test-Property $card 'may_override_official_raw') -and [bool]$card.may_override_official_raw
+
+        if ($supportsExact -and $family -ne 'frame_current_official_raw') {
+          $issues += "$relativePath allows non-official_raw evidence to support exact current facts: $family"
+        }
+        if ($family -eq 'generated_curated_reference' -and $supportsExact) {
+          $issues += "$relativePath allows generated reference to support exact current facts"
+        }
+        if ($family -in @('official_web', 'third_party_community_web') -and $supportsExact) {
+          $issues += "$relativePath allows web evidence to support exact current facts"
+        }
+        if ($family -in @('official_web', 'third_party_community_web') -and $mayOverride) {
+          $issues += "$relativePath allows web evidence to override official_raw"
+        }
+        if ($mayOverride) {
+          $issues += "$relativePath contains evidence that may override official_raw"
+        }
+
+        if (Test-Property $card 'source_ref') {
+          if (Test-Property $card.source_ref 'path') {
+            $sourcePath = [string]$card.source_ref.path
+            if ($sourcePath -match '^skills/sf6-agent/assets/frame-current/published/.+/official_raw\.json$') {
+              Assert-PathExists $sourcePath "$relativePath official_raw evidence" ([ref]$issues)
+            }
+            if ($sourcePath -eq 'skills/sf6-agent/references/generated-concepts.md') {
+              Assert-PathExists $sourcePath "$relativePath generated reference evidence" ([ref]$issues)
+            }
+          }
+        }
+      }
+    }
+
+    if (Test-Property $plan 'web_research') {
+      foreach ($field in @('web_required', 'web_allowed', 'web_used', 'web_forbidden_for_current_fact_override', 'conflict_requires_hold')) {
+        Assert-Property $plan.web_research $field "$relativePath web_research" ([ref]$issues)
+      }
+      if (Test-Property $plan.web_research 'required_source_authority') {
+        Assert-ValueIn $plan.web_research.required_source_authority $sourceAuthorityValues "$relativePath required_source_authority" ([ref]$issues)
+      }
+      if ((Test-Property $plan.web_research 'web_used') -and [bool]$plan.web_research.web_used) {
+        $issues += "$relativePath must not record live web research as already used"
+      }
+      if ((Test-Property $plan.web_research 'web_forbidden_for_current_fact_override') -and -not [bool]$plan.web_research.web_forbidden_for_current_fact_override) {
+        $issues += "$relativePath must forbid web current-fact override"
+      }
+      if ((Test-Property $plan.web_research 'conflict_requires_hold') -and -not [bool]$plan.web_research.conflict_requires_hold) {
+        $issues += "$relativePath must hold on web/current-fact conflict"
+      }
+    }
+
+    if (Test-Property $plan 'response_requirements') {
+      foreach ($field in @('cite_evidence', 'state_authority_boundary', 'state_confidence', 'boundary_notes')) {
+        Assert-Property $plan.response_requirements $field "$relativePath response_requirements" ([ref]$issues)
+      }
+    }
+
+    $coverage = if (Test-Property $fixture 'coverage') { [string]$fixture.coverage } else { '' }
+    if ($coverage -eq 'current_fact') {
+      $officialRawCards = @($evidenceCards | Where-Object {
+        $sourcePath = if (Test-Property $_.source_ref 'path') { [string]$_.source_ref.path } else { '' }
+        $_.evidence_family -eq 'frame_current_official_raw' -and
+        $_.supports_exact_current_fact -eq $true -and
+        $sourcePath -match '^skills/sf6-agent/assets/frame-current/published/.+/official_raw\.json$' -and
+        (Test-Path -LiteralPath (Join-Path $repoRoot $sourcePath) -PathType Leaf)
+      })
+      if ($officialRawCards.Count -eq 0) {
+        $issues += "$relativePath current_fact fixture must reference packaged official_raw"
+      }
+      if ((Test-Property $plan.web_research 'web_required') -and [bool]$plan.web_research.web_required) {
+        $issues += "$relativePath current_fact fixture must not require web research"
+      }
+    }
+
+    if ($coverage -eq 'stable_concept') {
+      $generatedCards = @($evidenceCards | Where-Object {
+        $_.evidence_family -eq 'generated_curated_reference' -and
+        $_.supports_exact_current_fact -eq $false
+      })
+      if ($generatedCards.Count -eq 0) {
+        $issues += "$relativePath stable_concept fixture must use generated references without exact current-fact authority"
+      }
+    }
+
+    if ($coverage -eq 'strategy') {
+      if (-not (Test-Property $fixture.smoke_expectations 'assumptions') -or @($fixture.smoke_expectations.assumptions).Count -eq 0) {
+        $issues += "$relativePath strategy fixture must list assumptions"
+      }
+      if (-not (Test-Property $fixture.smoke_expectations 'confidence_boundaries') -or @($fixture.smoke_expectations.confidence_boundaries).Count -eq 0) {
+        $issues += "$relativePath strategy fixture must list confidence boundaries"
+      }
+      if ((Test-Property $fixture.smoke_expectations 'strategy_conclusion_as_authority') -and [bool]$fixture.smoke_expectations.strategy_conclusion_as_authority) {
+        $issues += "$relativePath strategy fixture must not present conclusions as authority"
+      }
+    }
+
+    if ($coverage -eq 'hold') {
+      if (-not (Test-Property $plan 'hold_reasons') -or @($plan.hold_reasons).Count -eq 0) {
+        $issues += "$relativePath hold fixture must include hold reasons"
+      }
+    }
+
+    if ($coverage -eq 'web_needed') {
+      if (-not ((Test-Property $plan.web_research 'web_required') -and [bool]$plan.web_research.web_required)) {
+        $issues += "$relativePath web_needed fixture must mark web_required true"
+      }
+      if (-not ((Test-Property $plan.web_research 'web_forbidden_for_current_fact_override') -and [bool]$plan.web_research.web_forbidden_for_current_fact_override)) {
+        $issues += "$relativePath web_needed fixture must forbid official_raw override"
+      }
+    }
+
+    if ($coverage -eq 'japanese_query_normalization') {
+      foreach ($field in @('source_manifest', 'source_asset', 'runtime_authority', 'not_current_fact_authority', 'structured_inputs')) {
+        Assert-Property $fixture.normalization $field "$relativePath normalization" ([ref]$issues)
+      }
+      if ((Test-Property $fixture.normalization 'source_manifest') -and $fixture.normalization.source_manifest -ne $normalizationManifestRelativePath) {
+        $issues += "$relativePath must reference $normalizationManifestRelativePath"
+      }
+      if ((Test-Property $fixture.normalization 'source_asset') -and $fixture.normalization.source_asset -ne $normalizationAssetRelativePath) {
+        $issues += "$relativePath must reference $normalizationAssetRelativePath"
+      }
+      if ((Test-Property $fixture.normalization 'runtime_authority') -and $fixture.normalization.runtime_authority -ne 'query_normalization_only') {
+        $issues += "$relativePath normalization authority must be query_normalization_only"
+      }
+      if ((Test-Property $fixture.normalization 'not_current_fact_authority') -and $fixture.normalization.not_current_fact_authority -ne $true) {
+        $issues += "$relativePath normalization must be marked not_current_fact_authority"
+      }
+      if (Test-Property $fixture.normalization 'structured_inputs') {
+        $structured = $fixture.normalization.structured_inputs
+        foreach ($field in @('character_slug', 'move_input', 'requested_field')) {
+          Assert-Property $structured $field "$relativePath structured_inputs" ([ref]$issues)
+        }
+        if ((Test-Property $plan 'intent') -and (Test-Property $plan.intent 'entities')) {
+          foreach ($field in @('character_slug', 'move_input', 'requested_field')) {
+            if ((Test-Property $structured $field) -and (Test-Property $plan.intent.entities $field)) {
+              if ([string]$structured.$field -ne [string]$plan.intent.entities.$field) {
+                $issues += "$relativePath structured input mismatch for $field"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+foreach ($coverage in $requiredCoverage) {
+  if (-not $coverageSeen[$coverage]) {
+    $issues += "$fixtureRootRelativePath missing coverage: $coverage"
+  }
+}
+
+if ($issues.Count -gt 0) {
+  throw ($issues -join '; ')
+}
+
+Write-Host 'Answer smoke fixtures OK'


### PR DESCRIPTION
## Summary

Adds contract-level / fixture-level answer smoke skeletons for current fact, stable concept, strategy, hold, web-needed, and Japanese query-normalization paths.

This PR also adds a smoke report template and a dedicated validator for the answer smoke fixtures.

Closes #101

## Scope

- Added `tests/fixtures/answer-smoke/` with six contract-level smoke fixtures.
- Added `docs/testing/smoke-runs/answer-smoke-template.md` and marked it as a template, not an executed smoke report.
- Added `tests/validation/validate-answer-smoke-fixtures.ps1`.
- Added the validator to `tests/validation/run-all.ps1` near answer orchestration and normalization validators.

The fixtures cover:

- `current_fact` using packaged `official_raw`.
- `stable_concept` using generated references without exact current-fact authority.
- `strategy` with assumptions and confidence boundaries.
- `hold` for ambiguous current facts.
- `web_needed` without allowing web sources to override `official_raw`.
- Japanese query normalization mapped to structured inputs using #100 normalization runtime assets.

## Explicit Non-Changes

#102 and #103 are not implemented.

This is contract-level / fixture-level smoke only. It does not add live Hermes execution, live web research, operational answer prompts, retrieval or lookup code, public `sf6-agent` behavior changes, frame-current fact changes, generated knowledge outputs, historical smoke report rewrites, article/video planning docs, or old PR #71 merge/import.

## Validation

- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-answer-smoke-fixtures.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1`
- `git diff --check`
- `git diff --check origin/main...HEAD`

Windows PowerShell reported the expected git-unavailable warnings during generated-surface checks. Generated references, `.dist`, `skills/sf6-agent/assets/frame-current/`, and `skills/sf6-agent/assets/normalization/` were separately checked from a git-visible environment for residual unintended diff.