### PR TITLE
[v2.4] Add media binary exclusion validator

### DIFF
--- a/tests/validation/run-all.ps1
+++ b/tests/validation/run-all.ps1
@@ -52,6 +52,7 @@ $validationScripts = @(
   'tests/validation/validate-video-learning-report-template.ps1',
   'tests/validation/validate-external-frame-atlas-source-evaluation.ps1',
   'tests/validation/validate-external-frame-atlas-source-fixtures.ps1',
+  'tests/validation/validate-no-video-binary-assets.ps1',
   'tests/validation/validate-combo-damage-fixtures.ps1',
   'tests/validation/validate-evals.ps1',
   'tests/validation/validate-roster-source.ps1',

--- a/tests/validation/validate-no-video-binary-assets.ps1
+++ b/tests/validation/validate-no-video-binary-assets.ps1
@@ -24,6 +24,7 @@ $repoLocalCacheRoots = @(
 $forbiddenBinarySurfaces = @(
   '.dist',
   'skills/sf6-agent',
+  'skills/sf6-agent/assets/frame-current',
   'skills/sf6-agent/assets/normalization',
   'data/raw',
   'data/normalized',
@@ -32,9 +33,6 @@ $forbiddenBinarySurfaces = @(
   'knowledge',
   'docs/testing/smoke-runs'
 ) + $repoLocalCacheRoots
-$approvedBinaryPrefixes = @(
-  'skills/sf6-agent/assets/frame-current'
-)
 $suspiciousDirectoryNames = @(
   'frames',
   'frame-dump',
@@ -197,9 +195,6 @@ if ($issues.Count -eq 0) {
     $relativePath = ConvertTo-RepoRelativePath $item.FullName
 
     if (Test-RelativePathUnder $relativePath '.git') {
-      continue
-    }
-    if (Test-RelativePathUnderAny $relativePath $approvedBinaryPrefixes) {
       continue
     }
 

--- a/tests/validation/validate-no-video-binary-assets.ps1
+++ b/tests/validation/validate-no-video-binary-assets.ps1
@@ -1,0 +1,249 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$policyRelativePath = 'workflows/media-scratch-cache-policy.md'
+$runAllRelativePath = 'tests/validation/run-all.ps1'
+
+$policyPath = Join-Path $repoRoot $policyRelativePath
+$runAllPath = Join-Path $repoRoot $runAllRelativePath
+
+$mediaExtensions = @('.gif', '.png', '.jpg', '.jpeg', '.webp', '.mp4', '.mov', '.avi', '.mkv')
+$scratchOnlyExtensions = @('.vtt', '.srt', '.ass')
+$repoLocalCacheRoots = @(
+  'tmp',
+  '.cache',
+  'downloads',
+  'assets/raw',
+  '.external-cache',
+  '.external-assets',
+  '.local-media',
+  '.video-cache',
+  '.frame-atlas-cache'
+)
+$forbiddenBinarySurfaces = @(
+  '.dist',
+  'skills/sf6-agent',
+  'skills/sf6-agent/assets/normalization',
+  'data/raw',
+  'data/normalized',
+  'data/exports',
+  'tests/fixtures',
+  'knowledge',
+  'docs/testing/smoke-runs'
+) + $repoLocalCacheRoots
+$approvedBinaryPrefixes = @(
+  'skills/sf6-agent/assets/frame-current'
+)
+$suspiciousDirectoryNames = @(
+  'frames',
+  'frame-dump',
+  'frame_dump',
+  'frame-dumps',
+  'frame_dumps',
+  'contact-sheet',
+  'contact_sheet',
+  'contact-sheets',
+  'contact_sheets',
+  'screenshots',
+  'image-dump',
+  'image_dump',
+  'video-cache',
+  'frame-atlas-cache'
+)
+
+function ConvertTo-RepoRelativePath {
+  param([Parameter(Mandatory = $true)][string]$Path)
+
+  $fullPath = (Resolve-Path -LiteralPath $Path).Path
+  $rootPrefix = $repoRoot.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+  $rootPrefix = $rootPrefix + [System.IO.Path]::DirectorySeparatorChar
+  if ($fullPath.StartsWith($rootPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+    return ($fullPath.Substring($rootPrefix.Length) -replace '\\', '/')
+  }
+
+  return ($fullPath -replace '\\', '/')
+}
+
+function Test-RelativePathUnder {
+  param(
+    [Parameter(Mandatory = $true)][string]$RelativePath,
+    [Parameter(Mandatory = $true)][string]$Prefix
+  )
+
+  $normalizedPath = ($RelativePath -replace '\\', '/').TrimStart('./').TrimEnd('/')
+  $normalizedPrefix = ($Prefix -replace '\\', '/').TrimStart('./').TrimEnd('/')
+  return $normalizedPath -eq $normalizedPrefix -or $normalizedPath.StartsWith("$normalizedPrefix/", [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+function Test-RelativePathUnderAny {
+  param(
+    [Parameter(Mandatory = $true)][string]$RelativePath,
+    [Parameter(Mandatory = $true)][string[]]$Prefixes
+  )
+
+  foreach ($prefix in $Prefixes) {
+    if (Test-RelativePathUnder $RelativePath $prefix) {
+      return $true
+    }
+  }
+  return $false
+}
+
+function Assert-FileExists {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][string]$RelativePath,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    $Issues.Value += "Missing file: $RelativePath"
+  }
+}
+
+function Assert-Contains {
+  param(
+    [Parameter(Mandatory = $true)][string]$Content,
+    [Parameter(Mandatory = $true)][string]$Needle,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  if ($Content -notmatch [regex]::Escape($Needle)) {
+    $Issues.Value += "$Context missing required text: $Needle"
+  }
+}
+
+function Assert-NoActiveAcquisitionClaims {
+  param(
+    [Parameter(Mandatory = $true)][string]$Content,
+    [Parameter(Mandatory = $true)][string]$RelativePath,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  $activeVerbPattern = '\b(adds?|added|creates?|created|implements?|implemented|enables?|enabled|approves?|approved|authorizes?|authorized|permits?|permitted)\b'
+  $objectPattern = '\b(scraper|downloader|download|scrape|cache sync|local cache sync|binary storage|git lfs|move recognition|public `?sf6-agent`? runtime lookup|runtime lookup|external numeric frame-data ingestion|official_raw override)\b'
+  $safeLanguagePattern = '\b(no|not|does not|do not|must not|cannot|never|forbidden|exclude|excluded|without|later|future|deferred|not implemented|not approved|does not authorize|not authorize|repo-external by default|only if later|if a later|requires later|after #[0-9]+|blocked)\b'
+
+  foreach ($line in ($Content -split "`r?`n")) {
+    $lower = $line.ToLowerInvariant()
+    if ($lower -match $activeVerbPattern -and $lower -match $objectPattern -and $lower -notmatch $safeLanguagePattern) {
+      $Issues.Value += "$RelativePath appears to actively implement or approve forbidden media/cache behavior: $line"
+    }
+    if ($lower -match '\bexternal (visual|frame-atlas|atlas).*\b(current-fact authority|override `?official_raw`?|numeric frame-data ingestion)\b' -and $lower -notmatch '\b(not|no|do not|does not|must not|cannot|never|forbidden|unable to|do not override)\b') {
+      $Issues.Value += "$RelativePath appears to grant authority to external visual atlas assets: $line"
+    }
+  }
+}
+
+$issues = @()
+
+Assert-FileExists $policyPath $policyRelativePath ([ref]$issues)
+Assert-FileExists $runAllPath $runAllRelativePath ([ref]$issues)
+
+if ($issues.Count -eq 0) {
+  $policyRaw = Get-Content -LiteralPath $policyPath -Raw -Encoding UTF8
+  $runAllRaw = Get-Content -LiteralPath $runAllPath -Raw -Encoding UTF8
+
+  Assert-Contains $runAllRaw 'tests/validation/validate-no-video-binary-assets.ps1' $runAllRelativePath ([ref]$issues)
+
+  foreach ($requiredText in @(
+    'repo-external scratch/cache root',
+    'external frame-atlas cache sync',
+    'later explicit issue only',
+    'repo-external by default',
+    'disabled from CI',
+    'public `sf6-agent` behavior',
+    'does not authorize #140 to scrape, download, cache, or sync',
+    'External frame-atlas local cache sync smoke',
+    'External frame-atlas video usability smoke',
+    '`official_raw` remains the current-fact authority',
+    'not numeric frame-data ingestion sources',
+    'Forbidden Repo Locations',
+    'tests/fixtures/` unless metadata-only'
+  )) {
+    Assert-Contains $policyRaw $requiredText $policyRelativePath ([ref]$issues)
+  }
+
+  Assert-NoActiveAcquisitionClaims $policyRaw $policyRelativePath ([ref]$issues)
+
+  $textFilesToInspect = @(
+    $policyRelativePath,
+    'data/external-frame-atlas/evaluation/README.md',
+    'data/external-frame-atlas/evaluation/source-evaluation-matrix.json',
+    'contracts/external-frame-atlas-source.schema.json',
+    'docs/testing/smoke-runs/video-analysis-learning-report-20260513-first-smoke-batch.md'
+  )
+
+  $fixtureRoot = Join-Path $repoRoot 'tests/fixtures/external-frame-atlas'
+  if (Test-Path -LiteralPath $fixtureRoot -PathType Container) {
+    $textFilesToInspect += @(
+      Get-ChildItem -LiteralPath $fixtureRoot -Filter '*.json' -File |
+        ForEach-Object { ConvertTo-RepoRelativePath $_.FullName }
+    )
+  }
+
+  foreach ($relativePath in $textFilesToInspect) {
+    $path = Join-Path $repoRoot $relativePath
+    if (Test-Path -LiteralPath $path -PathType Leaf) {
+      $raw = Get-Content -LiteralPath $path -Raw -Encoding UTF8
+      Assert-NoActiveAcquisitionClaims $raw $relativePath ([ref]$issues)
+    }
+  }
+
+  $allItems = Get-ChildItem -LiteralPath $repoRoot -Force -Recurse -ErrorAction SilentlyContinue
+  foreach ($item in $allItems) {
+    $relativePath = ConvertTo-RepoRelativePath $item.FullName
+
+    if (Test-RelativePathUnder $relativePath '.git') {
+      continue
+    }
+    if (Test-RelativePathUnderAny $relativePath $approvedBinaryPrefixes) {
+      continue
+    }
+
+    if ($item.PSIsContainer) {
+      $directoryName = $item.Name.ToLowerInvariant()
+      if ($suspiciousDirectoryNames -contains $directoryName) {
+        $issues += "Forbidden media/cache directory found: $relativePath"
+      }
+      if ($repoLocalCacheRoots | Where-Object { Test-RelativePathUnder $relativePath $_ }) {
+        $issues += "Repo-local media/cache directory found: $relativePath"
+      }
+      continue
+    }
+
+    $extension = [System.IO.Path]::GetExtension($item.Name).ToLowerInvariant()
+    $underForbiddenSurface = Test-RelativePathUnderAny $relativePath $forbiddenBinarySurfaces
+    $underScratchSurface = Test-RelativePathUnderAny $relativePath $repoLocalCacheRoots
+
+    if ($underForbiddenSurface -and $mediaExtensions -contains $extension) {
+      $issues += "Forbidden media asset in repo/public/cache surface: $relativePath"
+    }
+
+    if ($underScratchSurface -and ($scratchOnlyExtensions -contains $extension)) {
+      $issues += "Subtitle/caption file in repo-local media scratch surface: $relativePath"
+    }
+
+    if ($underScratchSurface -and $item.Name.ToLowerInvariant().EndsWith('.info.json')) {
+      $issues += "yt-dlp metadata JSON in repo-local media scratch surface: $relativePath"
+    }
+
+    if ($underForbiddenSurface -and $item.Name -match '(?i)^contact[-_]sheet.*\.(png|jpg|jpeg|webp)$') {
+      $issues += "Contact sheet media file in forbidden surface: $relativePath"
+    }
+    if ($underForbiddenSurface -and $item.Name -match '(?i)^frame[-_][0-9]{4,}\.(png|jpg|jpeg|webp)$') {
+      $issues += "Frame dump media file in forbidden surface: $relativePath"
+    }
+    if ($underForbiddenSurface -and $item.Name -match '(?i)(thumb|thumbnail).*\.(png|jpg|jpeg|webp)$') {
+      $issues += "Thumbnail media file in forbidden surface: $relativePath"
+    }
+  }
+}
+
+if ($issues.Count -gt 0) {
+  throw ($issues -join '; ')
+}
+
+Write-Host 'No video binary assets OK'

--- a/workflows/media-scratch-cache-policy.md
+++ b/workflows/media-scratch-cache-policy.md
@@ -1,6 +1,6 @@
 # Media Scratch Cache Policy
 
-This workflow defines how maintainers should handle temporary images, screenshots, videos, browser artifacts, and vision artifacts during image-aware or video ingest.
+This workflow defines how maintainers should handle temporary images, screenshots, videos, browser artifacts, frame-atlas assets, and vision artifacts during image-aware or video ingest.
 
 Raw media is working material. It is not canonical SF6 knowledge and should not be committed to this repository by default.
 
@@ -25,11 +25,17 @@ Forbidden repo artifacts by default include:
 - screenshots
 - copied article image assets
 - downloaded videos or clips
+- GIFs, WebP files, frame dumps, contact sheets, thumbnails, or generated visual derivatives
 - full transcripts
+- raw captions or subtitle files
 - large excerpts
 - browser cache artifacts
+- local media cache directories
+- external frame-atlas binary assets
 - session, memory, cron, or profile state
 - credentials, tokens, or local `.env` files
+
+`official_raw` remains the current-fact authority. Local media caches, retained scratch files, external visual atlas assets, and visual review artifacts are not current-fact authority and do not override `official_raw`.
 
 ## Scratch Root
 
@@ -47,7 +53,82 @@ Optional Windows equivalent:
 %LOCALAPPDATA%\sf6-skills\media-ingest\
 ```
 
+Future external frame-atlas cache sync, if approved by a later explicit issue, must also use a repo-external root such as:
+
+```bash
+atlas_cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/sf6-skills/external-frame-atlas"
+```
+
 Do not use repo-local paths such as `tmp/`, `.cache/`, `downloads/`, or `assets/raw/` for media ingest scratch files.
+
+## External Frame-Atlas Boundary
+
+External frame-atlas assets are visual references only. They are not numeric frame-data ingestion sources, current-fact authority, public answer behavior, or permission to store binaries in the repository.
+
+Future external frame-atlas cache sync or GIF/image video-usability smoke must be:
+
+- a later explicit issue only;
+- maintainer-local only;
+- repo-external by default;
+- disabled from CI;
+- excluded from public `sf6-agent` behavior and release bundles;
+- sanitized into reports or metadata only;
+- unable to override `official_raw`;
+- unable to become current-fact authority;
+- unable to ingest numeric frame data from external visual sources.
+
+This policy does not authorize #140 to scrape, download, cache, or sync external frame-atlas assets. If a later issue approves acquisition, it should align with existing repo acquisition discipline before adding any new fetch technology, but #140 implements no acquisition.
+
+Recommended future gated sequence, not implemented here:
+
+1. External frame-atlas local cache sync smoke:
+   - later explicit issue only;
+   - after this binary/cache guard is merged;
+   - after permission, terms, robots, and rate-limit review;
+   - maintainer-local only;
+   - repo-external cache only;
+   - CI disabled;
+   - no raw binary commit;
+   - sanitized report and metadata only.
+2. External frame-atlas video usability smoke:
+   - later explicit issue only;
+   - after local cache sync smoke succeeds or is safely held;
+   - tiny sample only;
+   - compare hitbox overlay, clean visual, GIF/contact-sheet style review support;
+   - evaluate candidate move identification as useful, limited, not_safe, or unsupported;
+   - record false-positive risks, overlay/crop/compression failure modes, and source/effective FPS or GIF timing uncertainty;
+   - preserve not-inferred fields;
+   - no exact startup/active/recovery inference;
+   - no exact hit/block advantage inference;
+   - no current-fact promotion;
+   - no `official_raw` override.
+
+## Forbidden Repo Locations
+
+Repo-tracked binary media, media cache, and external atlas binary artifacts are forbidden by default in:
+
+- `skills/sf6-agent/`
+- public release bundle paths
+- `.dist`
+- `skills/sf6-agent/assets/frame-current/`
+- `skills/sf6-agent/assets/normalization/`
+- `data/raw`
+- `data/normalized`
+- `data/exports`
+- `tests/fixtures/` unless metadata-only
+- `knowledge/` unless metadata-only source, evidence, or report artifacts
+- `docs/testing/smoke-runs/` except sanitized reports
+- `tmp/`
+- `.cache/`
+- `downloads/`
+- `assets/raw/`
+- `.external-cache/`
+- `.external-assets/`
+- `.local-media/`
+- `.video-cache/`
+- `.frame-atlas-cache/`
+
+Maintainer-configured scratch paths are allowed only when they are outside the repository. Ignored local scratch inside the repository requires a later explicit issue, `.gitignore` coverage, and validator coverage.
 
 ## Per-run Directory
 
@@ -97,7 +178,11 @@ git status --porcelain
 find . \
   \( -name ".hermes" -o -name ".env" -o -iname "*session*" -o -iname "*memory*" -o -iname "*cron*" \
      -o -iname "*.png" -o -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.webp" \
-     -o -iname "*.mp4" -o -iname "*.mov" -o -iname "*.mkv" \) \
+     -o -iname "*.gif" \
+     -o -iname "*.mp4" -o -iname "*.mov" -o -iname "*.mkv" -o -iname "*.avi" \
+     -o -iname "*.vtt" -o -iname "*.srt" -o -iname "*.ass" \
+     -o -iname "*.info.json" \
+     -o -iname "*frame*dump*" -o -iname "*contact*sheet*" \) \
   -not -path "./.git/*" \
   -not -path "./skills/sf6-agent/assets/frame-current/*" \
   | sort

--- a/workflows/media-scratch-cache-policy.md
+++ b/workflows/media-scratch-cache-policy.md
@@ -184,7 +184,6 @@ find . \
      -o -iname "*.info.json" \
      -o -iname "*frame*dump*" -o -iname "*contact*sheet*" \) \
   -not -path "./.git/*" \
-  -not -path "./skills/sf6-agent/assets/frame-current/*" \
   | sort
 ```
 


### PR DESCRIPTION
## Summary
- Extended the existing media scratch/cache policy only where needed for v2.4 video-learning and external frame-atlas work.
- Added binary/media/cache exclusion validator.
- Wired the validator into `run-all.ps1`.
- Tightened the validator so `skills/sf6-agent/assets/frame-current/` is not directory-wide skipped; forbidden media extensions there are rejected while normal non-media frame-current files remain allowed.

## Scope
- Implements #140 only.
- #141 is not implemented.
- No local cache sync was added.
- No scraper/downloader was added.
- No GIF/image/video/frame asset was fetched or stored.
- No cache directory was created.
- No Git LFS or binary storage was added.
- No public `sf6-agent` behavior changed.
- No `ingest/frame_data` changes were made.

## Future experiment boundary
- Future external frame-atlas cache sync and GIF/image video-usability smoke are deferred to later explicit gated issues.
- This PR only adds policy/validator guardrails so future experiments cannot leak raw media, binary assets, frame dumps, contact sheets, or local cache state into the repo.
- Public answer generation and CI must not scrape/cache external atlas sources.
- External visual atlas assets remain visual references only and do not override `official_raw`.

## Policy boundary
- No duplicate cache policy was created.
- Cache remains repo-external by default.
- Allowed future cache locations and forbidden repo/public bundle locations are documented or confirmed.
- Retained local cache is non-canonical and not current-fact authority.

## Validation
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-no-video-binary-assets.ps1` - PASS (`No video binary assets OK`)
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-external-frame-atlas-source-evaluation.ps1` - PASS (`External frame-atlas source evaluation OK`)
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-external-frame-atlas-source-fixtures.ps1` - PASS (`External frame-atlas source fixtures OK`)
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1` - PASS (`V2 validation suite OK`)
- `git diff --check` - PASS
- `git diff --check origin/main...HEAD` - PASS
- Raw/binary leakage check - PASS; the requested `find` scan returned no entries and no longer excludes `./skills/sf6-agent/assets/frame-current/*`.

Warnings: `run-all.ps1` emitted existing PowerShell git-unavailable warnings during generated-surface checks. A git-visible shell check found no residual diffs in generated references, `.dist`, frame-current assets, normalization assets, `data/raw`, `data/normalized`, or `data/exports`.

Closes #140
