### PR TITLE
[v2.4] Add video learning report template and validator

### DIFF
--- a/docs/testing/smoke-runs/video-analysis-learning-report-template.md
+++ b/docs/testing/smoke-runs/video-analysis-learning-report-template.md
@@ -1,0 +1,253 @@
+# Video Analysis Learning Report Template
+
+TEMPLATE ONLY: this file is not an executed report and is not a historical
+smoke report.
+
+Use this template for future maintainer-local v2.4 video-analysis learning
+reports after the run is complete and the output has been sanitized. Executed
+learning reports should use this naming convention:
+
+`docs/testing/smoke-runs/video-analysis-learning-report-YYYYMMDD-<slug>.md`
+
+Report types:
+
+- Template: this reusable form. It contains placeholders and boundary rules.
+- Executed learning report: a sanitized report from a scoped maintainer-local
+  video-learning run, named with the convention above.
+- Historical smoke report: an existing report created before this template.
+  Historical smoke reports are not rewritten by #136.
+
+## Existing Video Smoke Report Audit
+
+#136 audited existing video-related smoke reports before defining this
+template. The audit used these existing repo reports as examples:
+
+- `docs/testing/smoke-runs/2026-05-03-video-observation-youtube-shorts-sycyvw6h8wi.md`
+- `docs/testing/smoke-runs/2026-05-04-jp-combo-damage-oracle-fixture.md`
+- `docs/testing/smoke-runs/2026-05-04-jp-combo-damage-oracle-coverage.md`
+- `docs/testing/smoke-runs/hermes-bridge-smoke-gap-report.md`
+
+Preserved fields and conventions:
+
+- date, issue, report type, source or source reference, selected scope, and
+  maintainer-local method summary
+- tool availability and limitation notes, including unavailable or deferred
+  tools
+- raw media, transcript, local state, and external asset exclusion confirmation
+- observation boundaries, `official_raw` boundary, cleanup status, findings,
+  and follow-up candidates
+
+Generalized fields and conventions:
+
+- source details become a non-fetching source-reference policy rather than a
+  live retrieval instruction
+- tooling tables become a generic tool availability section that can record
+  manual review, Hermes, `video_analyze`, vision analysis, and holds without
+  requiring any tool to run
+- video-specific smoke findings become taxonomy, visual layout, audio context,
+  capability, gap/failure, and follow-up candidate fields aligned with
+  `tests/fixtures/video-observation-taxonomy/`
+- repo boundary checks become a common cleanup and verification section for
+  future executed learning reports
+
+Deprecated or not carried forward:
+
+- live source URLs in executed report metadata are not required by this
+  template; use repo source records or non-fetching placeholders
+- raw command transcripts, raw Hermes output, raw `video_analyze` output,
+  full captions, and full transcripts are not report content
+- source-local commentary, observed damage labels, training UI labels, and
+  video-derived move observations are not accepted current facts
+- report shapes that imply canonical Hermes/video output are not carried
+  forward
+
+## Report Metadata
+
+| Field | Value |
+|---|---|
+| Report id | `<video-analysis-learning-report-YYYYMMDD-slug>` |
+| Date | `<YYYY-MM-DD>` |
+| Related issue | `<issue number>` |
+| Report type | `sanitized_video_analysis_learning_report` |
+| Maintainer-local only status | `yes` |
+| Template/executed status | `executed_learning_report` |
+| Source reference type | `existing_repo_source` / `placeholder` / `none` |
+| Source reference | `<repo source path, placeholder id, or none>` |
+| Non-fetching/source policy | `non_fetching_reference: true; no external fetch in this report` |
+
+## Raw Media And Local State Status
+
+Confirm that none of these are committed in the executed learning report PR:
+
+| Item | Committed? | Notes |
+|---|---|---|
+| raw video | no | `<confirmation>` |
+| frames | no | `<confirmation>` |
+| screenshots | no | `<confirmation>` |
+| GIFs | no | `<confirmation>` |
+| contact sheets | no | `<confirmation>` |
+| browser cache | no | `<confirmation>` |
+| full transcripts | no | `<confirmation>` |
+| raw Hermes output | no | `<confirmation>` |
+| raw `video_analyze` output | no | `<confirmation>` |
+| local Hermes sessions | no | `<confirmation>` |
+| memory | no | `<confirmation>` |
+| local skills | no | `<confirmation>` |
+| Curator output | no | `<confirmation>` |
+| logs | no | `<confirmation>` |
+| caches | no | `<confirmation>` |
+| credentials | no | `<confirmation>` |
+| secrets | no | `<confirmation>` |
+
+## Tool Availability
+
+| Tool / Capability | Value | Notes |
+|---|---|---|
+| Manual review used | `yes` / `no` / `unknown` | `<notes>` |
+| Hermes used | `yes` / `no` / `unknown` | `<notes>` |
+| `video_analyze` used | `yes` / `no` | `<notes>` |
+| Vision analysis used | `yes` / `no` / `unknown` | `<notes>` |
+| External asset fetch | `no` | `<confirmation>` |
+| Tool limitations | `<limitations>` | `<notes>` |
+| Unavailable tools | `<tools or none>` | `<notes>` |
+| Hold reasons | `<reasons or none>` | `<notes>` |
+
+This template does not require live Hermes, live video analysis, or
+`video_analyze`.
+
+## Source And Reference Policy
+
+| Field | Value |
+|---|---|
+| Source ref | `<non-fetching source ref or none>` |
+| Existing repo source ref | `<knowledge/sources/videos/<source>.md or none>` |
+| Non-fetching reference status | `true` |
+| No external fetch confirmation | `yes` |
+| Copyright/storage boundary | raw media and full transcripts are excluded from repo artifacts |
+| Source freshness limitations | `<limitations or unknown>` |
+| Current-fact authority boundary | exact current facts require current-fact authority; `official_raw` remains authority |
+
+## Video Taxonomy Classification
+
+Align this section with `tests/fixtures/video-observation-taxonomy/`.
+
+| Field | Value |
+|---|---|
+| video_type | `[<taxonomy labels>]` |
+| unknown_or_mixed handling | `<why unknown_or_mixed is used or not used>` |
+| taxonomy_update_needed | `true` / `false` |
+| Related taxonomy fixture | `<fixture id or gap>` |
+| Relationship to observation schema | metadata layer; this report does not replace `contracts/video-observation.schema.json` |
+
+## Visual Layout
+
+| Field | Value |
+|---|---|
+| gameplay visibility | `full` / `partial` / `intermittent` / `none` / `unknown` |
+| HUD visibility | `full` / `partial` / `blocked` / `cropped` / `none` / `unknown` |
+| input display visibility | `visible` / `partial` / `blocked` / `not_present` / `unknown` |
+| damage label visibility | `visible` / `partial` / `blocked` / `not_present` / `unknown` |
+| subtitles | `none` / `present_non_obstructing` / `present_obstructing` / `unknown` |
+| webcam / wipe overlay | `none` / `present_non_obstructing` / `present_obstructing` / `unknown` |
+| overlay obstruction | `none` / `minor` / `major` / `critical` / `unknown` |
+| vertical crop | `none` / `minor` / `major` / `critical` / `unknown` |
+| multi-match compilation | `true` / `false` / `unknown` |
+| replay speed uncertainty | `none` / `possible` / `likely` / `unknown` |
+| compression / resolution limitation | `none` / `minor` / `major` / `critical` / `unknown` |
+
+## Audio And Commentary Context
+
+| Field | Value |
+|---|---|
+| audio type | `no_audio` / `game_audio_only` / `commentary_only` / `gameplay_plus_commentary` / `mixed_voice_chat` / `music_ambient` / `unknown` |
+| commentary claims are source-local | `true` |
+| commentary visible/evidence boundary | commentary may be paraphrased as source-local review input only |
+| transcript status | `<none, unavailable, paraphrased only, or unknown>` |
+| no raw transcript confirmation | `yes` |
+
+## Analysis Capability
+
+| Dimension | Rating | Notes |
+|---|---|---|
+| candidate_move_identification | `likely` / `limited` / `not_safe` / `unknown` | `<notes>` |
+| hit_block_whiff_candidate_labeling | `likely` / `limited` / `not_safe` / `unknown` | `<notes>` |
+| timing_frame_window_observation | `likely` / `limited` / `not_safe` / `unknown` | `<notes>` |
+| matchup_strategy_summary | `likely` / `limited` / `not_safe` / `unknown` | `<notes>` |
+| input_hud_observation | `likely` / `limited` / `not_safe` / `unknown` | `<notes>` |
+| exact_current_fact | `forbidden` | exact_current_fact must always be forbidden from video alone |
+
+## Observed-Safe Notes
+
+Use paraphrased, safe observations only.
+
+- Observations are review input.
+- Observed damage labels are review/eval context only.
+- Training UI observations are not current-system authority by default.
+- Do not include raw transcript text or raw tool output.
+
+## Not-Inferred Notes
+
+- Exact current facts not inferred.
+- Exact startup/active/recovery not inferred.
+- Exact hit/block advantage not inferred.
+- `official_raw` not overridden.
+- Matchup/coaching conclusion not treated as final authority.
+
+## Gap / Failure Findings
+
+Record applicable categories and concise notes:
+
+- `overlay_blocks_important_area`: overlay blocks important area
+- `subtitles_cover_input_or_hud`: subtitles cover input/HUD
+- `vertical_crop_removes_hud`: vertical crop removes HUD
+- `compilation_cuts_destroy_timing`: compilation cuts destroy timing
+- `replay_speed_unknown`: replay speed unknown
+- `commentary_claims_not_visible`: commentary claims not visible
+- `low_resolution`: low resolution
+- `compression_artifacts`: compression artifacts
+- `ambiguous_character_or_move`: ambiguous character/move
+- `mixed_source_context`: mixed source/context
+- `unknown_or_mixed_source_format`: unknown/mixed source format
+
+## Follow-Up Candidates
+
+| Candidate | Value | Mapping |
+|---|---|---|
+| taxonomy update candidate | `true` / `false` | #135 or later scoped taxonomy issue |
+| fixture candidate | `true` / `false` | #135 taxonomy fixture shape or later fixture issue |
+| validator candidate | `true` / `false` | #136 validator follow-up or later scoped validator issue |
+| policy candidate | `true` / `false` | #140 media scratch/cache policy extension |
+| later issue candidate | `<issue or none>` | #137, #140, #141, or later scoped issue |
+| unsupported/hold | `<reason or none>` | hold when evidence is unsafe or unavailable |
+
+Notes:
+
+- Map first executed learning smoke findings to #137 when relevant.
+- Map binary/cache policy gaps to #140.
+- Map move-recognition or move-frequency evaluation gaps to #141.
+
+## Authority Boundaries
+
+- Video observations are observation/review input only.
+- Hermes/video outputs are draft input.
+- External visual atlas sources are not current-fact authority.
+- `official_raw` remains current-fact authority.
+- Exact current facts require current-fact authority.
+- No public `sf6-agent` behavior change.
+
+## Cleanup And Verification
+
+| Field | Value |
+|---|---|
+| Scratch cleanup status | `<done, not used, retained outside repo, or hold>` |
+| Retained repo-external cache reason | `<reason or none>` |
+| Git diff/status confirmation | `<confirmation>` |
+| Validator commands | `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-video-learning-report-template.ps1`; `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1`; `git diff --check`; `git diff --check origin/main...HEAD` |
+| No raw media / transcript / local state committed confirmation | `<confirmation>` |
+
+Final confirmation for executed reports:
+
+- No raw media committed.
+- No transcript committed.
+- No local state committed.
+- Historical smoke reports are not rewritten.

--- a/docs/testing/smoke-runs/video-analysis-learning-report-template.md
+++ b/docs/testing/smoke-runs/video-analysis-learning-report-template.md
@@ -176,6 +176,27 @@ Align this section with `tests/fixtures/video-observation-taxonomy/`.
 | input_hud_observation | `likely` / `limited` / `not_safe` / `unknown` | `<notes>` |
 | exact_current_fact | `forbidden` | exact_current_fact must always be forbidden from video alone |
 
+## Unsafe Inferences
+
+Record `unsafe_inferences` categories aligned with
+`tests/fixtures/video-observation-taxonomy/`.
+
+Required baseline categories for executed reports:
+
+- `exact_current_fact_from_video`
+- `official_raw_override`
+
+Optional categories when applicable:
+
+- `exact_frame_data_from_video`
+- `raw_tool_output_promotion`
+- `training_ui_damage_label_as_current_fact`
+- `commentary_claim_as_current_fact`
+- `external_visual_atlas_as_current_fact`
+
+These are unsafe inferences to reject, hold, or route to reviewed authority
+checks. They are not conclusions accepted by the report.
+
 ## Observed-Safe Notes
 
 Use paraphrased, safe observations only.

--- a/tests/validation/run-all.ps1
+++ b/tests/validation/run-all.ps1
@@ -49,6 +49,7 @@ $validationScripts = @(
   'tests/validation/validate-ingest-artifacts.ps1',
   'tests/validation/validate-video-artifacts.ps1',
   'tests/validation/validate-video-observation-taxonomy-fixtures.ps1',
+  'tests/validation/validate-video-learning-report-template.ps1',
   'tests/validation/validate-combo-damage-fixtures.ps1',
   'tests/validation/validate-evals.ps1',
   'tests/validation/validate-roster-source.ps1',

--- a/tests/validation/validate-video-learning-report-template.ps1
+++ b/tests/validation/validate-video-learning-report-template.ps1
@@ -1,0 +1,216 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$templateRelativePath = 'docs/testing/smoke-runs/video-analysis-learning-report-template.md'
+$templatePath = Join-Path $repoRoot $templateRelativePath
+
+function Assert-Contains {
+  param(
+    [Parameter(Mandatory = $true)][string]$Content,
+    [Parameter(Mandatory = $true)][string]$Needle,
+    [Parameter(Mandatory = $true)][string]$Description,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  if ($Content -notmatch [regex]::Escape($Needle)) {
+    $Issues.Value += "Missing $Description`: $Needle"
+  }
+}
+
+function Assert-Matches {
+  param(
+    [Parameter(Mandatory = $true)][string]$Content,
+    [Parameter(Mandatory = $true)][string]$Pattern,
+    [Parameter(Mandatory = $true)][string]$Description,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  if ($Content -notmatch $Pattern) {
+    $Issues.Value += "Missing $Description"
+  }
+}
+
+function Assert-RequiredSections {
+  param(
+    [Parameter(Mandatory = $true)][string]$Content,
+    [Parameter(Mandatory = $true)][string[]]$Headings,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  foreach ($heading in $Headings) {
+    if ($Content -notmatch "(?m)^$([regex]::Escape($heading))\s*$") {
+      $Issues.Value += "Missing required section: $heading"
+    }
+  }
+}
+
+function Assert-NoRawTranscriptMarkers {
+  param(
+    [Parameter(Mandatory = $true)][string]$Content,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  foreach ($marker in @('RAW TRANSCRIPT', 'assistant:', 'user:', 'tool_call')) {
+    if ($Content -cmatch [regex]::Escape($marker)) {
+      $Issues.Value += "Template contains raw transcript marker: $marker"
+    }
+  }
+}
+
+function Assert-NoLiveUrls {
+  param(
+    [Parameter(Mandatory = $true)][string]$Content,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  foreach ($pattern in @(
+    '(?i)https?://',
+    '(?i)\byoutube\.com\b',
+    '(?i)\byoutu\.be\b',
+    '(?i)\btwitch\.tv\b'
+  )) {
+    if ($Content -match $pattern) {
+      $Issues.Value += 'Template contains a live or fetchable URL; use non-fetching placeholders or repo source references'
+    }
+  }
+}
+
+function Assert-NoBinaryMediaPaths {
+  param(
+    [Parameter(Mandatory = $true)][string]$Content,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  $binaryPathPattern = '(?i)(^|["''\s:/\\])([A-Za-z0-9_.-]+[\\/])+[A-Za-z0-9_.-]+\.(gif|png|jpg|jpeg|webp|mp4|mov|avi|mkv)(["''\s,)}\]]|$)'
+  if ($Content -match $binaryPathPattern) {
+    $Issues.Value += 'Template contains a path-like binary media reference'
+  }
+}
+
+function Assert-NoActiveForbiddenStorage {
+  param(
+    [Parameter(Mandatory = $true)][string]$Content,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  $verbPattern = '\b(commit|store|save|persist|add|include|write|retain)\b'
+  $objectPattern = '\b(raw video|frames?|screenshots?|gifs?|contact sheets?|browser cache|full transcripts?|raw hermes output|raw `?video_analyze`? output|local hermes sessions?|sessions?|memory|local skills?|curator output|logs?|caches?|credentials?|secrets?)\b'
+  $negationPattern = '\b(do not|must not|not|no|none|never|forbid|forbidden|exclude|excluded|without|is not|are not)\b'
+
+  foreach ($line in ($Content -split "`r?`n")) {
+    if ($line -match "(?i)$verbPattern" -and $line -match "(?i)$objectPattern" -and $line -notmatch "(?i)$negationPattern") {
+      $Issues.Value += "Potential active forbidden storage instruction: $line"
+    }
+  }
+}
+
+$issues = @()
+
+if (-not (Test-Path -LiteralPath $templatePath -PathType Leaf)) {
+  throw "Missing video learning report template: $templateRelativePath"
+}
+
+$raw = Get-Content -LiteralPath $templatePath -Raw -Encoding UTF8
+
+Assert-Contains $raw 'TEMPLATE ONLY' 'template-only marker' ([ref]$issues)
+Assert-Contains $raw 'not an executed report' 'not-executed marker' ([ref]$issues)
+Assert-Contains $raw 'executed learning report' 'executed learning report distinction' ([ref]$issues)
+Assert-Contains $raw 'historical smoke report' 'historical smoke report distinction' ([ref]$issues)
+Assert-Contains $raw 'docs/testing/smoke-runs/video-analysis-learning-report-YYYYMMDD-<slug>.md' 'executed report naming convention' ([ref]$issues)
+Assert-Contains $raw 'Historical smoke reports are not rewritten' 'historical smoke rewrite boundary' ([ref]$issues)
+Assert-Contains $raw 'Existing Video Smoke Report Audit' 'existing smoke report audit section' ([ref]$issues)
+
+foreach ($auditedReport in @(
+  'docs/testing/smoke-runs/2026-05-03-video-observation-youtube-shorts-sycyvw6h8wi.md',
+  'docs/testing/smoke-runs/2026-05-04-jp-combo-damage-oracle-fixture.md',
+  'docs/testing/smoke-runs/2026-05-04-jp-combo-damage-oracle-coverage.md',
+  'docs/testing/smoke-runs/hermes-bridge-smoke-gap-report.md'
+)) {
+  Assert-Contains $raw $auditedReport 'audited smoke report path' ([ref]$issues)
+}
+
+Assert-RequiredSections $raw @(
+  '## Report Metadata',
+  '## Raw Media And Local State Status',
+  '## Tool Availability',
+  '## Source And Reference Policy',
+  '## Video Taxonomy Classification',
+  '## Visual Layout',
+  '## Audio And Commentary Context',
+  '## Analysis Capability',
+  '## Observed-Safe Notes',
+  '## Not-Inferred Notes',
+  '## Gap / Failure Findings',
+  '## Follow-Up Candidates',
+  '## Authority Boundaries',
+  '## Cleanup And Verification'
+) ([ref]$issues)
+
+foreach ($taxonomyField in @('video_type', 'unknown_or_mixed', 'exact_current_fact', 'official_raw')) {
+  Assert-Contains $raw $taxonomyField 'taxonomy or authority field' ([ref]$issues)
+}
+Assert-Matches $raw '(?is)exact_current_fact.{0,160}forbidden|forbidden.{0,160}exact_current_fact' 'exact_current_fact forbidden boundary' ([ref]$issues)
+
+foreach ($requiredText in @(
+  'raw video',
+  'frames',
+  'screenshots',
+  'GIFs',
+  'contact sheets',
+  'browser cache',
+  'full transcripts',
+  'raw Hermes output',
+  'raw `video_analyze` output',
+  'local Hermes sessions',
+  'memory',
+  'local skills',
+  'Curator output',
+  'logs',
+  'caches',
+  'credentials',
+  'secrets',
+  'observations are review input',
+  'observed damage labels are review/eval context only',
+  'Training UI observations are not current-system authority by default',
+  'Exact current facts not inferred',
+  '`official_raw` not overridden',
+  'Video observations are observation/review input only',
+  'Hermes/video outputs are draft input',
+  'External visual atlas sources are not current-fact authority',
+  '`official_raw` remains current-fact authority',
+  'No public `sf6-agent` behavior change'
+)) {
+  Assert-Contains $raw $requiredText 'required boundary text' ([ref]$issues)
+}
+
+foreach ($gapCategory in @(
+  'overlay blocks important area',
+  'subtitles cover input/HUD',
+  'vertical crop removes HUD',
+  'compilation cuts destroy timing',
+  'replay speed unknown',
+  'commentary claims not visible',
+  'low resolution',
+  'compression artifacts',
+  'ambiguous character/move',
+  'mixed source/context',
+  'unknown/mixed source format'
+)) {
+  Assert-Contains $raw $gapCategory 'gap/failure category' ([ref]$issues)
+}
+
+foreach ($followUp in @('taxonomy update candidate', 'fixture candidate', 'validator candidate', 'policy candidate', 'later issue candidate', 'unsupported/hold', '#135', '#137', '#140', '#141')) {
+  Assert-Contains $raw $followUp 'follow-up mapping text' ([ref]$issues)
+}
+
+Assert-NoRawTranscriptMarkers $raw ([ref]$issues)
+Assert-NoLiveUrls $raw ([ref]$issues)
+Assert-NoBinaryMediaPaths $raw ([ref]$issues)
+Assert-NoActiveForbiddenStorage $raw ([ref]$issues)
+
+if ($issues.Count -gt 0) {
+  throw ($issues -join '; ')
+}
+
+Write-Host 'Video learning report template OK'

--- a/tests/validation/validate-video-learning-report-template.ps1
+++ b/tests/validation/validate-video-learning-report-template.ps1
@@ -139,6 +139,7 @@ Assert-RequiredSections $raw @(
   '## Visual Layout',
   '## Audio And Commentary Context',
   '## Analysis Capability',
+  '## Unsafe Inferences',
   '## Observed-Safe Notes',
   '## Not-Inferred Notes',
   '## Gap / Failure Findings',
@@ -149,6 +150,9 @@ Assert-RequiredSections $raw @(
 
 foreach ($taxonomyField in @('video_type', 'unknown_or_mixed', 'exact_current_fact', 'official_raw')) {
   Assert-Contains $raw $taxonomyField 'taxonomy or authority field' ([ref]$issues)
+}
+foreach ($unsafeInference in @('unsafe_inferences', 'exact_current_fact_from_video', 'official_raw_override')) {
+  Assert-Contains $raw $unsafeInference 'unsafe inference field or category' ([ref]$issues)
 }
 Assert-Matches $raw '(?is)exact_current_fact.{0,160}forbidden|forbidden.{0,160}exact_current_fact' 'exact_current_fact forbidden boundary' ([ref]$issues)
 


### PR DESCRIPTION
## Summary

- Added a sanitized video-analysis learning report template for future maintainer-local v2.4 video-learning runs.
- Audited existing video-related smoke report conventions and documented preserved, generalized, and deprecated fields.
- Added a validator for the template and wired it into `tests/validation/run-all.ps1` near existing video validators.

## Scope

- Implements #136 only.
- #137, #138, #139, #140, and #141 are not implemented.
- No executed report was added.
- No live video analysis, live Hermes, or `video_analyze` test was run or required.
- No external asset scrape, download, or cache was added.
- No raw media, screenshots, frames, transcripts, public `sf6-agent` behavior change, frame-current change, normalization change, generated output, `.dist`, historical smoke rewrite, or existing observation artifact rewrite was added.

## Validation

- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-video-learning-report-template.ps1` - PASS
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1` - PASS
- `git diff --check` - PASS
- `git diff --check origin/main...HEAD` - PASS
- PowerShell reported git-unavailable warnings during generated-surface checks; bash git status confirmed no residual diff in generated references, `.dist`, frame-current assets, normalization assets, `data/normalized`, or `data/exports`.

Closes #136