### PR TITLE
[v2.3] Add Codex-Hermes repo-local pack skeleton and boundary validator

### DIFF
--- a/packs/codex-hermes-sf6/README.md
+++ b/packs/codex-hermes-sf6/README.md
@@ -1,0 +1,47 @@
+# Codex-Hermes SF6 Pack
+
+This pack is repo-local maintainer support only.
+
+It is not public `sf6-agent` distribution, must not live under `skills/`,
+and does not define public answer behavior. It teaches Codex how to prepare
+and review Hermes delegation for maintainer work. It does not teach end users
+how to answer SF6 questions directly.
+
+Hermes output remains draft input until converted into reviewed repo
+artifacts through issue scope, validators, PR review, and merge. Repo
+artifacts, validators, workflows, contracts, issue scope, and PR review remain
+authoritative.
+
+## Contents
+
+- `skill/SKILL.md`: repo-local Codex skill/playbook source.
+- `resources/`: request templates, review checklists, and pointer notes.
+- `guards/`: boundary notes for local state, current facts, article/video
+  inputs, video observations, and external visual assets.
+
+## Required References
+
+This pack points to reviewed repo surfaces instead of duplicating them:
+
+- `workflows/maintainer-agent-session.md`
+- `workflows/codex-to-hermes-delegation.md`
+- `docs/architecture/codex-hermes-bridge-policy.md`
+- `docs/architecture/hermes-cli-capability-reference.md`
+- `docs/architecture/sf6-video-analysis-protocol.md`
+- `docs/architecture/external-frame-atlas-policy.md`
+
+## Rules
+
+- Keep this pack under `packs/codex-hermes-sf6/`.
+- Do not move Codex-Hermes maintainer support under `skills/`.
+- Do not modify `skills/sf6-agent/` from this pack.
+- Do not add public answer behavior.
+- Do not require live Hermes or live video analysis in CI.
+- Do not commit Hermes memory, sessions, local skills, Curator output,
+  browser state, cron state, Kanban state, checkpoints, local configs, logs,
+  caches, credentials, secrets, or tokens.
+- Do not treat stale PR #71 or PR #83 as active source material.
+- Do not promote exact current facts from Hermes output.
+- Do not override packaged `official_raw`.
+- Do not copy the Hermes CLI capability table from
+  `docs/architecture/hermes-cli-capability-reference.md`.

--- a/packs/codex-hermes-sf6/guards/article-video-boundary.md
+++ b/packs/codex-hermes-sf6/guards/article-video-boundary.md
@@ -1,0 +1,14 @@
+# Article And Video Boundary
+
+Article sources provide candidate claims and review input only until reviewed
+and promoted through an accepted repo path.
+
+Video observations are observation-only until reviewed and promoted through an
+accepted repo path.
+
+Do not store raw article dumps, raw video, frames, screenshots, GIFs, contact
+sheets, browser cache, or full transcripts by default.
+
+Do not infer exact current facts from article or video alone. Use hold,
+review, or a scoped refresh workflow when article or video material conflicts
+with current-fact authority.

--- a/packs/codex-hermes-sf6/guards/current-fact-boundary.md
+++ b/packs/codex-hermes-sf6/guards/current-fact-boundary.md
@@ -1,0 +1,16 @@
+# Current-Fact Boundary
+
+Exact current facts remain grounded in packaged/current-fact authorities:
+
+- `data/exports/`
+- `data/roster/`
+- generated frame-current runtime assets
+- packaged frame-current `official_raw`
+
+Hermes output is not exact current-fact authority.
+
+Web, article, video, and external visual atlas inputs must not override
+packaged `official_raw`. Conflicts require hold, review, or the appropriate
+frame-data refresh workflow.
+
+Do not promote exact current facts from draft Hermes output.

--- a/packs/codex-hermes-sf6/guards/external-visual-asset-boundary.md
+++ b/packs/codex-hermes-sf6/guards/external-visual-asset-boundary.md
@@ -1,0 +1,19 @@
+# External Visual Asset Boundary
+
+Reviewed policy:
+
+- `docs/architecture/external-frame-atlas-policy.md`
+
+External GIF, image, frame atlas, sprite sheet, video, screenshot, and contact
+sheet binaries are forbidden by default.
+
+External visual assets must use repo-external cache unless a future explicit
+issue approves another storage path with permission, license, validator, and
+bundle boundaries.
+
+External visual assets must not enter public `sf6-agent` bundles by default.
+They are not exact current-fact authority and cannot override packaged
+`official_raw`.
+
+Do not treat visual descriptor or perceptual hash matches as exact move
+confirmation without review.

--- a/packs/codex-hermes-sf6/guards/hermes-local-state-boundary.md
+++ b/packs/codex-hermes-sf6/guards/hermes-local-state-boundary.md
@@ -1,0 +1,23 @@
+# Hermes Local State Boundary
+
+Do not commit Hermes or Codex local state.
+
+Forbidden repo content includes:
+
+- Hermes memory
+- sessions
+- local skills
+- Curator archives or output
+- browser state
+- cron state
+- Kanban state
+- checkpoints
+- local configs
+- logs
+- caches
+- credentials
+- secrets
+- tokens
+
+If local state produces a useful idea, recreate the idea as an in-scope repo
+artifact through GitHub issue scope, validators, PR review, and merge.

--- a/packs/codex-hermes-sf6/guards/video-observation-boundary.md
+++ b/packs/codex-hermes-sf6/guards/video-observation-boundary.md
@@ -1,0 +1,15 @@
+# Video Observation Boundary
+
+Reviewed policy:
+
+- `docs/architecture/sf6-video-analysis-protocol.md`
+
+Video observations are draft input. They must record source fps uncertainty,
+tool availability, tool limitations, direct observations, not-inferred values,
+and review status.
+
+Do not infer exact frame values from video alone. Do not treat observed damage
+labels as current-system authority. Observed damage labels are review/eval
+context only unless accepted by a separate authority path.
+
+Packaged `official_raw` remains authority for current facts.

--- a/packs/codex-hermes-sf6/resources/codex-to-hermes-request-template.md
+++ b/packs/codex-hermes-sf6/resources/codex-to-hermes-request-template.md
@@ -1,0 +1,35 @@
+# Codex-To-Hermes Request Template
+
+Use this concise template when the target issue allows Hermes delegation.
+Hermes output is draft input only.
+
+```yaml
+target_issue:
+scope_summary:
+source_material:
+requested_artifact_type:
+allowed_outputs:
+forbidden_outputs:
+authority_boundaries:
+validators_to_run:
+review_checklist:
+```
+
+## Field Guidance
+
+- `target_issue`: the GitHub issue controlling scope and acceptance.
+- `scope_summary`: a short restatement of scope, non-goals, and acceptance.
+- `source_material`: repo artifacts, links, notes, article/video references,
+  or other input. Source material is not automatically canonical.
+- `requested_artifact_type`: draft note, candidate observation, review
+  checklist, validator proposal, or other scoped draft.
+- `allowed_outputs`: what Hermes may produce as draft input.
+- `forbidden_outputs`: exact current facts, public answer behavior, raw
+  article/video dumps, local state, secrets, or out-of-scope artifacts.
+- `authority_boundaries`: current-fact, article, video, external visual atlas,
+  and public adapter boundaries that apply.
+- `validators_to_run`: repo validators Codex must run before commit.
+- `review_checklist`: checks Codex must perform before using the draft.
+
+Reference `workflows/codex-to-hermes-delegation.md` for the canonical
+delegation workflow.

--- a/packs/codex-hermes-sf6/resources/external-frame-atlas-policy.md
+++ b/packs/codex-hermes-sf6/resources/external-frame-atlas-policy.md
@@ -1,0 +1,19 @@
+# External Frame Atlas Policy Pointer
+
+The reviewed external visual atlas policy is:
+
+- `docs/architecture/external-frame-atlas-policy.md`
+
+External visual atlas sources are visual reference inputs only. They do not
+provide exact current-fact authority and cannot override packaged
+`official_raw`.
+
+Future use requires source feasibility and evaluation before fetching,
+normalizing, caching, hashing, or referencing assets. This pack does not
+authorize scraping, downloading, caching, or binary storage by default.
+
+External visual assets must not enter public `sf6-agent` bundles by default.
+Visual descriptors or perceptual hashes must not become exact move
+confirmation without review.
+
+This resource is a pointer and short boundary reminder only.

--- a/packs/codex-hermes-sf6/resources/hermes-cli-capability-reference.md
+++ b/packs/codex-hermes-sf6/resources/hermes-cli-capability-reference.md
@@ -1,0 +1,15 @@
+# Hermes CLI Capability Reference Pointer
+
+The reviewed capability reference is:
+
+- `docs/architecture/hermes-cli-capability-reference.md`
+
+#121 owns the reviewed Hermes CLI capability reference. This pack must not
+encode separate Hermes CLI command truth and must not duplicate the #121
+command table.
+
+Unverified commands must not be required repo behavior. If a command,
+toolset, provider, model, or local configuration is unavailable or unverified,
+Codex must record the limitation and use a documented fallback or hold.
+
+This pointer is a usage note only.

--- a/packs/codex-hermes-sf6/resources/hermes-response-review-checklist.md
+++ b/packs/codex-hermes-sf6/resources/hermes-response-review-checklist.md
@@ -1,0 +1,19 @@
+# Hermes Response Review Checklist
+
+Use this checklist before converting Hermes output into repo artifacts.
+
+- Hermes output is draft input.
+- Source refs are not canonical evidence by themselves.
+- Candidate claims or observations must identify uncertainty and review
+  status.
+- Exact current facts require current-fact authority surfaces.
+- Web, article, video, and external atlas inputs cannot override
+  `official_raw`.
+- Local Hermes memory, sessions, skills, Curator output, browser state, cron
+  state, Kanban state, checkpoints, logs, caches, and profile state are
+  non-canonical.
+- Validators and PR review remain required before merge.
+- Public `sf6-agent` behavior must not change unless the target issue
+  explicitly allows it.
+- Generated surfaces, frame-current assets, normalization assets, `.dist`, and
+  historical smoke reports must remain unchanged unless explicitly in scope.

--- a/packs/codex-hermes-sf6/resources/sf6-video-analysis-protocol.md
+++ b/packs/codex-hermes-sf6/resources/sf6-video-analysis-protocol.md
@@ -1,0 +1,15 @@
+# SF6 Video Analysis Protocol Pointer
+
+The reviewed video protocol is:
+
+- `docs/architecture/sf6-video-analysis-protocol.md`
+
+Video output is observation draft input. Source video fps and game-native
+60fps must not be confused. Exact frame values and current facts cannot be
+inferred from video alone.
+
+Packaged frame-current `official_raw` remains authority for current facts.
+Video observations that conflict with current facts require hold, review, or a
+frame-data refresh workflow.
+
+This resource is a pointer and short boundary reminder only.

--- a/packs/codex-hermes-sf6/resources/stale-debt-boundary.md
+++ b/packs/codex-hermes-sf6/resources/stale-debt-boundary.md
@@ -1,0 +1,13 @@
+# Stale Debt Boundary
+
+Stale PR #71 and PR #83 are closed historical debt. They are not active source
+material.
+
+Old issues #70 and #82 are not active sources in their old form. Old branches,
+old draft observations, and stale notes are not active implementation input.
+
+Useful old ideas must be recreated as fresh, scoped GitHub issues under the
+current v2.2/v2.3 boundaries before any implementation work relies on them.
+
+Do not import stale PR content into this pack, public `sf6-agent` behavior,
+current-fact surfaces, video observations, or external visual atlas policy.

--- a/packs/codex-hermes-sf6/skill/SKILL.md
+++ b/packs/codex-hermes-sf6/skill/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: codex-hermes-sf6
+description: Repo-local Codex playbook for safe Hermes delegation in the SF6 Knowledge Agent Kit.
+---
+
+# Codex-Hermes SF6 Playbook
+
+This is repo-local Codex skill/playbook source. It is maintainer support only,
+not public `sf6-agent` distribution, and it does not define public answer
+behavior.
+
+## When To Use
+
+Use this playbook when issue scope allows Codex to delegate bounded draft or
+review work to Hermes, such as:
+
+- source analysis drafts
+- claim or observation draft shaping
+- validator-pattern proposals
+- review checklist drafting
+- maintainer workflow improvement proposals
+
+Codex remains the repo implementation entrypoint.
+
+## When Not To Use
+
+Do not use this playbook to:
+
+- answer public SF6 user questions directly
+- change `skills/sf6-agent/`
+- promote exact current facts from Hermes output
+- override packaged `official_raw`
+- run live Hermes in CI
+- run live video analysis in CI
+- scrape, download, cache, or store external visual assets
+- rely on closed PR #71 or PR #83
+
+## Required Procedure
+
+1. Read the target issue and restate scope, non-goals, and acceptance.
+2. Follow `workflows/maintainer-agent-session.md`.
+3. Use `workflows/codex-to-hermes-delegation.md` for request and response
+   shape when delegation is appropriate.
+4. Check `docs/architecture/codex-hermes-bridge-policy.md` before deciding
+   whether Hermes delegation fits.
+5. Check `docs/architecture/hermes-cli-capability-reference.md` for reviewed
+   Hermes capability status. Do not invent command requirements.
+6. For video work, check
+   `docs/architecture/sf6-video-analysis-protocol.md`.
+7. For external visual atlas work, check
+   `docs/architecture/external-frame-atlas-policy.md`.
+8. Convert useful Hermes output into reviewed repo artifacts only when the
+   target issue scope allows it.
+9. Run the relevant validators and record results before commit.
+
+## Review Checklist
+
+- Hermes output remains draft input.
+- Source references are review inputs, not canonical evidence by themselves.
+- Exact current facts remain grounded in current-fact authority surfaces.
+- Web, article, video, and external visual atlas inputs do not override
+  `official_raw`.
+- Hermes memory, sessions, local skills, Curator output, browser state, cron
+  state, Kanban state, and checkpoints are non-canonical.
+- Stale PR #71 and PR #83 are closed historical debt, not active sources.
+- Validators and PR review remain required.
+
+## Verification
+
+For pack changes, run:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-codex-hermes-pack.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1
+```
+
+Also run:
+
+```bash
+git diff --check
+git diff --check origin/main...HEAD
+```
+
+If PowerShell cannot see `git` during generated-surface checks, verify from a
+git-visible environment that generated references, `.dist`, frame-current
+assets, and normalization assets have no residual unintended diff.
+
+## Pitfalls
+
+- Do not copy the Hermes CLI command table into this pack.
+- Do not make Hermes local state into repo state.
+- Do not confuse video observations with current-fact authority.
+- Do not treat external GIF, image, or frame atlas assets as source-of-truth
+  data.
+- Do not add public adapter behavior to a maintainer playbook.

--- a/tests/validation/run-all.ps1
+++ b/tests/validation/run-all.ps1
@@ -37,6 +37,7 @@ $validationScripts = @(
   'tests/validation/validate-v2-surfaces.ps1',
   'tests/validation/validate-architecture-markers.ps1',
   'tests/validation/validate-hermes-pack.ps1',
+  'tests/validation/validate-codex-hermes-pack.ps1',
   'tests/validation/validate-v2-contracts.ps1',
   'tests/validation/validate-agent-toolchain.ps1',
   'tests/validation/validate-answer-orchestration-contracts.ps1',

--- a/tests/validation/validate-codex-hermes-pack.ps1
+++ b/tests/validation/validate-codex-hermes-pack.ps1
@@ -106,7 +106,7 @@ if ($issues.Count -eq 0) {
     }
   }
 
-  $activeStoragePattern = '(?im)^\s*(commit|store|save|persist|include|write|add)\b.*\b(memory|sessions?|local skills?|curator|browser state|cron state|kanban state|checkpoints?|local configs?|logs?|caches?|credentials?|secrets?|tokens?)\b'
+  $activeStoragePattern = '(?im)^\s*(?:[-*+]\s+|\d+[.)]\s+)?(commit|store|save|persist|include|write|add)\b.*\b(memory|sessions?|local skills?|curator|browser state|cron state|kanban state|checkpoints?|local configs?|logs?|caches?|credentials?|secrets?|tokens?)\b'
   $activeStalePattern = '(?i)\b(use|treat|list|include)\b.*\b(PR #71|PR #83)\b.*\bactive source\b'
   foreach ($relativePath in $requiredFiles) {
     $lineNumber = 0

--- a/tests/validation/validate-codex-hermes-pack.ps1
+++ b/tests/validation/validate-codex-hermes-pack.ps1
@@ -1,0 +1,173 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$packRootRelative = 'packs/codex-hermes-sf6'
+$packRoot = Join-Path $repoRoot $packRootRelative
+
+function Read-Text {
+  param([Parameter(Mandatory = $true)][string]$RelativePath)
+  return Get-Content -LiteralPath (Join-Path $repoRoot $RelativePath) -Raw -Encoding UTF8
+}
+
+function Add-Issue {
+  param(
+    [Parameter(Mandatory = $true)][ref]$Issues,
+    [Parameter(Mandatory = $true)][string]$Message
+  )
+  $Issues.Value += $Message
+}
+
+function Assert-File {
+  param(
+    [Parameter(Mandatory = $true)][string]$RelativePath,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  if (-not (Test-Path -LiteralPath (Join-Path $repoRoot $RelativePath) -PathType Leaf)) {
+    $Issues.Value += "Missing Codex-Hermes pack file: $RelativePath"
+  }
+}
+
+function Get-PackRelativePath {
+  param([Parameter(Mandatory = $true)][string]$FullPath)
+
+  $root = (Resolve-Path $packRoot).Path.TrimEnd([char[]]@('\', '/'))
+  $relative = $FullPath.Substring($root.Length)
+  $relative = $relative -replace '^[\\/]+', ''
+  return "$packRootRelative/$($relative -replace '\\', '/')"
+}
+
+$requiredFiles = @(
+  'packs/codex-hermes-sf6/README.md',
+  'packs/codex-hermes-sf6/skill/SKILL.md',
+  'packs/codex-hermes-sf6/resources/codex-to-hermes-request-template.md',
+  'packs/codex-hermes-sf6/resources/hermes-response-review-checklist.md',
+  'packs/codex-hermes-sf6/resources/stale-debt-boundary.md',
+  'packs/codex-hermes-sf6/resources/hermes-cli-capability-reference.md',
+  'packs/codex-hermes-sf6/resources/sf6-video-analysis-protocol.md',
+  'packs/codex-hermes-sf6/resources/external-frame-atlas-policy.md',
+  'packs/codex-hermes-sf6/guards/hermes-local-state-boundary.md',
+  'packs/codex-hermes-sf6/guards/current-fact-boundary.md',
+  'packs/codex-hermes-sf6/guards/article-video-boundary.md',
+  'packs/codex-hermes-sf6/guards/video-observation-boundary.md',
+  'packs/codex-hermes-sf6/guards/external-visual-asset-boundary.md'
+)
+
+$issues = @()
+
+if (-not (Test-Path -LiteralPath $packRoot -PathType Container)) {
+  $issues += "Missing Codex-Hermes pack root: $packRootRelative"
+}
+
+foreach ($relativePath in $requiredFiles) {
+  Assert-File $relativePath ([ref]$issues)
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot 'skills/codex-hermes-sf6')) {
+  $issues += 'Codex-Hermes maintainer support must not be placed under skills/.'
+}
+
+if ($issues.Count -eq 0) {
+  $combinedText = ($requiredFiles | ForEach-Object { Read-Text $_ }) -join "`n"
+
+  $requiredPhrases = @(
+    'repo-local maintainer support only',
+    'does not define public answer behavior',
+    'workflows/maintainer-agent-session.md',
+    'workflows/codex-to-hermes-delegation.md',
+    'docs/architecture/codex-hermes-bridge-policy.md',
+    'docs/architecture/hermes-cli-capability-reference.md',
+    'docs/architecture/sf6-video-analysis-protocol.md',
+    'docs/architecture/external-frame-atlas-policy.md',
+    'Hermes output remains draft input',
+    'Stale PR #71 and PR #83 are closed historical debt',
+    'official_raw'
+  )
+
+  foreach ($phrase in $requiredPhrases) {
+    if ($combinedText -notmatch [regex]::Escape($phrase)) {
+      $issues += "Codex-Hermes pack missing required phrase: $phrase"
+    }
+  }
+
+  $cliPointer = Read-Text 'packs/codex-hermes-sf6/resources/hermes-cli-capability-reference.md'
+  if ($cliPointer -match '\|\s*Capability\s*\|') {
+    $issues += 'Codex-Hermes pack must not duplicate the #121 Hermes CLI capability command table.'
+  }
+
+  $activePublicAnswerPatterns = @(
+    '(?im)^\s*(this pack|the pack)\s+defines\s+public answer behavior',
+    '(?im)^\s*define\s+public answer behavior'
+  )
+  foreach ($pattern in $activePublicAnswerPatterns) {
+    if ($combinedText -match $pattern) {
+      $issues += 'Codex-Hermes pack appears to define public answer behavior.'
+    }
+  }
+
+  $activeStoragePattern = '(?im)^\s*(commit|store|save|persist|include|write|add)\b.*\b(memory|sessions?|local skills?|curator|browser state|cron state|kanban state|checkpoints?|local configs?|logs?|caches?|credentials?|secrets?|tokens?)\b'
+  $activeStalePattern = '(?i)\b(use|treat|list|include)\b.*\b(PR #71|PR #83)\b.*\bactive source\b'
+  foreach ($relativePath in $requiredFiles) {
+    $lineNumber = 0
+    foreach ($line in (Read-Text $relativePath) -split "`r?`n") {
+      $lineNumber += 1
+      if (
+        $line -match $activeStalePattern -and
+        $line -notmatch '(?i)\b(do not|must not|not active|closed historical debt)\b'
+      ) {
+        $issues += "Codex-Hermes pack treats stale PR #71 or #83 as active source material in $relativePath line ${lineNumber}: $line"
+      }
+
+      if (
+        $line -match $activeStoragePattern -and
+        $line -notmatch '(?i)\b(do not|must not|forbid|forbidden|not)\b'
+      ) {
+        $issues += "Potential active local-state storage instruction in $relativePath line ${lineNumber}: $line"
+      }
+    }
+  }
+}
+
+if (Test-Path -LiteralPath $packRoot -PathType Container) {
+  $forbiddenPathPatterns = @(
+    '(^|[\\/])\.env($|[\\.\\/])',
+    'secret',
+    'token',
+    'credential',
+    'session',
+    'memory',
+    'cache',
+    'log',
+    'browser-state',
+    'profile-state',
+    'cron',
+    'kanban',
+    'checkpoint',
+    '\.sqlite$',
+    '\.db$'
+  )
+
+  $binaryExtensions = @('.gif', '.png', '.jpg', '.jpeg', '.webp', '.mp4', '.mov', '.avi', '.mkv')
+
+  foreach ($item in Get-ChildItem -LiteralPath $packRoot -Force -Recurse -File) {
+    $relativePath = Get-PackRelativePath $item.FullName
+    $relativeLower = $relativePath.ToLowerInvariant()
+
+    foreach ($pattern in $forbiddenPathPatterns) {
+      if ($relativeLower -match $pattern) {
+        $issues += "Forbidden local-state or secret-like path under Codex-Hermes pack: $relativePath"
+      }
+    }
+
+    if ($binaryExtensions -contains $item.Extension.ToLowerInvariant()) {
+      $issues += "Forbidden binary asset under Codex-Hermes pack: $relativePath"
+    }
+  }
+}
+
+if ($issues.Count -gt 0) {
+  throw ($issues -join '; ')
+}
+
+Write-Host 'Codex-Hermes pack OK'


### PR DESCRIPTION
## Summary

- Add `packs/codex-hermes-sf6/` as a repo-local Codex-Hermes maintainer support pack.
- Add repo-local playbook, request template, review checklist, stale-debt boundary, and pointer resources for #121, #123, and #124.
- Add guard docs for Hermes local state, current facts, article/video inputs, video observations, and external visual assets.
- Add `tests/validation/validate-codex-hermes-pack.ps1` and include it in `tests/validation/run-all.ps1`.

## Scope

This PR implements #120 only.

The pack is maintainer support only and does not define public `sf6-agent` answer behavior. The Hermes CLI capability reference, SF6 video-analysis protocol, and external frame-atlas policy are referenced as reviewed owner surfaces rather than copied into the pack.

#115 and #119 are not implemented.

No live Hermes execution, live video analysis, dry-run fixtures, plugin/gateway planning, production cron/MCP/gateway/Kanban config, local Hermes state, credentials/secrets, external asset scraping/download/cache, GIF/image/video binaries, public `sf6-agent` behavior change, frame-current change, normalization change, generated output, `.dist` change, historical smoke rewrite, or stale PR #71/#83 active import was added.

## Validation

- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-codex-hermes-pack.ps1` passed (`Codex-Hermes pack OK`).
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1` passed (`V2 validation suite OK`).
  - PowerShell reported `git is unavailable` warnings during generated-surface checks.
- `git diff --check` passed.
- `git diff --check origin/main...HEAD` passed.
- WSL git-visible generated-surface check confirmed no residual unintended diff in `skills/sf6-agent/references`, `.dist`, `skills/sf6-agent/assets/frame-current`, or `skills/sf6-agent/assets/normalization`.

Closes #120
