### PR TITLE
[v2.3] Add Codex-to-Hermes dry-run delegation fixtures

### DIFF
--- a/tests/fixtures/codex-hermes-delegation/external-atlas-binary-import-forbidden.json
+++ b/tests/fixtures/codex-hermes-delegation/external-atlas-binary-import-forbidden.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": "codex-hermes-delegation-fixture/v1",
+  "scenario_id": "external-atlas-binary-import-forbidden",
+  "scenario_kind": "external_atlas_binary_forbidden",
+  "codex_request": {
+    "target_issue": "#115",
+    "target_scope_summary": "Validate rejection of a request to download, cache, or commit external GIF/image/frame-atlas binaries.",
+    "source_material": [
+      {
+        "source_kind": "external_visual_atlas",
+        "source_role": "unreviewed_visual_reference",
+        "ref": "external-atlas-candidate-placeholder"
+      }
+    ],
+    "requested_artifact_type": "external atlas binary import",
+    "allowed_outputs": [
+      "rejection",
+      "defer note",
+      "metadata-only source evaluation guidance"
+    ],
+    "forbidden_outputs": [
+      "download external GIF assets",
+      "download external image assets",
+      "commit frame-atlas binaries",
+      "repo-local binary asset path",
+      "public bundle inclusion"
+    ],
+    "authority_boundaries": [
+      "external visual atlas sources are visual reference inputs only",
+      "binary storage requires a future explicit issue",
+      "official_raw cannot be overridden"
+    ],
+    "validators_to_run": [
+      "tests/validation/validate-codex-hermes-delegation-fixtures.ps1",
+      "tests/validation/run-all.ps1"
+    ],
+    "review_checklist": [
+      "confirm binary import request is rejected",
+      "confirm no file writes are proposed",
+      "confirm no repo cache paths are proposed",
+      "confirm metadata-only guidance is optional and safe"
+    ]
+  },
+  "hermes_draft_response": {
+    "summary": "Reject the binary import request and defer any asset work to a future explicit issue.",
+    "proposed_artifacts": [
+      "metadata-only source evaluation note"
+    ],
+    "source_refs": [
+      "docs/architecture/external-frame-atlas-policy.md"
+    ],
+    "evidence_candidate_notes": [
+      "External GIF, image, and frame-atlas binaries are not allowed in this scope.",
+      "Future source evaluation may assess feasibility without downloading assets."
+    ],
+    "uncertainty_or_hold_reasons": [
+      "permission, license, redistribution, and freshness are not reviewed",
+      "binary storage is not approved"
+    ],
+    "boundary_notes": [
+      "reject external atlas binary import",
+      "no file writes",
+      "no public bundle inclusion",
+      "official_raw remains authority"
+    ],
+    "follow_up_recommendations": [
+      "Create a later source evaluation matrix before any asset workflow."
+    ]
+  },
+  "post_delegation_review": {
+    "hermes_output_is_draft_input": true,
+    "canonical_promotion_allowed": false,
+    "requires_codex_review": true,
+    "requires_validators": true,
+    "local_state_committed": false,
+    "raw_transcript_committed": false
+  },
+  "expected_boundary_outcome": {
+    "status": "reject",
+    "reason": "External GIF/image/frame-atlas binary import is forbidden by default and must be deferred."
+  }
+}

--- a/tests/fixtures/codex-hermes-delegation/external-atlas-metadata-only-guidance.json
+++ b/tests/fixtures/codex-hermes-delegation/external-atlas-metadata-only-guidance.json
@@ -1,0 +1,84 @@
+{
+  "schema_version": "codex-hermes-delegation-fixture/v1",
+  "scenario_id": "external-atlas-metadata-only-guidance",
+  "scenario_kind": "external_atlas_metadata_only",
+  "codex_request": {
+    "target_issue": "#115",
+    "target_scope_summary": "Validate metadata-only guidance for future external visual atlas use.",
+    "source_material": [
+      {
+        "source_kind": "external_visual_atlas_policy",
+        "source_role": "reviewed_policy",
+        "ref": "docs/architecture/external-frame-atlas-policy.md"
+      }
+    ],
+    "requested_artifact_type": "metadata-only guidance",
+    "allowed_outputs": [
+      "source evaluation guidance",
+      "acquisition feasibility checklist",
+      "metadata-only manifest recommendation",
+      "candidate move-recognition review boundary"
+    ],
+    "forbidden_outputs": [
+      "scraping",
+      "download",
+      "cache creation",
+      "binary storage",
+      "official_raw override",
+      "exact move confirmation without review"
+    ],
+    "authority_boundaries": [
+      "external visual references are observation support only",
+      "candidate move recognition requires confidence and review",
+      "official_raw remains current-fact authority"
+    ],
+    "validators_to_run": [
+      "tests/validation/validate-codex-hermes-delegation-fixtures.ps1",
+      "tests/validation/run-all.ps1"
+    ],
+    "review_checklist": [
+      "confirm source evaluation or acquisition feasibility is recommended",
+      "confirm no scraping, download, cache, or binary storage is allowed",
+      "confirm official_raw remains authority",
+      "confirm candidate recognition is review-only"
+    ]
+  },
+  "hermes_draft_response": {
+    "summary": "Use metadata-only source evaluation and acquisition feasibility before any external visual atlas workflow.",
+    "proposed_artifacts": [
+      "metadata-only source evaluation checklist",
+      "manifest field recommendation"
+    ],
+    "source_refs": [
+      "docs/architecture/external-frame-atlas-policy.md"
+    ],
+    "evidence_candidate_notes": [
+      "Source evaluation should check access, terms, rate limits, coverage, move mapping, and freshness.",
+      "Candidate move recognition remains review-only and must include confidence."
+    ],
+    "uncertainty_or_hold_reasons": [
+      "permission, license, and redistribution status are not reviewed",
+      "binary-derived fields may be null"
+    ],
+    "boundary_notes": [
+      "no scraping, download, cache creation, or binary storage",
+      "official_raw is not overridden",
+      "external visual references are not exact current-fact authority"
+    ],
+    "follow_up_recommendations": [
+      "Add a future source evaluation matrix before any local-only asset workflow."
+    ]
+  },
+  "post_delegation_review": {
+    "hermes_output_is_draft_input": true,
+    "canonical_promotion_allowed": false,
+    "requires_codex_review": true,
+    "requires_validators": true,
+    "local_state_committed": false,
+    "raw_transcript_committed": false
+  },
+  "expected_boundary_outcome": {
+    "status": "metadata_only_guidance",
+    "reason": "Metadata-only guidance is allowed when it forbids scraping, download, cache creation, binary storage, and official_raw override."
+  }
+}

--- a/tests/fixtures/codex-hermes-delegation/move-frequency-review-only.json
+++ b/tests/fixtures/codex-hermes-delegation/move-frequency-review-only.json
@@ -1,0 +1,88 @@
+{
+  "schema_version": "codex-hermes-delegation-fixture/v1",
+  "scenario_id": "move-frequency-review-only",
+  "scenario_kind": "move_frequency_review_only",
+  "codex_request": {
+    "target_issue": "#115",
+    "target_scope_summary": "Validate that candidate move-recognition or move-frequency aggregation remains confidence-scored review-only draft input.",
+    "source_material": [
+      {
+        "source_kind": "video_observation_plan",
+        "source_role": "planning_context",
+        "ref": "docs/architecture/sf6-video-analysis-protocol.md"
+      },
+      {
+        "source_kind": "external_visual_atlas_policy",
+        "source_role": "planning_context",
+        "ref": "docs/architecture/external-frame-atlas-policy.md"
+      }
+    ],
+    "requested_artifact_type": "move-frequency draft",
+    "allowed_outputs": [
+      "candidate move counts",
+      "confidence labels",
+      "review-only notes",
+      "official_raw consistency check requirement"
+    ],
+    "forbidden_outputs": [
+      "exact move confirmation without review",
+      "matchup verdict",
+      "coaching conclusion as final authority",
+      "current-fact promotion",
+      "official_raw override"
+    ],
+    "authority_boundaries": [
+      "candidate move recognition is not final authority",
+      "move frequency aggregation is review-only draft input",
+      "external visual references do not become exact current-fact authority"
+    ],
+    "validators_to_run": [
+      "tests/validation/validate-codex-hermes-delegation-fixtures.ps1",
+      "tests/validation/run-all.ps1"
+    ],
+    "review_checklist": [
+      "confirm candidate and confidence fields are present",
+      "confirm review-only status",
+      "confirm external visual references do not override official_raw",
+      "confirm no final coaching or matchup conclusion is promoted"
+    ]
+  },
+  "hermes_draft_response": {
+    "summary": "Candidate move-frequency aggregation can be proposed only as confidence-scored review input.",
+    "proposed_artifacts": [
+      "candidate move-frequency review table"
+    ],
+    "source_refs": [
+      "docs/architecture/sf6-video-analysis-protocol.md",
+      "docs/architecture/external-frame-atlas-policy.md"
+    ],
+    "evidence_candidate_notes": [
+      "Candidate move counts require confidence and review status.",
+      "External visual references are observation support only."
+    ],
+    "uncertainty_or_hold_reasons": [
+      "source fps, move mapping, and visual reference freshness may be uncertain",
+      "candidate recognition is not final authority"
+    ],
+    "boundary_notes": [
+      "review-only draft input",
+      "official_raw consistency check is required for current facts",
+      "no exact move confirmation without review"
+    ],
+    "follow_up_recommendations": [
+      "Use metadata-only external atlas guidance before any future local-only recognition pipeline."
+    ]
+  },
+  "post_delegation_review": {
+    "hermes_output_is_draft_input": true,
+    "canonical_promotion_allowed": false,
+    "requires_codex_review": true,
+    "requires_validators": true,
+    "local_state_committed": false,
+    "raw_transcript_committed": false
+  },
+  "expected_boundary_outcome": {
+    "status": "accept_draft",
+    "reason": "Move-frequency aggregation is allowed only as candidate, confidence-scored, review-only draft input."
+  }
+}

--- a/tests/fixtures/codex-hermes-delegation/source-analysis-valid.json
+++ b/tests/fixtures/codex-hermes-delegation/source-analysis-valid.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": "codex-hermes-delegation-fixture/v1",
+  "scenario_id": "source-analysis-valid",
+  "scenario_kind": "source_analysis",
+  "codex_request": {
+    "target_issue": "#115",
+    "target_scope_summary": "Validate a dry-run article/source analysis delegation shape without live Hermes, live web research, raw excerpts, or claim promotion.",
+    "source_material": [
+      {
+        "source_kind": "repo_artifact",
+        "source_role": "reviewed_policy",
+        "ref": "docs/architecture/codex-hermes-bridge-policy.md"
+      }
+    ],
+    "requested_artifact_type": "source analysis draft",
+    "allowed_outputs": [
+      "summary draft",
+      "source_refs",
+      "evidence_candidate_notes",
+      "uncertainty notes",
+      "boundary_notes"
+    ],
+    "forbidden_outputs": [
+      "raw excerpts",
+      "full copied source text",
+      "exact current facts promoted from draft output",
+      "public answer behavior"
+    ],
+    "authority_boundaries": [
+      "Hermes output remains draft input",
+      "source_refs are review inputs, not canonical evidence by themselves",
+      "exact current facts remain grounded in data exports, roster data, and packaged official_raw"
+    ],
+    "validators_to_run": [
+      "tests/validation/validate-codex-hermes-delegation-fixtures.ps1",
+      "tests/validation/run-all.ps1"
+    ],
+    "review_checklist": [
+      "confirm source_refs are non-canonical review inputs",
+      "confirm no raw excerpts are present",
+      "confirm no current facts are promoted",
+      "confirm Codex review and validators are still required"
+    ]
+  },
+  "hermes_draft_response": {
+    "summary": "The bridge policy allows bounded source analysis as maintainer draft input only.",
+    "proposed_artifacts": [
+      "review note draft for Codex"
+    ],
+    "source_refs": [
+      "docs/architecture/codex-hermes-bridge-policy.md"
+    ],
+    "evidence_candidate_notes": [
+      "Codex remains the implementation entrypoint.",
+      "Hermes output must be reviewed before becoming a repo artifact."
+    ],
+    "uncertainty_or_hold_reasons": [
+      "This is a dry-run fixture and not an executed delegation."
+    ],
+    "boundary_notes": [
+      "Hermes output remains draft input.",
+      "No exact current facts are promoted.",
+      "No public sf6-agent behavior changes."
+    ],
+    "follow_up_recommendations": [
+      "Use this fixture to validate source_refs and boundary_notes handling."
+    ]
+  },
+  "post_delegation_review": {
+    "hermes_output_is_draft_input": true,
+    "canonical_promotion_allowed": false,
+    "requires_codex_review": true,
+    "requires_validators": true,
+    "local_state_committed": false,
+    "raw_transcript_committed": false
+  },
+  "expected_boundary_outcome": {
+    "status": "accept_draft",
+    "reason": "A source analysis draft is acceptable when it keeps source_refs non-canonical and promotes no exact current facts."
+  }
+}

--- a/tests/fixtures/codex-hermes-delegation/stale-pr-active-source-rejection.json
+++ b/tests/fixtures/codex-hermes-delegation/stale-pr-active-source-rejection.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "codex-hermes-delegation-fixture/v1",
+  "scenario_id": "stale-pr-active-source-rejection",
+  "scenario_kind": "stale_pr_rejection",
+  "codex_request": {
+    "target_issue": "#115",
+    "target_scope_summary": "Validate rejection of stale PR #71 or PR #83 as active source material.",
+    "source_material": [
+      {
+        "source_kind": "closed_pull_request",
+        "source_role": "historical_debt",
+        "ref": "PR #71 and PR #83"
+      }
+    ],
+    "requested_artifact_type": "active source import",
+    "allowed_outputs": [
+      "rejection",
+      "fresh scoped issue recommendation"
+    ],
+    "forbidden_outputs": [
+      "active source use",
+      "stale PR content promotion",
+      "old branch import",
+      "current-fact promotion"
+    ],
+    "authority_boundaries": [
+      "closed PRs are historical debt",
+      "old ideas require fresh scoped issue recreation",
+      "repo artifacts and current contracts remain authoritative"
+    ],
+    "validators_to_run": [
+      "tests/validation/validate-codex-hermes-delegation-fixtures.ps1",
+      "tests/validation/run-all.ps1"
+    ],
+    "review_checklist": [
+      "confirm PR #71 and PR #83 are rejected as active sources",
+      "confirm fresh scoped issue recreation is required",
+      "confirm no stale content is promoted"
+    ]
+  },
+  "hermes_draft_response": {
+    "summary": "Reject PR #71 and PR #83 as active source material.",
+    "proposed_artifacts": [
+      "fresh scoped issue outline if a narrow idea is worth reconsidering"
+    ],
+    "source_refs": [
+      "docs/architecture/codex-hermes-bridge-policy.md",
+      "packs/codex-hermes-sf6/resources/stale-debt-boundary.md"
+    ],
+    "evidence_candidate_notes": [
+      "PR #71 and PR #83 are closed historical debt.",
+      "Old ideas must be recreated under current contracts and validators."
+    ],
+    "uncertainty_or_hold_reasons": [
+      "stale material is non-canonical"
+    ],
+    "boundary_notes": [
+      "reject active-source use",
+      "no stale PR content is promoted",
+      "fresh scoped issue recreation is required"
+    ],
+    "follow_up_recommendations": [
+      "Open a new narrow issue if a specific old idea should be reconsidered."
+    ]
+  },
+  "post_delegation_review": {
+    "hermes_output_is_draft_input": true,
+    "canonical_promotion_allowed": false,
+    "requires_codex_review": true,
+    "requires_validators": true,
+    "local_state_committed": false,
+    "raw_transcript_committed": false
+  },
+  "expected_boundary_outcome": {
+    "status": "reject",
+    "reason": "Stale PR #71 and PR #83 must not be used as active source material."
+  }
+}

--- a/tests/fixtures/codex-hermes-delegation/validator-pattern-proposal.json
+++ b/tests/fixtures/codex-hermes-delegation/validator-pattern-proposal.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": "codex-hermes-delegation-fixture/v1",
+  "scenario_id": "validator-pattern-proposal",
+  "scenario_kind": "validator_pattern",
+  "codex_request": {
+    "target_issue": "#115",
+    "target_scope_summary": "Validate that Hermes may propose validator patterns as review input only, without live command execution or automatic enforcement.",
+    "source_material": [
+      {
+        "source_kind": "repo_artifact",
+        "source_role": "validator",
+        "ref": "tests/validation/validate-codex-hermes-pack.ps1"
+      }
+    ],
+    "requested_artifact_type": "validator-pattern proposal",
+    "allowed_outputs": [
+      "review input",
+      "candidate checks",
+      "expected pass examples",
+      "expected fail examples"
+    ],
+    "forbidden_outputs": [
+      "live command execution requirement",
+      "automatic code modification",
+      "canonical promotion without PR review",
+      "public answer behavior"
+    ],
+    "authority_boundaries": [
+      "validator proposals are review input only",
+      "implementation still requires scoped PR and validators",
+      "live Hermes is not required"
+    ],
+    "validators_to_run": [
+      "tests/validation/validate-codex-hermes-delegation-fixtures.ps1",
+      "tests/validation/run-all.ps1"
+    ],
+    "review_checklist": [
+      "confirm proposal is review input",
+      "confirm no live command execution is required",
+      "confirm no canonical promotion is allowed",
+      "confirm scoped PR review remains required"
+    ]
+  },
+  "hermes_draft_response": {
+    "summary": "A validator-pattern proposal can suggest checks, but it remains review input only.",
+    "proposed_artifacts": [
+      "candidate required-field check",
+      "candidate forbidden-boundary check"
+    ],
+    "source_refs": [
+      "tests/validation/validate-codex-hermes-pack.ps1"
+    ],
+    "evidence_candidate_notes": [
+      "Expected pass examples can describe compliant fixture shape.",
+      "Expected fail examples can describe missing boundary fields."
+    ],
+    "uncertainty_or_hold_reasons": [
+      "Actual enforcement requires Codex implementation and repository validators."
+    ],
+    "boundary_notes": [
+      "This proposal is review input only.",
+      "No external command execution is required by the fixture.",
+      "No public sf6-agent behavior changes."
+    ],
+    "follow_up_recommendations": [
+      "Codex should implement any accepted validator change in a scoped PR."
+    ]
+  },
+  "post_delegation_review": {
+    "hermes_output_is_draft_input": true,
+    "canonical_promotion_allowed": false,
+    "requires_codex_review": true,
+    "requires_validators": true,
+    "local_state_committed": false,
+    "raw_transcript_committed": false
+  },
+  "expected_boundary_outcome": {
+    "status": "accept_draft",
+    "reason": "Validator-pattern proposals are acceptable as review input only and do not require live command execution."
+  }
+}

--- a/tests/fixtures/codex-hermes-delegation/video-analyze-unavailable-fallback.json
+++ b/tests/fixtures/codex-hermes-delegation/video-analyze-unavailable-fallback.json
@@ -1,0 +1,84 @@
+{
+  "schema_version": "codex-hermes-delegation-fixture/v1",
+  "scenario_id": "video-analyze-unavailable-fallback",
+  "scenario_kind": "video_fallback",
+  "codex_request": {
+    "target_issue": "#115",
+    "target_scope_summary": "Validate fallback behavior when video_analyze is unavailable or unverified.",
+    "source_material": [
+      {
+        "source_kind": "video_reference",
+        "source_role": "observation_request",
+        "ref": "provided-video-reference-placeholder"
+      }
+    ],
+    "requested_artifact_type": "video observation draft",
+    "allowed_outputs": [
+      "tool_unavailable note",
+      "tool_limitations",
+      "manual review fallback",
+      "hold status",
+      "not_inferred list"
+    ],
+    "forbidden_outputs": [
+      "live video analysis",
+      "video_analyze execution",
+      "exact frame values",
+      "exact current facts from video",
+      "official_raw override"
+    ],
+    "authority_boundaries": [
+      "video_analyze is provider-model-toolset dependent",
+      "video observations are draft input only",
+      "official_raw remains authority for current facts"
+    ],
+    "validators_to_run": [
+      "tests/validation/validate-codex-hermes-delegation-fixtures.ps1",
+      "tests/validation/run-all.ps1"
+    ],
+    "review_checklist": [
+      "confirm tool_unavailable is recorded",
+      "confirm not_inferred includes exact frame/current facts",
+      "confirm official_raw check is required",
+      "confirm review_status is hold"
+    ]
+  },
+  "hermes_draft_response": {
+    "summary": "video_analyze is unavailable for this dry-run fixture, so the request must use fallback or hold.",
+    "proposed_artifacts": [
+      "video observation hold draft"
+    ],
+    "source_refs": [
+      "docs/architecture/sf6-video-analysis-protocol.md"
+    ],
+    "evidence_candidate_notes": [
+      "tool_unavailable: video_analyze unavailable",
+      "tool_limitations: no live video analysis in this fixture"
+    ],
+    "uncertainty_or_hold_reasons": [
+      "source fps is unknown",
+      "tool availability is not verified",
+      "exact frame-window inference is unsafe"
+    ],
+    "boundary_notes": [
+      "not_inferred: exact startup, exact active frames, exact recovery, exact block advantage, current-system frame fact",
+      "official_raw check is required before any current-fact promotion",
+      "review_status: hold"
+    ],
+    "follow_up_recommendations": [
+      "Use manual review or frame sampling only in a later scoped workflow."
+    ]
+  },
+  "post_delegation_review": {
+    "hermes_output_is_draft_input": true,
+    "canonical_promotion_allowed": false,
+    "requires_codex_review": true,
+    "requires_validators": true,
+    "local_state_committed": false,
+    "raw_transcript_committed": false
+  },
+  "expected_boundary_outcome": {
+    "status": "hold",
+    "reason": "Unavailable video_analyze must produce tool_unavailable, limitations, not_inferred, and official_raw review requirements instead of fabricated observations."
+  }
+}

--- a/tests/fixtures/codex-hermes-delegation/video-current-fact-forbidden.json
+++ b/tests/fixtures/codex-hermes-delegation/video-current-fact-forbidden.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": "codex-hermes-delegation-fixture/v1",
+  "scenario_id": "video-current-fact-forbidden",
+  "scenario_kind": "video_current_fact_forbidden",
+  "codex_request": {
+    "target_issue": "#115",
+    "target_scope_summary": "Validate rejection of a request that tries to infer exact current facts from video alone.",
+    "source_material": [
+      {
+        "source_kind": "video_reference",
+        "source_role": "non_canonical_observation",
+        "ref": "provided-video-reference-placeholder"
+      }
+    ],
+    "requested_artifact_type": "current-fact claim from video",
+    "allowed_outputs": [
+      "rejection",
+      "hold reason",
+      "official_raw lookup requirement",
+      "not_inferred list"
+    ],
+    "forbidden_outputs": [
+      "exact startup as video-derived fact",
+      "exact active frames as video-derived fact",
+      "exact recovery as video-derived fact",
+      "exact block advantage as video-derived fact",
+      "current-system frame fact from video alone"
+    ],
+    "authority_boundaries": [
+      "official_raw remains authority",
+      "video alone cannot establish exact current facts",
+      "source video fps uncertainty must be recorded"
+    ],
+    "validators_to_run": [
+      "tests/validation/validate-codex-hermes-delegation-fixtures.ps1",
+      "tests/validation/run-all.ps1"
+    ],
+    "review_checklist": [
+      "confirm request is rejected or held",
+      "confirm official_raw remains authority",
+      "confirm no exact frame data is accepted from video alone",
+      "confirm no public answer behavior changes"
+    ]
+  },
+  "hermes_draft_response": {
+    "summary": "Reject exact current-fact inference from video alone.",
+    "proposed_artifacts": [
+      "hold note"
+    ],
+    "source_refs": [
+      "docs/architecture/sf6-video-analysis-protocol.md"
+    ],
+    "evidence_candidate_notes": [
+      "Video may support candidate observations only.",
+      "Source video fps and effective fps may be unknown."
+    ],
+    "uncertainty_or_hold_reasons": [
+      "video alone cannot establish exact current facts",
+      "official_raw lookup is required"
+    ],
+    "boundary_notes": [
+      "official_raw remains authority",
+      "reject exact startup, active, recovery, and block advantage claims from video alone",
+      "Hermes output remains draft input"
+    ],
+    "follow_up_recommendations": [
+      "Route any conflict to review or frame-data refresh workflow."
+    ]
+  },
+  "post_delegation_review": {
+    "hermes_output_is_draft_input": true,
+    "canonical_promotion_allowed": false,
+    "requires_codex_review": true,
+    "requires_validators": true,
+    "local_state_committed": false,
+    "raw_transcript_committed": false
+  },
+  "expected_boundary_outcome": {
+    "status": "reject",
+    "reason": "Exact current facts from video alone are forbidden; official_raw remains the authority gate."
+  }
+}

--- a/tests/fixtures/codex-hermes-delegation/video-observed-damage-label-boundary.json
+++ b/tests/fixtures/codex-hermes-delegation/video-observed-damage-label-boundary.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": "codex-hermes-delegation-fixture/v1",
+  "scenario_id": "video-observed-damage-label-boundary",
+  "scenario_kind": "observed_damage_label_boundary",
+  "codex_request": {
+    "target_issue": "#115",
+    "target_scope_summary": "Validate that observed damage labels in video are review context only, not current-system authority.",
+    "source_material": [
+      {
+        "source_kind": "video_reference",
+        "source_role": "observation_request",
+        "ref": "provided-video-reference-placeholder"
+      }
+    ],
+    "requested_artifact_type": "observed damage label note",
+    "allowed_outputs": [
+      "candidate observed damage label",
+      "review context",
+      "uncertainty notes",
+      "official_raw check requirement"
+    ],
+    "forbidden_outputs": [
+      "damage formula authority",
+      "current-system damage fact",
+      "combo verdict",
+      "route verdict",
+      "official_raw override"
+    ],
+    "authority_boundaries": [
+      "observed damage labels are eval or review context only",
+      "training UI observations are not current-system authority by default",
+      "official_raw remains authority for current facts"
+    ],
+    "validators_to_run": [
+      "tests/validation/validate-codex-hermes-delegation-fixtures.ps1",
+      "tests/validation/run-all.ps1"
+    ],
+    "review_checklist": [
+      "confirm observed damage label is not current-system authority",
+      "confirm official_raw check is required",
+      "confirm no damage verdict is promoted"
+    ]
+  },
+  "hermes_draft_response": {
+    "summary": "An observed damage label can be recorded as review context only.",
+    "proposed_artifacts": [
+      "observed damage label review note"
+    ],
+    "source_refs": [
+      "docs/architecture/sf6-video-analysis-protocol.md"
+    ],
+    "evidence_candidate_notes": [
+      "The visible label may help review a candidate interaction.",
+      "The label is not accepted as current-system authority."
+    ],
+    "uncertainty_or_hold_reasons": [
+      "source video context and patch context may be unknown",
+      "training UI observations require separate authority review"
+    ],
+    "boundary_notes": [
+      "observed damage label is review context only",
+      "official_raw check is required before current-fact promotion",
+      "no combo or damage verdict is accepted"
+    ],
+    "follow_up_recommendations": [
+      "Cover observed damage label handling in video dry-run fixtures."
+    ]
+  },
+  "post_delegation_review": {
+    "hermes_output_is_draft_input": true,
+    "canonical_promotion_allowed": false,
+    "requires_codex_review": true,
+    "requires_validators": true,
+    "local_state_committed": false,
+    "raw_transcript_committed": false
+  },
+  "expected_boundary_outcome": {
+    "status": "accept_draft",
+    "reason": "Observed damage labels may be review context only and cannot become current-system authority."
+  }
+}

--- a/tests/validation/run-all.ps1
+++ b/tests/validation/run-all.ps1
@@ -38,6 +38,7 @@ $validationScripts = @(
   'tests/validation/validate-architecture-markers.ps1',
   'tests/validation/validate-hermes-pack.ps1',
   'tests/validation/validate-codex-hermes-pack.ps1',
+  'tests/validation/validate-codex-hermes-delegation-fixtures.ps1',
   'tests/validation/validate-v2-contracts.ps1',
   'tests/validation/validate-agent-toolchain.ps1',
   'tests/validation/validate-answer-orchestration-contracts.ps1',

--- a/tests/validation/validate-codex-hermes-delegation-fixtures.ps1
+++ b/tests/validation/validate-codex-hermes-delegation-fixtures.ps1
@@ -1,0 +1,362 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$fixtureRootRelative = 'tests/fixtures/codex-hermes-delegation'
+$fixtureRoot = Join-Path $repoRoot $fixtureRootRelative
+
+function Test-Property {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name
+  )
+  return $null -ne $Object.PSObject.Properties[$Name]
+}
+
+function Assert-Property {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  if (-not (Test-Property $Object $Name)) {
+    $Issues.Value += "$Context missing property: $Name"
+  }
+}
+
+function Assert-BooleanValue {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][bool]$Expected,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  if (-not (Test-Property $Object $Name)) {
+    $Issues.Value += "$Context missing property: $Name"
+    return
+  }
+
+  if ([bool]$Object.$Name -ne $Expected) {
+    $Issues.Value += "$Context.$Name must be $Expected"
+  }
+}
+
+function Assert-ArrayNotEmpty {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  if (-not (Test-Property $Object $Name)) {
+    $Issues.Value += "$Context missing property: $Name"
+    return
+  }
+
+  if (@($Object.$Name).Count -eq 0) {
+    $Issues.Value += "$Context.$Name must not be empty"
+  }
+}
+
+function Read-Fixture {
+  param([Parameter(Mandatory = $true)][System.IO.FileInfo]$File)
+
+  $raw = Get-Content -LiteralPath $File.FullName -Raw -Encoding UTF8
+  $json = $raw | ConvertFrom-Json
+  return @{
+    Raw = $raw
+    Json = $json
+    RelativePath = $File.FullName.Substring($repoRoot.Length + 1).Replace('\', '/')
+  }
+}
+
+$expectedFixtures = [ordered]@{
+  'source-analysis-valid.json' = 'source_analysis'
+  'validator-pattern-proposal.json' = 'validator_pattern'
+  'video-analyze-unavailable-fallback.json' = 'video_fallback'
+  'video-current-fact-forbidden.json' = 'video_current_fact_forbidden'
+  'external-atlas-binary-import-forbidden.json' = 'external_atlas_binary_forbidden'
+  'external-atlas-metadata-only-guidance.json' = 'external_atlas_metadata_only'
+  'stale-pr-active-source-rejection.json' = 'stale_pr_rejection'
+  'video-observed-damage-label-boundary.json' = 'observed_damage_label_boundary'
+  'move-frequency-review-only.json' = 'move_frequency_review_only'
+}
+
+$allowedScenarioKinds = @(
+  'source_analysis',
+  'validator_pattern',
+  'video_fallback',
+  'video_current_fact_forbidden',
+  'external_atlas_binary_forbidden',
+  'external_atlas_metadata_only',
+  'stale_pr_rejection',
+  'observed_damage_label_boundary',
+  'move_frequency_review_only'
+)
+
+$allowedOutcomeStatuses = @(
+  'accept_draft',
+  'reject',
+  'hold',
+  'metadata_only_guidance'
+)
+
+$issues = @()
+
+if (-not (Test-Path -LiteralPath $fixtureRoot -PathType Container)) {
+  $issues += "Missing Codex-Hermes delegation fixture directory: $fixtureRootRelative"
+}
+
+foreach ($fileName in $expectedFixtures.Keys) {
+  $path = Join-Path $fixtureRoot $fileName
+  if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+    $issues += "Missing Codex-Hermes delegation fixture: $fixtureRootRelative/$fileName"
+  }
+}
+
+if ($issues.Count -eq 0) {
+  $fixtureFiles = @(Get-ChildItem -LiteralPath $fixtureRoot -Filter '*.json' -File | Sort-Object Name)
+
+  foreach ($file in $fixtureFiles) {
+    $fixtureRecord = Read-Fixture $file
+    $raw = [string]$fixtureRecord.Raw
+    $fixture = $fixtureRecord.Json
+    $relativePath = [string]$fixtureRecord.RelativePath
+    $rawLower = $raw.ToLowerInvariant()
+
+    foreach ($field in @(
+      'schema_version',
+      'scenario_id',
+      'scenario_kind',
+      'codex_request',
+      'hermes_draft_response',
+      'post_delegation_review',
+      'expected_boundary_outcome'
+    )) {
+      Assert-Property $fixture $field $relativePath ([ref]$issues)
+    }
+
+    if ((Test-Property $fixture 'schema_version') -and [string]$fixture.schema_version -ne 'codex-hermes-delegation-fixture/v1') {
+      $issues += "$relativePath must use schema_version codex-hermes-delegation-fixture/v1"
+    }
+
+    if (Test-Property $fixture 'scenario_kind') {
+      $kind = [string]$fixture.scenario_kind
+      if ($allowedScenarioKinds -notcontains $kind) {
+        $issues += "$relativePath has invalid scenario_kind: $kind"
+      }
+
+      $expectedName = $file.Name
+      if ($expectedFixtures.Contains($expectedName) -and $expectedFixtures[$expectedName] -ne $kind) {
+        $issues += "$relativePath expected scenario_kind $($expectedFixtures[$expectedName]) but found $kind"
+      }
+    }
+
+    if (Test-Property $fixture 'codex_request') {
+      foreach ($field in @(
+        'target_issue',
+        'target_scope_summary',
+        'source_material',
+        'requested_artifact_type',
+        'allowed_outputs',
+        'forbidden_outputs',
+        'authority_boundaries',
+        'validators_to_run',
+        'review_checklist'
+      )) {
+        Assert-Property $fixture.codex_request $field "$relativePath codex_request" ([ref]$issues)
+      }
+    }
+
+    if (Test-Property $fixture 'hermes_draft_response') {
+      foreach ($field in @(
+        'summary',
+        'proposed_artifacts',
+        'source_refs',
+        'evidence_candidate_notes',
+        'uncertainty_or_hold_reasons',
+        'boundary_notes',
+        'follow_up_recommendations'
+      )) {
+        Assert-Property $fixture.hermes_draft_response $field "$relativePath hermes_draft_response" ([ref]$issues)
+      }
+    }
+
+    if (Test-Property $fixture 'post_delegation_review') {
+      Assert-BooleanValue $fixture.post_delegation_review 'hermes_output_is_draft_input' $true "$relativePath post_delegation_review" ([ref]$issues)
+      Assert-BooleanValue $fixture.post_delegation_review 'canonical_promotion_allowed' $false "$relativePath post_delegation_review" ([ref]$issues)
+      Assert-BooleanValue $fixture.post_delegation_review 'requires_codex_review' $true "$relativePath post_delegation_review" ([ref]$issues)
+      Assert-BooleanValue $fixture.post_delegation_review 'requires_validators' $true "$relativePath post_delegation_review" ([ref]$issues)
+      Assert-BooleanValue $fixture.post_delegation_review 'local_state_committed' $false "$relativePath post_delegation_review" ([ref]$issues)
+      Assert-BooleanValue $fixture.post_delegation_review 'raw_transcript_committed' $false "$relativePath post_delegation_review" ([ref]$issues)
+    }
+
+    if (Test-Property $fixture 'expected_boundary_outcome') {
+      Assert-Property $fixture.expected_boundary_outcome 'status' "$relativePath expected_boundary_outcome" ([ref]$issues)
+      Assert-Property $fixture.expected_boundary_outcome 'reason' "$relativePath expected_boundary_outcome" ([ref]$issues)
+
+      if ((Test-Property $fixture.expected_boundary_outcome 'status') -and $allowedOutcomeStatuses -notcontains [string]$fixture.expected_boundary_outcome.status) {
+        $issues += "$relativePath has invalid expected_boundary_outcome.status: $($fixture.expected_boundary_outcome.status)"
+      }
+    }
+
+    foreach ($marker in @('RAW TRANSCRIPT', 'assistant:', 'user:', 'tool_call')) {
+      if ($raw -match [regex]::Escape($marker)) {
+        $issues += "$relativePath contains raw transcript marker: $marker"
+      }
+    }
+
+    foreach ($pattern in @(
+      '"requires_live_hermes"\s*:\s*true',
+      '"requires_live_web_research"\s*:\s*true',
+      '"requires_live_video_analysis"\s*:\s*true',
+      '"video_analyze_tested"\s*:\s*true',
+      '(?i)live hermes execution is required',
+      '(?i)live web research is required',
+      '(?i)live video analysis is required'
+    )) {
+      if ($raw -match $pattern) {
+        $issues += "$relativePath requires live execution outside dry-run scope: $pattern"
+      }
+    }
+
+    foreach ($pattern in @(
+      '(^|[\\/])\.env($|[\\/])',
+      '\.sqlite\b',
+      '\.db\b',
+      '(?i)\b[A-Za-z0-9_\-./\\]*(secret|token|credential)[A-Za-z0-9_\-./\\]*[\\/]'
+    )) {
+      if ($raw -match $pattern) {
+        $issues += "$relativePath contains local secret/state path-like pattern: $pattern"
+      }
+    }
+
+    $activeStoragePattern = '(?im)^\s*(?:[-*+]\s+|\d+[.)]\s+)?(commit|store|save|persist|include|write|add)\b.*\b(sessions?|memory|local skills?|curator|checkpoints?|kanban state|logs?|caches?|credentials?|secrets?|tokens?)\b'
+    foreach ($line in ($raw -split "`r?`n")) {
+      if ($line -match $activeStoragePattern -and $line -notmatch '(?i)\b(do not|must not|forbid|forbidden|not|no|reject|rejection)\b') {
+        $issues += "Potential active local-state storage instruction in ${relativePath}: $line"
+      }
+    }
+
+    if ($raw -match '(?i)[A-Za-z0-9_\-./\\]+\.(gif|png|jpg|jpeg|webp|mp4|mov|avi|mkv)\b') {
+      $issues += "$relativePath contains a binary asset path"
+    }
+
+    switch ([string]$fixture.scenario_kind) {
+      'source_analysis' {
+        Assert-ArrayNotEmpty $fixture.hermes_draft_response 'source_refs' "$relativePath hermes_draft_response" ([ref]$issues)
+        Assert-ArrayNotEmpty $fixture.hermes_draft_response 'evidence_candidate_notes' "$relativePath hermes_draft_response" ([ref]$issues)
+        Assert-ArrayNotEmpty $fixture.hermes_draft_response 'boundary_notes' "$relativePath hermes_draft_response" ([ref]$issues)
+        if ($raw -match '"raw_excerpt"' -or $raw -match '"full_article_text"') {
+          $issues += "$relativePath must not contain raw_excerpt or full_article_text"
+        }
+      }
+      'validator_pattern' {
+        if ($rawLower -notmatch 'review input') {
+          $issues += "$relativePath must describe validator proposals as review input"
+        }
+        if ($raw -match '"requires_live_command_execution"\s*:\s*true') {
+          $issues += "$relativePath must not require live command execution"
+        }
+        if ([string]$fixture.expected_boundary_outcome.status -ne 'accept_draft') {
+          $issues += "$relativePath expected outcome must be accept_draft"
+        }
+      }
+      'video_fallback' {
+        foreach ($requiredText in @('video_analyze', 'not_inferred', 'official_raw')) {
+          if ($raw -notmatch [regex]::Escape($requiredText)) {
+            $issues += "$relativePath must include $requiredText"
+          }
+        }
+        if ($rawLower -notmatch 'tool_unavailable|unavailable') {
+          $issues += "$relativePath must record tool_unavailable or unavailable"
+        }
+        if ([string]$fixture.expected_boundary_outcome.status -ne 'hold') {
+          $issues += "$relativePath expected status must be hold"
+        }
+      }
+      'video_current_fact_forbidden' {
+        if ($raw -notmatch 'official_raw') {
+          $issues += "$relativePath must include official_raw"
+        }
+        if ($rawLower -notmatch 'video alone') {
+          $issues += "$relativePath must reject exact current facts from video alone"
+        }
+        foreach ($pattern in @(
+          '(?i)\baccept\b.*exact startup',
+          '(?i)\baccept\b.*exact active',
+          '(?i)\baccept\b.*exact recovery',
+          '(?i)\baccept\b.*exact block advantage'
+        )) {
+          if ($raw -match $pattern) {
+            $issues += "$relativePath appears to accept exact video-derived frame facts: $pattern"
+          }
+        }
+      }
+      'external_atlas_binary_forbidden' {
+        foreach ($requiredText in @('GIF', 'image', 'frame-atlas')) {
+          if ($raw -notmatch [regex]::Escape($requiredText)) {
+            $issues += "$relativePath must include binary import request text for $requiredText"
+          }
+        }
+        if ([string]$fixture.expected_boundary_outcome.status -ne 'reject') {
+          $issues += "$relativePath expected status must be reject"
+        }
+        foreach ($forbiddenPath in @('.external-cache', '.external-assets', '.local-media', '.video-cache', '.frame-atlas-cache')) {
+          if ($raw -match [regex]::Escape($forbiddenPath)) {
+            $issues += "$relativePath must not include repo cache path: $forbiddenPath"
+          }
+        }
+      }
+      'external_atlas_metadata_only' {
+        if ([string]$fixture.expected_boundary_outcome.status -ne 'metadata_only_guidance') {
+          $issues += "$relativePath expected status must be metadata_only_guidance"
+        }
+        if ($rawLower -notmatch 'source evaluation|acquisition feasibility') {
+          $issues += "$relativePath must include source evaluation or acquisition feasibility"
+        }
+        foreach ($requiredText in @('scraping', 'download', 'cache', 'binary storage', 'official_raw')) {
+          if ($rawLower -notmatch [regex]::Escape($requiredText.ToLowerInvariant())) {
+            $issues += "$relativePath must include $requiredText"
+          }
+        }
+      }
+      'stale_pr_rejection' {
+        if ($raw -notmatch 'PR #71|PR #83') {
+          $issues += "$relativePath must include PR #71 or PR #83"
+        }
+        if ($rawLower -notmatch 'reject') {
+          $issues += "$relativePath must reject active-source use"
+        }
+        if ($rawLower -notmatch 'fresh scoped issue') {
+          $issues += "$relativePath must require fresh scoped issue recreation"
+        }
+      }
+      'observed_damage_label_boundary' {
+        foreach ($requiredText in @('observed damage label', 'review context', 'current-system authority', 'official_raw')) {
+          if ($rawLower -notmatch [regex]::Escape($requiredText.ToLowerInvariant())) {
+            $issues += "$relativePath must include $requiredText"
+          }
+        }
+      }
+      'move_frequency_review_only' {
+        foreach ($requiredText in @('candidate', 'confidence', 'review-only', 'official_raw')) {
+          if ($rawLower -notmatch [regex]::Escape($requiredText.ToLowerInvariant())) {
+            $issues += "$relativePath must include $requiredText"
+          }
+        }
+      }
+    }
+  }
+}
+
+if ($issues.Count -gt 0) {
+  throw ($issues -join '; ')
+}
+
+Write-Host 'Codex-Hermes delegation fixtures OK'

--- a/tests/validation/validate-codex-hermes-delegation-fixtures.ps1
+++ b/tests/validation/validate-codex-hermes-delegation-fixtures.ps1
@@ -40,7 +40,14 @@ function Assert-BooleanValue {
     return
   }
 
-  if ([bool]$Object.$Name -ne $Expected) {
+  $value = $Object.$Name
+
+  if ($value -isnot [bool]) {
+    $Issues.Value += "$Context.$Name must be a boolean"
+    return
+  }
+
+  if ($value -ne $Expected) {
     $Issues.Value += "$Context.$Name must be $Expected"
   }
 }
@@ -121,6 +128,12 @@ foreach ($fileName in $expectedFixtures.Keys) {
 
 if ($issues.Count -eq 0) {
   $fixtureFiles = @(Get-ChildItem -LiteralPath $fixtureRoot -Filter '*.json' -File | Sort-Object Name)
+
+  foreach ($file in $fixtureFiles) {
+    if (-not $expectedFixtures.Contains($file.Name)) {
+      $issues += "Unexpected Codex-Hermes delegation fixture: $fixtureRootRelative/$($file.Name)"
+    }
+  }
 
   foreach ($file in $fixtureFiles) {
     $fixtureRecord = Read-Fixture $file


### PR DESCRIPTION
## Summary
- Adds Codex-to-Hermes dry-run delegation fixtures for #115.
- Adds a validator for fixture schema, required request/response/review fields, scenario coverage, and boundary checks.
- Wires the new validator into the v2 validation suite.

## Scope
- Closes #115.
- Adds fixtures under tests/fixtures/codex-hermes-delegation/.
- Adds tests/validation/validate-codex-hermes-delegation-fixtures.ps1.
- Updates tests/validation/run-all.ps1.
- Covers source analysis, validator-pattern proposal, unavailable video_analyze fallback, forbidden exact current-fact inference from video, external atlas binary import rejection, metadata-only atlas guidance, stale PR rejection, observed damage label boundary, and move-frequency review-only draft behavior.

## Not Implemented
- #119 is not implemented.
- No live Hermes, live web, live video, video_analyze test, plugin/gateway planning, external asset scraping/download/cache, GIF/image/video binary, public sf6-agent behavior change, claim promotion, frame-current change, normalization change, generated output, .dist change, historical smoke rewrite, raw transcript, session, memory, local skill, Curator output, log, cache, credential, or secret was added.

## Validation
- powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-codex-hermes-delegation-fixtures.ps1 - PASS
- powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 - PASS
- git diff --check - PASS
- git diff --check origin/main...HEAD - PASS

PowerShell reported git-unavailable warnings during generated-surface checks; WSL git separately verified no residual diff in skills/sf6-agent/references, .dist, frame-current assets, or normalization assets.