### PR TITLE
[v2.5] Source E2E: commentary-only video VCPzwAwRrLA

### DIFF
--- a/knowledge/curated/glossary/cancel.md
+++ b/knowledge/curated/glossary/cancel.md
@@ -1,0 +1,43 @@
+---
+id: sf6-glossary-cancel
+title: Cancel
+claim_kind: stable_concept
+source_kind: community
+source_role: community terminology boundary
+evidence_basis:
+  - "The term describes ending the later recovery of one action into another action."
+  - "The #168 commentary-only source was reviewed at caption level and supports the broad terminology boundary, but not move-specific cancelability."
+verification_state: partially_verified
+confidence: 0.62
+volatility: stable
+patch_sensitivity: low
+review_status: accepted
+source_refs:
+  - label: "Source metadata: YouTube VCPzwAwRrLA"
+    path: "knowledge/sources/videos/youtube-vcpzwawrrla.md"
+    accessed_at: "2026-05-14"
+  - label: "Terminology claims: YouTube VCPzwAwRrLA"
+    path: "knowledge/evidence/claims/youtube-vcpzwawrrla-terminology.claims.md"
+    accessed_at: "2026-05-14"
+  - label: "Terminology review: YouTube VCPzwAwRrLA"
+    path: "knowledge/review/unresolved/youtube-vcpzwawrrla-terminology.review.md"
+    accessed_at: "2026-05-14"
+review_after: "2026-10-14"
+summary: "Cancel, or キャンセル, is community terminology for ending the later recovery of one action into another action, such as a normal into a special, without asserting current move-specific cancel routes."
+generated_allowed: true
+must_not_include:
+  - "move-specific current cancelability"
+  - "exact cancel windows"
+  - "specific combo route guarantees"
+---
+
+# Cancel
+
+Cancel, often called `キャンセル` in Japanese SF6 discussion, is community
+terminology for ending the later recovery of one action into another action.
+For example, players often discuss a normal attack being canceled into a special
+move as a general concept.
+
+Use this page for the stable term only. Whether a specific move can cancel, when
+it can cancel, and what routes are valid are current move or route facts that
+need separate evidence.

--- a/knowledge/curated/glossary/cross-up.md
+++ b/knowledge/curated/glossary/cross-up.md
@@ -1,0 +1,42 @@
+---
+id: sf6-glossary-cross-up
+title: Cross-Up
+claim_kind: stable_concept
+source_kind: community
+source_role: community terminology boundary
+evidence_basis:
+  - "The term describes an attack that crosses or hits from the opposite side, creating guard-direction ambiguity."
+  - "The #168 commentary-only source was reviewed at caption level and supports the broad terminology boundary, but not any current move-specific cross-up list."
+verification_state: partially_verified
+confidence: 0.64
+volatility: stable
+patch_sensitivity: low
+review_status: accepted
+source_refs:
+  - label: "Source metadata: YouTube VCPzwAwRrLA"
+    path: "knowledge/sources/videos/youtube-vcpzwawrrla.md"
+    accessed_at: "2026-05-14"
+  - label: "Terminology observations: YouTube VCPzwAwRrLA"
+    path: "knowledge/evidence/video-observations/youtube-vcpzwawrrla-terminology.observations.md"
+    accessed_at: "2026-05-14"
+  - label: "Terminology review: YouTube VCPzwAwRrLA"
+    path: "knowledge/review/unresolved/youtube-vcpzwawrrla-terminology.review.md"
+    accessed_at: "2026-05-14"
+review_after: "2026-10-14"
+summary: "Cross-up, or めくり, is community terminology for an attack that crosses or threatens from the opposite side and changes or obscures the defender's guard direction."
+generated_allowed: true
+must_not_include:
+  - "claims that a specific current move always crosses up"
+  - "exact spacing, hurtbox, or active-frame requirements"
+  - "guaranteed setup validity"
+---
+
+# Cross-Up
+
+Cross-up, often called `めくり` in Japanese SF6 discussion, is community
+terminology for an attack that crosses or threatens from the opposite side and
+therefore changes or obscures the defender's guard direction.
+
+Use this as a terminology boundary. Do not treat it as evidence that a specific
+current jump attack, setup, spacing, or character route crosses up without
+separate verification.

--- a/knowledge/curated/glossary/lethal.md
+++ b/knowledge/curated/glossary/lethal.md
@@ -1,0 +1,42 @@
+---
+id: sf6-glossary-lethal
+title: Lethal
+claim_kind: stable_concept
+source_kind: community
+source_role: community terminology boundary
+evidence_basis:
+  - "The term describes an option, sequence, or combo that can finish the opponent from the current life total."
+  - "The #168 commentary-only source was reviewed at caption level and supports the broad terminology boundary, but not route-specific kill thresholds."
+verification_state: partially_verified
+confidence: 0.62
+volatility: stable
+patch_sensitivity: low
+review_status: accepted
+source_refs:
+  - label: "Source metadata: YouTube VCPzwAwRrLA"
+    path: "knowledge/sources/videos/youtube-vcpzwawrrla.md"
+    accessed_at: "2026-05-14"
+  - label: "Terminology claims: YouTube VCPzwAwRrLA"
+    path: "knowledge/evidence/claims/youtube-vcpzwawrrla-terminology.claims.md"
+    accessed_at: "2026-05-14"
+  - label: "Terminology review: YouTube VCPzwAwRrLA"
+    path: "knowledge/review/unresolved/youtube-vcpzwawrrla-terminology.review.md"
+    accessed_at: "2026-05-14"
+review_after: "2026-10-14"
+summary: "Lethal, or リーサル, is community terminology for an option or combo that can finish the opponent from the current life total."
+generated_allowed: true
+must_not_include:
+  - "route-specific damage thresholds"
+  - "claims that a current combo always kills"
+  - "character-, resource-, or patch-specific kill calculations"
+---
+
+# Lethal
+
+Lethal, often called `リーサル` in Japanese SF6 discussion, is community
+terminology for an option, sequence, or combo that can finish the opponent from
+the current life total.
+
+Use this as a stable term only. Whether something is actually lethal depends on
+current health, character, resources, scaling, route damage, positioning, and
+patch-specific behavior.

--- a/knowledge/curated/glossary/meaty.md
+++ b/knowledge/curated/glossary/meaty.md
@@ -1,0 +1,44 @@
+---
+id: sf6-glossary-meaty
+title: Meaty
+claim_kind: stable_concept
+source_kind: community
+source_role: community terminology boundary
+evidence_basis:
+  - "The term describes timing an attack so it overlaps the defender's wake-up or recovery timing."
+  - "The #168 commentary-only source was reviewed at caption level and supports the broad terminology boundary, but not exact setup timing."
+verification_state: partially_verified
+confidence: 0.62
+volatility: stable
+patch_sensitivity: low
+review_status: accepted
+source_refs:
+  - label: "Source metadata: YouTube VCPzwAwRrLA"
+    path: "knowledge/sources/videos/youtube-vcpzwawrrla.md"
+    accessed_at: "2026-05-14"
+  - label: "Terminology claims: YouTube VCPzwAwRrLA"
+    path: "knowledge/evidence/claims/youtube-vcpzwawrrla-terminology.claims.md"
+    accessed_at: "2026-05-14"
+  - label: "Terminology review: YouTube VCPzwAwRrLA"
+    path: "knowledge/review/unresolved/youtube-vcpzwawrrla-terminology.review.md"
+    accessed_at: "2026-05-14"
+review_after: "2026-10-14"
+summary: "Meaty, or 重ね, is community terminology for timing an attack to overlap a defender's wake-up or recovery timing without asserting a specific guaranteed setup."
+generated_allowed: true
+must_not_include:
+  - "specific current wake-up setup timing"
+  - "guaranteed follow-up or punish routes"
+  - "exact frame advantage values"
+---
+
+# Meaty
+
+Meaty, often called `重ね` in Japanese SF6 discussion, is community terminology
+for timing an attack so it overlaps the defender's wake-up or recovery timing.
+The basic idea is that the attacker places an active threat where the defender
+is about to become able to act.
+
+Use this as a stable terminology explanation only. Whether a particular meaty
+setup works depends on knockdown type, spacing, recovery timing, active
+duration, invincible options, defensive system choices, and current move
+behavior.

--- a/knowledge/evidence/claims/youtube-vcpzwawrrla-terminology.claims.md
+++ b/knowledge/evidence/claims/youtube-vcpzwawrrla-terminology.claims.md
@@ -4,7 +4,7 @@ title: "Candidate terminology claims from YouTube VCPzwAwRrLA"
 source_kind: community
 source_role: commentary_only_terminology_claims
 verification_state: partially_verified
-confidence: 0.52
+confidence: 0.45
 volatility: stable
 patch_sensitivity: medium
 review_status: needs_review
@@ -26,6 +26,18 @@ These claims are extracted for review only. They are not accepted curated knowle
 The source was analyzed for terminology and concept knowledge units, not for a
 video summary. Temporary caption review happened outside the repository; the raw
 captions and transcript-like text are not stored here.
+
+## Caption-Level Review Boundary
+
+- Claims are derived from temporary auto-generated caption-level content review.
+- Direct audio reviewed? no.
+- Direct video reviewed? no.
+- Claim wording is paraphrased; exact source wording is not preserved.
+- Official terminology authority is not claimed.
+- Automatic captions can misrecognize Japanese terms, omit speaker nuance, or
+  segment commentary imperfectly.
+- Any term requiring exact definition wording, official terminology authority,
+  move-specific current behavior, or exact setup validity remains `needs_review`.
 
 ## Source-Derived Terminology Units
 
@@ -63,7 +75,7 @@ changed by this PR.
         "Timestamped sanitized observation recorded in knowledge/evidence/video-observations/youtube-vcpzwawrrla-terminology.observations.md."
       ],
       "verification_state": "partially_verified",
-      "confidence": 0.62,
+      "confidence": 0.52,
       "volatility": "stable",
       "patch_sensitivity": "medium",
       "review_status": "needs_review",
@@ -90,7 +102,7 @@ changed by this PR.
         "Temporary Japanese caption review of YouTube VCPzwAwRrLA on 2026-05-14."
       ],
       "verification_state": "partially_verified",
-      "confidence": 0.65,
+      "confidence": 0.54,
       "volatility": "stable",
       "patch_sensitivity": "low",
       "review_status": "needs_review",
@@ -118,7 +130,7 @@ changed by this PR.
         "Existing curated shimmy page was inspected but not changed."
       ],
       "verification_state": "partially_verified",
-      "confidence": 0.68,
+      "confidence": 0.56,
       "volatility": "stable",
       "patch_sensitivity": "low",
       "review_status": "needs_review",
@@ -145,7 +157,7 @@ changed by this PR.
         "Temporary Japanese caption review of YouTube VCPzwAwRrLA on 2026-05-14."
       ],
       "verification_state": "partially_verified",
-      "confidence": 0.62,
+      "confidence": 0.52,
       "volatility": "stable",
       "patch_sensitivity": "medium",
       "review_status": "needs_review",
@@ -172,7 +184,7 @@ changed by this PR.
         "Temporary Japanese caption review of YouTube VCPzwAwRrLA on 2026-05-14."
       ],
       "verification_state": "partially_verified",
-      "confidence": 0.64,
+      "confidence": 0.52,
       "volatility": "stable",
       "patch_sensitivity": "medium",
       "review_status": "needs_review",

--- a/knowledge/evidence/claims/youtube-vcpzwawrrla-terminology.claims.md
+++ b/knowledge/evidence/claims/youtube-vcpzwawrrla-terminology.claims.md
@@ -1,0 +1,201 @@
+---
+id: claims-youtube-vcpzwawrrla-terminology
+title: "Candidate terminology claims from YouTube VCPzwAwRrLA"
+source_kind: community
+source_role: commentary_only_terminology_claims
+verification_state: partially_verified
+confidence: 0.52
+volatility: stable
+patch_sensitivity: medium
+review_status: needs_review
+review_after: "2026-08-14"
+source_refs:
+  - label: "Source metadata: YouTube VCPzwAwRrLA"
+    path: "knowledge/sources/videos/youtube-vcpzwawrrla.md"
+    url: "https://www.youtube.com/watch?v=VCPzwAwRrLA"
+    accessed_at: "2026-05-14"
+  - label: "Video observation: YouTube VCPzwAwRrLA terminology"
+    path: "knowledge/evidence/video-observations/youtube-vcpzwawrrla-terminology.observations.md"
+    accessed_at: "2026-05-14"
+---
+
+# Candidate Claims
+
+These claims are extracted for review only. They are not accepted curated knowledge and must not feed generated references until reviewed and promoted through the normal process.
+
+The source was analyzed for terminology and concept knowledge units, not for a
+video summary. Temporary caption review happened outside the repository; the raw
+captions and transcript-like text are not stored here.
+
+## Source-Derived Terminology Units
+
+| knowledge_unit_id | source-derived knowledge | claim_kind | target surface | review_status | terminal decision | notes |
+|---|---|---|---|---|---|---|
+| `term-vcpzwawrrla-meaty-001` | `重ね` is explained as timing an attack or special move against a waking opponent so it overlaps the opponent's wake-up. | `stable_concept` | review note / future glossary candidate | needs_review | review-only terminology candidate | Exact meaty setups, timing, and guaranteed followups remain separate current or matchup claims. |
+| `term-vcpzwawrrla-crossup-002` | `めくり` is explained through a jump attack that hits or threatens from behind/crossing side, causing guard-direction ambiguity or reversal. | `stable_concept` | review note / future glossary candidate | needs_review | review-only terminology candidate | Do not infer which current jump attacks cross up. |
+| `term-vcpzwawrrla-sukashi-003` | `すかし` is explained as withholding the expected jump attack and landing into another option such as low or throw pressure. | `strategy_or_matchup` | review note | needs_review | review-only terminology candidate | Option coverage is context-dependent and source-local. |
+| `term-vcpzwawrrla-line-004` | `ライン` is explained as screen-position pressure: advancing pushes the opponent toward the corner, retreating lowers the line. | `strategy_or_matchup` | review note | needs_review | review-only concept candidate | No exact spacing rule or matchup claim is accepted. |
+| `term-vcpzwawrrla-grapple-005` | `グラップ` is used as community wording for throw escape / throw tech, including delayed throw-tech context. | `stable_concept` | review note / future glossary candidate | needs_review | review-only terminology candidate | Not treated as official terminology authority. |
+| `term-vcpzwawrrla-shimmy-006` | `シミー` is explained as baiting an opponent's throw-tech / grapple response, making it whiff, and punishing it. | `stable_concept` | existing curated glossary boundary plus review note | needs_review | corroborates existing stable concept; no new curated promotion | Existing `knowledge/curated/glossary/shimmy.md` remains unchanged. |
+| `term-vcpzwawrrla-abare-007` | `暴れ` is explained as attacking from disadvantage or an expected-block situation to interrupt pressure. | `strategy_or_matchup` | review note | needs_review | review-only terminology candidate | Any exact advantage examples remain current-fact-like and are not accepted here. |
+| `term-vcpzwawrrla-katame-008` | `固め` is explained as using attacks or pressure strings to make the defender hard to move. | `strategy_or_matchup` | review note | needs_review | review-only concept candidate | SF6-specific pressure strength and plus-state claims remain held. |
+| `term-vcpzwawrrla-cancel-009` | `キャンセル` is explained as cutting off the later recovery of one action into another action, commonly normal into special. | `stable_concept` | review note / future glossary candidate | needs_review | review-only terminology candidate | Move-specific cancelability is a current-system fact. |
+| `term-vcpzwawrrla-lethal-010` | `リーサル` is explained as an option or combo that can finish the opponent from the current life total. | `stable_concept` | review note / future glossary candidate | needs_review | review-only terminology candidate | Exact kill thresholds are route-, resource-, character-, and patch-sensitive. |
+
+## Claim Payloads
+
+The JSON payloads below are review-only claim candidates. Every embedded
+`review_status` remains `needs_review`; accepted public-use surfaces are not
+changed by this PR.
+
+```json
+[
+  {
+    "id": "claim-youtube-vcpzwawrrla-meaty-001",
+    "claim_kind": "stable_concept",
+    "statement": "The source explains `重ね` as timing an attack or special move against a waking opponent so it overlaps wake-up.",
+    "scope": "Community fighting-game terminology; no exact setup or current timing claim.",
+    "evidence": {
+      "source_kind": "community",
+      "source_role": "commentary_only_terminology_source",
+      "evidence_basis": [
+        "Temporary Japanese caption review of YouTube VCPzwAwRrLA on 2026-05-14.",
+        "Timestamped sanitized observation recorded in knowledge/evidence/video-observations/youtube-vcpzwawrrla-terminology.observations.md."
+      ],
+      "verification_state": "partially_verified",
+      "confidence": 0.62,
+      "volatility": "stable",
+      "patch_sensitivity": "medium",
+      "review_status": "needs_review",
+      "source_refs": [
+        {
+          "label": "YouTube VCPzwAwRrLA source metadata",
+          "path": "knowledge/sources/videos/youtube-vcpzwawrrla.md",
+          "accessed_at": "2026-05-14"
+        }
+      ],
+      "review_after": "2026-08-14"
+    },
+    "notes": "Keep as terminology candidate. Exact meaty setup validity is not accepted."
+  },
+  {
+    "id": "claim-youtube-vcpzwawrrla-crossup-002",
+    "claim_kind": "stable_concept",
+    "statement": "The source explains `めくり` as a jump-attack situation where the defender's guard direction becomes reversed or ambiguous because the attack comes from the crossing side.",
+    "scope": "Community fighting-game terminology; no accepted current move list.",
+    "evidence": {
+      "source_kind": "community",
+      "source_role": "commentary_only_terminology_source",
+      "evidence_basis": [
+        "Temporary Japanese caption review of YouTube VCPzwAwRrLA on 2026-05-14."
+      ],
+      "verification_state": "partially_verified",
+      "confidence": 0.65,
+      "volatility": "stable",
+      "patch_sensitivity": "low",
+      "review_status": "needs_review",
+      "source_refs": [
+        {
+          "label": "YouTube VCPzwAwRrLA source metadata",
+          "path": "knowledge/sources/videos/youtube-vcpzwawrrla.md",
+          "accessed_at": "2026-05-14"
+        }
+      ],
+      "review_after": "2026-08-14"
+    },
+    "notes": "Candidate glossary definition only. Current jump-attack behavior remains separate."
+  },
+  {
+    "id": "claim-youtube-vcpzwawrrla-shimmy-006",
+    "claim_kind": "stable_concept",
+    "statement": "The source explains `シミー` as baiting an opponent's throw-tech or grapple response, making it whiff, and punishing it.",
+    "scope": "Community terminology corroborating the existing shimmy boundary.",
+    "evidence": {
+      "source_kind": "community",
+      "source_role": "commentary_only_terminology_source",
+      "evidence_basis": [
+        "Temporary Japanese caption review of YouTube VCPzwAwRrLA on 2026-05-14.",
+        "Existing curated shimmy page was inspected but not changed."
+      ],
+      "verification_state": "partially_verified",
+      "confidence": 0.68,
+      "volatility": "stable",
+      "patch_sensitivity": "low",
+      "review_status": "needs_review",
+      "source_refs": [
+        {
+          "label": "YouTube VCPzwAwRrLA source metadata",
+          "path": "knowledge/sources/videos/youtube-vcpzwawrrla.md",
+          "accessed_at": "2026-05-14"
+        }
+      ],
+      "review_after": "2026-08-14"
+    },
+    "notes": "No curated text changed. This source is review corroboration only."
+  },
+  {
+    "id": "claim-youtube-vcpzwawrrla-cancel-009",
+    "claim_kind": "stable_concept",
+    "statement": "The source explains `キャンセル` as ending the later recovery of one action into another action, especially normal into special.",
+    "scope": "Community terminology; no accepted move-specific cancelability claim.",
+    "evidence": {
+      "source_kind": "community",
+      "source_role": "commentary_only_terminology_source",
+      "evidence_basis": [
+        "Temporary Japanese caption review of YouTube VCPzwAwRrLA on 2026-05-14."
+      ],
+      "verification_state": "partially_verified",
+      "confidence": 0.62,
+      "volatility": "stable",
+      "patch_sensitivity": "medium",
+      "review_status": "needs_review",
+      "source_refs": [
+        {
+          "label": "YouTube VCPzwAwRrLA source metadata",
+          "path": "knowledge/sources/videos/youtube-vcpzwawrrla.md",
+          "accessed_at": "2026-05-14"
+        }
+      ],
+      "review_after": "2026-08-14"
+    },
+    "notes": "Do not infer current cancel routes or move properties from this source alone."
+  },
+  {
+    "id": "claim-youtube-vcpzwawrrla-lethal-010",
+    "claim_kind": "stable_concept",
+    "statement": "The source explains `リーサル` as an option or combo that can finish the opponent from the current life total.",
+    "scope": "Community terminology; no route-specific kill threshold claim.",
+    "evidence": {
+      "source_kind": "community",
+      "source_role": "commentary_only_terminology_source",
+      "evidence_basis": [
+        "Temporary Japanese caption review of YouTube VCPzwAwRrLA on 2026-05-14."
+      ],
+      "verification_state": "partially_verified",
+      "confidence": 0.64,
+      "volatility": "stable",
+      "patch_sensitivity": "medium",
+      "review_status": "needs_review",
+      "source_refs": [
+        {
+          "label": "YouTube VCPzwAwRrLA source metadata",
+          "path": "knowledge/sources/videos/youtube-vcpzwawrrla.md",
+          "accessed_at": "2026-05-14"
+        }
+      ],
+      "review_after": "2026-08-14"
+    },
+    "notes": "Exact lethal routes and damage thresholds need current route/resource verification."
+  }
+]
+```
+
+## Held / Routed Claims
+
+- `暴れ` included source-local examples involving advantage/disadvantage; exact
+  advantage values are not recorded here and remain current-fact-like.
+- `固め` included SF6-specific commentary about pressure strength; keep that as
+  source-local review input, not accepted public guidance.
+- `グラップ`, `すかし`, and `ライン` are captured as terminology or concept
+  candidates, but they need normalization before curated glossary promotion.
+- No rejected unsafe claim was found in this source-unit run.

--- a/knowledge/evidence/claims/youtube-vcpzwawrrla-terminology.claims.md
+++ b/knowledge/evidence/claims/youtube-vcpzwawrrla-terminology.claims.md
@@ -43,22 +43,27 @@ captions and transcript-like text are not stored here.
 
 | knowledge_unit_id | source-derived knowledge | claim_kind | target surface | review_status | terminal decision | notes |
 |---|---|---|---|---|---|---|
-| `term-vcpzwawrrla-meaty-001` | `重ね` is explained as timing an attack or special move against a waking opponent so it overlaps the opponent's wake-up. | `stable_concept` | review note / future glossary candidate | needs_review | review-only terminology candidate | Exact meaty setups, timing, and guaranteed followups remain separate current or matchup claims. |
-| `term-vcpzwawrrla-crossup-002` | `めくり` is explained through a jump attack that hits or threatens from behind/crossing side, causing guard-direction ambiguity or reversal. | `stable_concept` | review note / future glossary candidate | needs_review | review-only terminology candidate | Do not infer which current jump attacks cross up. |
+| `term-vcpzwawrrla-meaty-001` | `重ね` is explained as timing an attack or special move against a waking opponent so it overlaps the opponent's wake-up. | `stable_concept` | `knowledge/curated/glossary/meaty.md` | needs_review | accepted curated glossary entry; embedded claim remains review-only | Exact meaty setups, timing, and guaranteed followups remain separate current or matchup claims. |
+| `term-vcpzwawrrla-crossup-002` | `めくり` is explained through a jump attack that hits or threatens from behind/crossing side, causing guard-direction ambiguity or reversal. | `stable_concept` | `knowledge/curated/glossary/cross-up.md` | needs_review | accepted curated glossary entry; embedded claim remains review-only | Do not infer which current jump attacks cross up. |
 | `term-vcpzwawrrla-sukashi-003` | `すかし` is explained as withholding the expected jump attack and landing into another option such as low or throw pressure. | `strategy_or_matchup` | review note | needs_review | review-only terminology candidate | Option coverage is context-dependent and source-local. |
 | `term-vcpzwawrrla-line-004` | `ライン` is explained as screen-position pressure: advancing pushes the opponent toward the corner, retreating lowers the line. | `strategy_or_matchup` | review note | needs_review | review-only concept candidate | No exact spacing rule or matchup claim is accepted. |
 | `term-vcpzwawrrla-grapple-005` | `グラップ` is used as community wording for throw escape / throw tech, including delayed throw-tech context. | `stable_concept` | review note / future glossary candidate | needs_review | review-only terminology candidate | Not treated as official terminology authority. |
 | `term-vcpzwawrrla-shimmy-006` | `シミー` is explained as baiting an opponent's throw-tech / grapple response, making it whiff, and punishing it. | `stable_concept` | existing curated glossary boundary plus review note | needs_review | corroborates existing stable concept; no new curated promotion | Existing `knowledge/curated/glossary/shimmy.md` remains unchanged. |
 | `term-vcpzwawrrla-abare-007` | `暴れ` is explained as attacking from disadvantage or an expected-block situation to interrupt pressure. | `strategy_or_matchup` | review note | needs_review | review-only terminology candidate | Any exact advantage examples remain current-fact-like and are not accepted here. |
 | `term-vcpzwawrrla-katame-008` | `固め` is explained as using attacks or pressure strings to make the defender hard to move. | `strategy_or_matchup` | review note | needs_review | review-only concept candidate | SF6-specific pressure strength and plus-state claims remain held. |
-| `term-vcpzwawrrla-cancel-009` | `キャンセル` is explained as cutting off the later recovery of one action into another action, commonly normal into special. | `stable_concept` | review note / future glossary candidate | needs_review | review-only terminology candidate | Move-specific cancelability is a current-system fact. |
-| `term-vcpzwawrrla-lethal-010` | `リーサル` is explained as an option or combo that can finish the opponent from the current life total. | `stable_concept` | review note / future glossary candidate | needs_review | review-only terminology candidate | Exact kill thresholds are route-, resource-, character-, and patch-sensitive. |
+| `term-vcpzwawrrla-cancel-009` | `キャンセル` is explained as cutting off the later recovery of one action into another action, commonly normal into special. | `stable_concept` | `knowledge/curated/glossary/cancel.md` | needs_review | accepted curated glossary entry; embedded claim remains review-only | Move-specific cancelability is a current-system fact. |
+| `term-vcpzwawrrla-lethal-010` | `リーサル` is explained as an option or combo that can finish the opponent from the current life total. | `stable_concept` | `knowledge/curated/glossary/lethal.md` | needs_review | accepted curated glossary entry; embedded claim remains review-only | Exact kill thresholds are route-, resource-, character-, and patch-sensitive. |
 
 ## Claim Payloads
 
 The JSON payloads below are review-only claim candidates. Every embedded
-`review_status` remains `needs_review`; accepted public-use surfaces are not
-changed by this PR.
+`review_status` remains `needs_review`; accepted public-use surfaces are changed
+only through the curated glossary files listed in the table above.
+
+For terms promoted to curated glossary entries, the accepted terminal decision
+is recorded in the table and the new curated page. The embedded JSON stays
+review-only because video-derived claim artifacts must not mark their own
+payloads accepted.
 
 ```json
 [
@@ -210,4 +215,7 @@ changed by this PR.
   source-local review input, not accepted public guidance.
 - `グラップ`, `すかし`, and `ライン` are captured as terminology or concept
   candidates, but they need normalization before curated glossary promotion.
+- `重ね`, `めくり`, `キャンセル`, and `リーサル` are promoted only as stable
+  glossary boundaries. Their setup-, move-, route-, resource-, and
+  current-system details remain held.
 - No rejected unsafe claim was found in this source-unit run.

--- a/knowledge/evidence/video-observations/youtube-vcpzwawrrla-terminology.observations.md
+++ b/knowledge/evidence/video-observations/youtube-vcpzwawrrla-terminology.observations.md
@@ -1,0 +1,149 @@
+---
+id: video-observation-youtube-vcpzwawrrla-terminology
+title: YouTube VCPzwAwRrLA Commentary Terminology Observation
+source_kind: reproducible_observation
+source_role: commentary_only_terminology_observation
+review_status: needs_review
+review_after: "2026-08-14"
+---
+
+# YouTube VCPzwAwRrLA Commentary Terminology Observation
+
+This artifact records sanitized observations from a commentary-only terminology
+video. It is an observation artifact, not accepted strategy knowledge, and it
+must not feed generated references without later review.
+
+## Source
+
+- Source metadata: `knowledge/sources/videos/youtube-vcpzwawrrla.md`
+- Source URL: `https://www.youtube.com/watch?v=VCPzwAwRrLA`
+- Accessed: 2026-05-14
+- Observation method: no-cookie YouTube metadata access plus temporary Japanese
+  caption review in a repo-external scratch/cache location.
+- Reviewed duration: full source structure by chapter, approximately 20:14.
+- Raw media stored in repo: no.
+- Full transcript stored in repo: no.
+
+## Timestamped Observations
+
+| Time | Observation kind | Visible observation | Speaker/commentary claim | Confidence | Notes |
+|---|---|---|---|---|---|
+| 00:46-02:01 | commentary terminology | Commentary chapter introduces `重ね`. | Source explains the term as timing an attack or special move against a waking opponent, and treats a failed overlap as a missed meaty timing. | high | Review-only terminology candidate; exact wake-up setups remain outside this artifact. |
+| 02:01-03:31 | commentary terminology | Commentary chapter introduces `めくり`. | Source explains the term through a jump attack that crosses or hits behind the opponent so the guard direction is reversed; it also connects the idea to cross-up wording. | high | Stable glossary candidate, but source-local wording is not copied. |
+| 03:31-04:49 | commentary terminology | Commentary chapter introduces `すかし`. | Source frames it as withholding the expected jump attack and instead landing into another option such as a low or throw-like threat. | medium | Keep as terminology candidate; exact option coverage is context-dependent. |
+| 04:49-06:50 | commentary terminology | Commentary chapter introduces `ライン`. | Source uses line to describe screen-position pressure: advancing the line pushes the opponent toward the corner, while retreating lowers the line. | medium | Strategy concept candidate; no exact screen-position rule is accepted. |
+| 06:50-08:44 | commentary terminology | Commentary chapter introduces `グラップ`. | Source uses the term as throw escape / throw-tech wording in SF6 commentary and connects it to delayed throw-tech situations. | medium | Community terminology candidate; not official terminology authority. |
+| 08:44-11:20 | commentary terminology | Commentary chapter introduces `シミー`. | Source explains shimmy as baiting an opponent's throw-tech / grapple response, making it whiff, and punishing it. | high | Existing curated shimmy page was not modified; this row is review input only. |
+| 11:20-14:44 | commentary terminology | Commentary chapter introduces `暴れ`. | Source frames the term as pressing an attack from a disadvantage or expected-block situation, such as wake-up or after guarding pressure. | medium | Exact advantage examples are held as current-fact-like and are not recorded as accepted values. |
+| 14:44-16:06 | commentary terminology | Commentary chapter introduces `固め`. | Source explains it as using normals, specials, or pressure strings to make the defender hard to move, while noting SF6-specific pressure caveats. | medium | General concept candidate; SF6-specific pressure strength remains review-needed. |
+| 16:06-18:01 | commentary terminology | Commentary chapter introduces `キャンセル`. | Source explains cancel as cutting off the later recovery of one action, especially a normal, into another action such as a special. | high | Stable terminology candidate; move-specific cancelability remains current fact. |
+| 18:01-20:14 | commentary terminology | Commentary chapter introduces `リーサル`. | Source explains lethal as an option or combo that can finish the opponent from the current life total. | high | Stable concept candidate; exact route kill thresholds are current or matchup facts. |
+
+## Contract-Shaped Observation Payload
+
+This payload follows the shape of `contracts/video-observation.schema.json` at a
+coarse commentary-review level. Segment text is paraphrased; no full transcript
+or raw captions are stored.
+
+```json
+{
+  "schema_version": "2.0.0",
+  "clip_metadata": {
+    "clip_id": "youtube-vcpzwawrrla-terminology-review",
+    "source_fps": null,
+    "normalized_fps": 60,
+    "total_frames": 72840
+  },
+  "actor_bindings": [
+    {
+      "actor_ref": "actor_a",
+      "character_slug": null,
+      "binding_confidence": 0.0,
+      "binding_basis": [
+        "commentary-only source; no gameplay actor binding accepted"
+      ]
+    },
+    {
+      "actor_ref": "actor_b",
+      "character_slug": null,
+      "binding_confidence": 0.0,
+      "binding_basis": [
+        "commentary-only source; no gameplay actor binding accepted"
+      ]
+    }
+  ],
+  "segments": [
+    {
+      "segment_id": "seg-terminology-0001",
+      "track": "transcript",
+      "kind": "term_meaty_source_claim",
+      "start_frame": 2760,
+      "end_frame": 7260,
+      "confidence": 0.8,
+      "summary": "Source-derived `重ね` explanation candidate.",
+      "evidence_refs": [
+        "knowledge/sources/videos/youtube-vcpzwawrrla.md"
+      ]
+    },
+    {
+      "segment_id": "seg-terminology-0002",
+      "track": "transcript",
+      "kind": "term_crossup_source_claim",
+      "start_frame": 7260,
+      "end_frame": 12660,
+      "confidence": 0.85,
+      "summary": "Source-derived `めくり` explanation candidate.",
+      "evidence_refs": [
+        "knowledge/sources/videos/youtube-vcpzwawrrla.md"
+      ]
+    },
+    {
+      "segment_id": "seg-terminology-0003",
+      "track": "transcript",
+      "kind": "term_shimmy_source_claim",
+      "start_frame": 31440,
+      "end_frame": 40800,
+      "confidence": 0.85,
+      "summary": "Source-derived `シミー` explanation candidate.",
+      "evidence_refs": [
+        "knowledge/sources/videos/youtube-vcpzwawrrla.md"
+      ]
+    },
+    {
+      "segment_id": "seg-terminology-0004",
+      "track": "transcript",
+      "kind": "term_cancel_and_lethal_source_claim",
+      "start_frame": 57960,
+      "end_frame": 72840,
+      "confidence": 0.8,
+      "summary": "Source-derived `キャンセル` and `リーサル` explanation candidates.",
+      "evidence_refs": [
+        "knowledge/sources/videos/youtube-vcpzwawrrla.md"
+      ]
+    }
+  ],
+  "derived_events": [
+    {
+      "event_id": "event-terminology-0001",
+      "kind": "commentary_only_terminology_extraction_seed",
+      "source_segment_ids": [
+        "seg-terminology-0001",
+        "seg-terminology-0002",
+        "seg-terminology-0003",
+        "seg-terminology-0004"
+      ]
+    }
+  ]
+}
+```
+
+## Boundary Notes
+
+- These are review-only observations.
+- The extracted terminology candidates are not accepted current facts.
+- Commentary definitions are source-derived review input, not official
+  terminology authority.
+- Exact frame advantage, guaranteed setup validity, and move-specific
+  cancelability are held for separate verification.
+- No raw media, frames, screenshots, contact sheets, full captions, or full
+  transcript are stored in the repository.

--- a/knowledge/evidence/video-observations/youtube-vcpzwawrrla-terminology.observations.md
+++ b/knowledge/evidence/video-observations/youtube-vcpzwawrrla-terminology.observations.md
@@ -18,8 +18,9 @@ must not feed generated references without later review.
 - Source metadata: `knowledge/sources/videos/youtube-vcpzwawrrla.md`
 - Source URL: `https://www.youtube.com/watch?v=VCPzwAwRrLA`
 - Accessed: 2026-05-14
-- Observation method: no-cookie YouTube metadata access plus temporary Japanese
-  caption review in a repo-external scratch/cache location.
+- Observation method: no-cookie YouTube metadata access plus temporary
+  auto-generated Japanese caption review in a repo-external scratch/cache
+  location.
 - Reviewed duration: full source structure by chapter, approximately 20:14.
 - Raw media stored in repo: no.
 - Full transcript stored in repo: no.
@@ -28,16 +29,34 @@ must not feed generated references without later review.
 
 | Time | Observation kind | Visible observation | Speaker/commentary claim | Confidence | Notes |
 |---|---|---|---|---|---|
-| 00:46-02:01 | commentary terminology | Commentary chapter introduces `重ね`. | Source explains the term as timing an attack or special move against a waking opponent, and treats a failed overlap as a missed meaty timing. | high | Review-only terminology candidate; exact wake-up setups remain outside this artifact. |
-| 02:01-03:31 | commentary terminology | Commentary chapter introduces `めくり`. | Source explains the term through a jump attack that crosses or hits behind the opponent so the guard direction is reversed; it also connects the idea to cross-up wording. | high | Stable glossary candidate, but source-local wording is not copied. |
+| 00:46-02:01 | commentary terminology | Commentary chapter introduces `重ね`. | Source explains the term as timing an attack or special move against a waking opponent, and treats a failed overlap as a missed meaty timing. | medium | Review-only terminology candidate; confidence reflects broad topic identification from automatic captions, not exact definition wording. |
+| 02:01-03:31 | commentary terminology | Commentary chapter introduces `めくり`. | Source explains the term through a jump attack that crosses or hits behind the opponent so the guard direction is reversed; it also connects the idea to cross-up wording. | medium | Stable glossary candidate, but source-local wording is not copied and exact wording remains needs_review. |
 | 03:31-04:49 | commentary terminology | Commentary chapter introduces `すかし`. | Source frames it as withholding the expected jump attack and instead landing into another option such as a low or throw-like threat. | medium | Keep as terminology candidate; exact option coverage is context-dependent. |
 | 04:49-06:50 | commentary terminology | Commentary chapter introduces `ライン`. | Source uses line to describe screen-position pressure: advancing the line pushes the opponent toward the corner, while retreating lowers the line. | medium | Strategy concept candidate; no exact screen-position rule is accepted. |
 | 06:50-08:44 | commentary terminology | Commentary chapter introduces `グラップ`. | Source uses the term as throw escape / throw-tech wording in SF6 commentary and connects it to delayed throw-tech situations. | medium | Community terminology candidate; not official terminology authority. |
-| 08:44-11:20 | commentary terminology | Commentary chapter introduces `シミー`. | Source explains shimmy as baiting an opponent's throw-tech / grapple response, making it whiff, and punishing it. | high | Existing curated shimmy page was not modified; this row is review input only. |
+| 08:44-11:20 | commentary terminology | Commentary chapter introduces `シミー`. | Source explains shimmy as baiting an opponent's throw-tech / grapple response, making it whiff, and punishing it. | medium | Existing curated shimmy page was not modified; this row is review input only and caption-derived. |
 | 11:20-14:44 | commentary terminology | Commentary chapter introduces `暴れ`. | Source frames the term as pressing an attack from a disadvantage or expected-block situation, such as wake-up or after guarding pressure. | medium | Exact advantage examples are held as current-fact-like and are not recorded as accepted values. |
 | 14:44-16:06 | commentary terminology | Commentary chapter introduces `固め`. | Source explains it as using normals, specials, or pressure strings to make the defender hard to move, while noting SF6-specific pressure caveats. | medium | General concept candidate; SF6-specific pressure strength remains review-needed. |
-| 16:06-18:01 | commentary terminology | Commentary chapter introduces `キャンセル`. | Source explains cancel as cutting off the later recovery of one action, especially a normal, into another action such as a special. | high | Stable terminology candidate; move-specific cancelability remains current fact. |
-| 18:01-20:14 | commentary terminology | Commentary chapter introduces `リーサル`. | Source explains lethal as an option or combo that can finish the opponent from the current life total. | high | Stable concept candidate; exact route kill thresholds are current or matchup facts. |
+| 16:06-18:01 | commentary terminology | Commentary chapter introduces `キャンセル`. | Source explains cancel as cutting off the later recovery of one action, especially a normal, into another action such as a special. | medium | Stable terminology candidate; move-specific cancelability remains current fact and exact wording remains needs_review. |
+| 18:01-20:14 | commentary terminology | Commentary chapter introduces `リーサル`. | Source explains lethal as an option or combo that can finish the opponent from the current life total. | medium | Stable concept candidate; exact route kill thresholds are current or matchup facts. |
+
+## Caption Review Provenance And Limits
+
+- Caption provenance: auto-generated. `yt-dlp --list-subs` reported no
+  uploaded/manual subtitles and available automatic captions for this source.
+- Direct audio reviewed? no.
+- Direct video reviewed? no.
+- Content execution depth: `caption_level_content_review`.
+- Timestamped observations are paraphrased from temporary caption-level review
+  plus chapter metadata; raw captions and transcript-like text are not
+  committed.
+- Automatic caption errors may affect Japanese terminology extraction,
+  especially source-local wording, speaker nuance, and homophones.
+- Confidence values mean confidence in broad chapter/topic identification and
+  paraphrased concept extraction, not official definition accuracy or exact
+  source wording.
+- Terms requiring exact wording, official terminology authority, or
+  move/system-specific claims remain `needs_review`.
 
 ## Contract-Shaped Observation Payload
 
@@ -79,7 +98,7 @@ or raw captions are stored.
       "kind": "term_meaty_source_claim",
       "start_frame": 2760,
       "end_frame": 7260,
-      "confidence": 0.8,
+      "confidence": 0.62,
       "summary": "Source-derived `重ね` explanation candidate.",
       "evidence_refs": [
         "knowledge/sources/videos/youtube-vcpzwawrrla.md"
@@ -91,7 +110,7 @@ or raw captions are stored.
       "kind": "term_crossup_source_claim",
       "start_frame": 7260,
       "end_frame": 12660,
-      "confidence": 0.85,
+      "confidence": 0.65,
       "summary": "Source-derived `めくり` explanation candidate.",
       "evidence_refs": [
         "knowledge/sources/videos/youtube-vcpzwawrrla.md"
@@ -103,7 +122,7 @@ or raw captions are stored.
       "kind": "term_shimmy_source_claim",
       "start_frame": 31440,
       "end_frame": 40800,
-      "confidence": 0.85,
+      "confidence": 0.65,
       "summary": "Source-derived `シミー` explanation candidate.",
       "evidence_refs": [
         "knowledge/sources/videos/youtube-vcpzwawrrla.md"
@@ -115,7 +134,7 @@ or raw captions are stored.
       "kind": "term_cancel_and_lethal_source_claim",
       "start_frame": 57960,
       "end_frame": 72840,
-      "confidence": 0.8,
+      "confidence": 0.62,
       "summary": "Source-derived `キャンセル` and `リーサル` explanation candidates.",
       "evidence_refs": [
         "knowledge/sources/videos/youtube-vcpzwawrrla.md"
@@ -140,6 +159,7 @@ or raw captions are stored.
 ## Boundary Notes
 
 - These are review-only observations.
+- They are based on caption-level content review, not direct audio/video review.
 - The extracted terminology candidates are not accepted current facts.
 - Commentary definitions are source-derived review input, not official
   terminology authority.

--- a/knowledge/review/unresolved/youtube-vcpzwawrrla-terminology.review.md
+++ b/knowledge/review/unresolved/youtube-vcpzwawrrla-terminology.review.md
@@ -10,7 +10,7 @@ evidence_basis:
   - "Candidate claims recorded in knowledge/evidence/claims/youtube-vcpzwawrrla-terminology.claims.md."
   - "Temporary captions were reviewed in repo-external scratch and were not committed."
 verification_state: partially_verified
-confidence: 0.48
+confidence: 0.42
 volatility: stable
 patch_sensitivity: medium
 review_status: needs_review
@@ -25,7 +25,7 @@ source_refs:
     path: "knowledge/evidence/claims/youtube-vcpzwawrrla-terminology.claims.md"
     accessed_at: "2026-05-14"
 review_after: "2026-08-14"
-summary: "Review note for #168 source E2E on a commentary-only terminology video; source-derived terminology candidates are captured as review-only knowledge."
+summary: "Review note for #168 source E2E on a commentary-only terminology video; source-derived terminology candidates are captured as review-only knowledge from caption-level content review."
 ---
 
 # YouTube VCPzwAwRrLA Commentary Terminology Review
@@ -39,8 +39,10 @@ curated knowledge and must not feed generated knowledge references.
 - Source metadata artifact created: yes.
 - Timestamped observation artifact created: yes.
 - Candidate terminology claims artifact created: yes.
-- Actual content review occurred: yes, via temporary Japanese caption review in
-  repo-external scratch.
+- Caption-level content review occurred: yes, via temporary auto-generated
+  Japanese captions in repo-external scratch.
+- Direct audio review occurred: no.
+- Direct video review occurred: no.
 - Raw video stored in repo: no.
 - Raw audio stored in repo: no.
 - Raw frames or screenshots stored in repo: no.
@@ -88,8 +90,13 @@ are not accepted public-answer authority until reviewed and promoted.
 | Field | Result |
 |---|---|
 | Source URL | `https://www.youtube.com/watch?v=VCPzwAwRrLA` |
-| Access method | Public no-cookie YouTube metadata access plus temporary Japanese caption review. |
-| Actual content review occurred? | yes. |
+| Access method | Public no-cookie YouTube metadata access plus temporary auto-generated Japanese caption review. |
+| Caption provenance | auto-generated; `yt-dlp --list-subs` reported no uploaded/manual subtitles. |
+| Content execution depth | caption-level commentary review. |
+| Direct audio reviewed? | no. |
+| Direct video reviewed? | no. |
+| Caption-level content review occurred? | yes. |
+| Main limitation | Caption transcription, speaker nuance, and chapter segmentation may be imperfect. |
 | Raw video/audio committed? | no. |
 | Captions/transcript committed? | no. |
 | Frames/screenshots/contact sheets committed? | no. |

--- a/knowledge/review/unresolved/youtube-vcpzwawrrla-terminology.review.md
+++ b/knowledge/review/unresolved/youtube-vcpzwawrrla-terminology.review.md
@@ -1,0 +1,121 @@
+---
+id: sf6-review-youtube-vcpzwawrrla-terminology
+title: YouTube VCPzwAwRrLA Commentary Terminology Review
+claim_kind: unresolved
+source_kind: community
+source_role: commentary_only_terminology_review
+evidence_basis:
+  - "Source metadata recorded in knowledge/sources/videos/youtube-vcpzwawrrla.md."
+  - "Sanitized observations recorded in knowledge/evidence/video-observations/youtube-vcpzwawrrla-terminology.observations.md."
+  - "Candidate claims recorded in knowledge/evidence/claims/youtube-vcpzwawrrla-terminology.claims.md."
+  - "Temporary captions were reviewed in repo-external scratch and were not committed."
+verification_state: partially_verified
+confidence: 0.48
+volatility: stable
+patch_sensitivity: medium
+review_status: needs_review
+source_refs:
+  - label: "Source metadata: YouTube VCPzwAwRrLA"
+    path: "knowledge/sources/videos/youtube-vcpzwawrrla.md"
+    accessed_at: "2026-05-14"
+  - label: "Video observations: YouTube VCPzwAwRrLA terminology"
+    path: "knowledge/evidence/video-observations/youtube-vcpzwawrrla-terminology.observations.md"
+    accessed_at: "2026-05-14"
+  - label: "Candidate claims: YouTube VCPzwAwRrLA terminology"
+    path: "knowledge/evidence/claims/youtube-vcpzwawrrla-terminology.claims.md"
+    accessed_at: "2026-05-14"
+review_after: "2026-08-14"
+summary: "Review note for #168 source E2E on a commentary-only terminology video; source-derived terminology candidates are captured as review-only knowledge."
+---
+
+# YouTube VCPzwAwRrLA Commentary Terminology Review
+
+This review note tracks #168 one-source E2E execution for a commentary-only
+terminology source. It is canonical review tracking, but it is not accepted
+curated knowledge and must not feed generated knowledge references.
+
+## Review Status
+
+- Source metadata artifact created: yes.
+- Timestamped observation artifact created: yes.
+- Candidate terminology claims artifact created: yes.
+- Actual content review occurred: yes, via temporary Japanese caption review in
+  repo-external scratch.
+- Raw video stored in repo: no.
+- Raw audio stored in repo: no.
+- Raw frames or screenshots stored in repo: no.
+- Full captions or transcript stored in repo: no.
+- Scratch/cache policy followed: yes.
+- Curated promotion performed: no.
+- Generated references changed: no.
+- Exact current-system values accepted: no.
+- Current verification required before public use: yes for setup-, frame-, or
+  move-specific claims.
+
+## Source-Derived Knowledge Units
+
+The output of this source E2E is not a video summary. The source was analyzed
+for terminology and concept knowledge units, then routed into review-only repo
+surfaces. Review-only terminology candidates are still repo knowledge, but they
+are not accepted public-answer authority until reviewed and promoted.
+
+| knowledge_unit_id | extracted knowledge | knowledge type | repo surface | terminal state | authority boundary |
+|---|---|---|---|---|---|
+| `ku-vcpzwawrrla-meaty` | `重ね` as wake-up-overlap attack timing. | source-derived terminology candidate | claims + observation + review | review-only hold, `needs_review` | Exact setup timing and guaranteed followups are not accepted. |
+| `ku-vcpzwawrrla-crossup` | `めくり` as cross-side jump attack / guard-direction reversal concept. | source-derived terminology candidate | claims + observation + review | review-only hold, `needs_review` | Current move-specific cross-up capability is not accepted. |
+| `ku-vcpzwawrrla-sukashi` | `すかし` as withholding an expected jump attack and landing into another option. | source-derived terminology candidate | claims + review | review-only hold, `needs_review` | Option coverage and setup validity are context-dependent. |
+| `ku-vcpzwawrrla-line` | `ライン` as screen-position pressure and corner-push concept. | source-derived strategy concept candidate | claims + review | review-only hold, `needs_review` | No exact positioning rule is accepted. |
+| `ku-vcpzwawrrla-grapple` | `グラップ` as throw escape / throw-tech wording in commentary. | source-derived terminology candidate | claims + review | review-only hold, `needs_review` | Community wording, not official terminology authority. |
+| `ku-vcpzwawrrla-shimmy` | `シミー` as baiting throw-tech / grapple and punishing the whiff. | source-derived terminology candidate | claims + existing curated boundary | review-only corroboration; no new curated promotion | Existing shimmy page remains the accepted surface; this source does not alter it. |
+| `ku-vcpzwawrrla-abare` | `暴れ` as attacking from disadvantage or expected-block situations. | source-derived terminology / strategy candidate | claims + review | review-only hold, `needs_review` | Source-local frame examples are held. |
+| `ku-vcpzwawrrla-katame` | `固め` as pressure strings that make the defender hard to move. | source-derived terminology / strategy candidate | claims + review | review-only hold, `needs_review` | SF6-specific pressure strength claims remain held. |
+| `ku-vcpzwawrrla-cancel` | `キャンセル` as ending later recovery into another action. | source-derived terminology candidate | claims + review | review-only hold, `needs_review` | Move-specific cancelability is current-system information. |
+| `ku-vcpzwawrrla-lethal` | `リーサル` as an option or combo that can finish the opponent from the current life total. | source-derived terminology candidate | claims + review | review-only hold, `needs_review` | Exact kill thresholds depend on current route, resources, health, and character state. |
+
+## Terminal Decisions
+
+| Candidate | Decision | Reason |
+|---|---|---|
+| Source metadata | metadata-only source artifact created | Needed to identify the public video and content-review boundary. |
+| Commentary observations | sanitized report / observation artifact created | Content was reviewed through temporary captions without committing raw transcript or media. |
+| Terminology/concept candidates | review-only hold, `needs_review` | The source is community commentary and should not become accepted glossary or strategy authority without review. |
+| Existing shimmy curated page | unchanged | The source corroborates the broad concept, but #168 does not alter accepted curated knowledge. |
+| Current-fact-like examples | held | Exact advantage, guaranteed setup validity, move-specific cancelability, and route-specific lethal thresholds require separate verification. |
+| Rejected unsafe | none | No unsupported unsafe claim was found; no rejection was fabricated for coverage. |
+
+## Content Execution Record
+
+| Field | Result |
+|---|---|
+| Source URL | `https://www.youtube.com/watch?v=VCPzwAwRrLA` |
+| Access method | Public no-cookie YouTube metadata access plus temporary Japanese caption review. |
+| Actual content review occurred? | yes. |
+| Raw video/audio committed? | no. |
+| Captions/transcript committed? | no. |
+| Frames/screenshots/contact sheets committed? | no. |
+| Credentials/cookies/browser profile used? | no. |
+| Public adapter behavior changed? | no. |
+| Curated promotion? | no. |
+
+## Workflow Findings
+
+- `workflows/ingest-video.md`, `workflows/review-claims.md`, and
+  `workflows/media-scratch-cache-policy.md` were sufficient for this source
+  after treating commentary-only video as an article-like source for claim
+  review.
+- `tests/validation/validate-ingest-artifacts.ps1` had an article-only source
+  reference check for claim artifacts. #168 updates that check so review-only
+  claim artifacts may cite either article or video source metadata when the
+  source E2E run actually produces video-derived claims.
+- No broad speculative validator was added.
+
+## Next Review Questions
+
+- Should `重ね`, `めくり`, `すかし`, `グラップ`, `暴れ`, `固め`, `キャンセル`, and
+  `リーサル` get dedicated glossary pages after a second source or maintainer
+  review?
+- Should the existing `knowledge/curated/glossary/shimmy.md` cite this source
+  in a future glossary-focused PR, or should it remain based on the legacy
+  reviewed note?
+- Does the repo need a dedicated `terminology_candidate` claim kind, or are
+  `stable_concept` and `strategy_or_matchup` sufficient for this stage?

--- a/knowledge/review/unresolved/youtube-vcpzwawrrla-terminology.review.md
+++ b/knowledge/review/unresolved/youtube-vcpzwawrrla-terminology.review.md
@@ -39,6 +39,8 @@ curated knowledge and must not feed generated knowledge references.
 - Source metadata artifact created: yes.
 - Timestamped observation artifact created: yes.
 - Candidate terminology claims artifact created: yes.
+- Curated glossary entries created: yes, limited to `重ね` / meaty, `めくり` /
+  cross-up, `キャンセル` / cancel, and `リーサル` / lethal.
 - Caption-level content review occurred: yes, via temporary auto-generated
   Japanese captions in repo-external scratch.
 - Direct audio review occurred: no.
@@ -48,8 +50,8 @@ curated knowledge and must not feed generated knowledge references.
 - Raw frames or screenshots stored in repo: no.
 - Full captions or transcript stored in repo: no.
 - Scratch/cache policy followed: yes.
-- Curated promotion performed: no.
-- Generated references changed: no.
+- Curated promotion performed: yes, limited to stable glossary boundaries.
+- Generated references changed: yes, regenerated from curated glossary changes.
 - Exact current-system values accepted: no.
 - Current verification required before public use: yes for setup-, frame-, or
   move-specific claims.
@@ -57,22 +59,23 @@ curated knowledge and must not feed generated knowledge references.
 ## Source-Derived Knowledge Units
 
 The output of this source E2E is not a video summary. The source was analyzed
-for terminology and concept knowledge units, then routed into review-only repo
-surfaces. Review-only terminology candidates are still repo knowledge, but they
-are not accepted public-answer authority until reviewed and promoted.
+for terminology and concept knowledge units, then routed into curated or
+review-only repo surfaces. Review-only terminology candidates are still repo
+knowledge, but they are not accepted public-answer authority until reviewed and
+promoted.
 
 | knowledge_unit_id | extracted knowledge | knowledge type | repo surface | terminal state | authority boundary |
 |---|---|---|---|---|---|
-| `ku-vcpzwawrrla-meaty` | `重ね` as wake-up-overlap attack timing. | source-derived terminology candidate | claims + observation + review | review-only hold, `needs_review` | Exact setup timing and guaranteed followups are not accepted. |
-| `ku-vcpzwawrrla-crossup` | `めくり` as cross-side jump attack / guard-direction reversal concept. | source-derived terminology candidate | claims + observation + review | review-only hold, `needs_review` | Current move-specific cross-up capability is not accepted. |
+| `ku-vcpzwawrrla-meaty` | `重ね` as wake-up-overlap attack timing. | source-derived terminology candidate | `knowledge/curated/glossary/meaty.md` plus claims/review | accepted stable glossary boundary | Exact setup timing and guaranteed followups are not accepted. |
+| `ku-vcpzwawrrla-crossup` | `めくり` as cross-side jump attack / guard-direction reversal concept. | source-derived terminology candidate | `knowledge/curated/glossary/cross-up.md` plus claims/review | accepted stable glossary boundary | Current move-specific cross-up capability is not accepted. |
 | `ku-vcpzwawrrla-sukashi` | `すかし` as withholding an expected jump attack and landing into another option. | source-derived terminology candidate | claims + review | review-only hold, `needs_review` | Option coverage and setup validity are context-dependent. |
 | `ku-vcpzwawrrla-line` | `ライン` as screen-position pressure and corner-push concept. | source-derived strategy concept candidate | claims + review | review-only hold, `needs_review` | No exact positioning rule is accepted. |
 | `ku-vcpzwawrrla-grapple` | `グラップ` as throw escape / throw-tech wording in commentary. | source-derived terminology candidate | claims + review | review-only hold, `needs_review` | Community wording, not official terminology authority. |
 | `ku-vcpzwawrrla-shimmy` | `シミー` as baiting throw-tech / grapple and punishing the whiff. | source-derived terminology candidate | claims + existing curated boundary | review-only corroboration; no new curated promotion | Existing shimmy page remains the accepted surface; this source does not alter it. |
 | `ku-vcpzwawrrla-abare` | `暴れ` as attacking from disadvantage or expected-block situations. | source-derived terminology / strategy candidate | claims + review | review-only hold, `needs_review` | Source-local frame examples are held. |
 | `ku-vcpzwawrrla-katame` | `固め` as pressure strings that make the defender hard to move. | source-derived terminology / strategy candidate | claims + review | review-only hold, `needs_review` | SF6-specific pressure strength claims remain held. |
-| `ku-vcpzwawrrla-cancel` | `キャンセル` as ending later recovery into another action. | source-derived terminology candidate | claims + review | review-only hold, `needs_review` | Move-specific cancelability is current-system information. |
-| `ku-vcpzwawrrla-lethal` | `リーサル` as an option or combo that can finish the opponent from the current life total. | source-derived terminology candidate | claims + review | review-only hold, `needs_review` | Exact kill thresholds depend on current route, resources, health, and character state. |
+| `ku-vcpzwawrrla-cancel` | `キャンセル` as ending later recovery into another action. | source-derived terminology candidate | `knowledge/curated/glossary/cancel.md` plus claims/review | accepted stable glossary boundary | Move-specific cancelability is current-system information. |
+| `ku-vcpzwawrrla-lethal` | `リーサル` as an option or combo that can finish the opponent from the current life total. | source-derived terminology candidate | `knowledge/curated/glossary/lethal.md` plus claims/review | accepted stable glossary boundary | Exact kill thresholds depend on current route, resources, health, and character state. |
 
 ## Terminal Decisions
 
@@ -80,7 +83,8 @@ are not accepted public-answer authority until reviewed and promoted.
 |---|---|---|
 | Source metadata | metadata-only source artifact created | Needed to identify the public video and content-review boundary. |
 | Commentary observations | sanitized report / observation artifact created | Content was reviewed through temporary captions without committing raw transcript or media. |
-| Terminology/concept candidates | review-only hold, `needs_review` | The source is community commentary and should not become accepted glossary or strategy authority without review. |
+| Stable glossary boundaries | accepted curated glossary entries for `重ね`, `めくり`, `キャンセル`, and `リーサル` | These entries define only stable community terminology and preserve setup/current-fact boundaries. |
+| Remaining terminology/concept candidates | review-only hold, `needs_review` | `すかし`, `ライン`, `グラップ`, `暴れ`, and `固め` need normalization, second-source corroboration, or tighter scope before curated promotion. |
 | Existing shimmy curated page | unchanged | The source corroborates the broad concept, but #168 does not alter accepted curated knowledge. |
 | Current-fact-like examples | held | Exact advantage, guaranteed setup validity, move-specific cancelability, and route-specific lethal thresholds require separate verification. |
 | Rejected unsafe | none | No unsupported unsafe claim was found; no rejection was fabricated for coverage. |
@@ -101,8 +105,8 @@ are not accepted public-answer authority until reviewed and promoted.
 | Captions/transcript committed? | no. |
 | Frames/screenshots/contact sheets committed? | no. |
 | Credentials/cookies/browser profile used? | no. |
-| Public adapter behavior changed? | no. |
-| Curated promotion? | no. |
+| Public adapter behavior changed? | yes, generated references were updated from curated glossary additions. |
+| Curated promotion? | yes, limited to `重ね`, `めくり`, `キャンセル`, and `リーサル` stable glossary boundaries. |
 
 ## Workflow Findings
 
@@ -118,9 +122,8 @@ are not accepted public-answer authority until reviewed and promoted.
 
 ## Next Review Questions
 
-- Should `重ね`, `めくり`, `すかし`, `グラップ`, `暴れ`, `固め`, `キャンセル`, and
-  `リーサル` get dedicated glossary pages after a second source or maintainer
-  review?
+- Should `すかし`, `ライン`, `グラップ`, `暴れ`, and `固め` get dedicated
+  glossary pages after a second source or maintainer review?
 - Should the existing `knowledge/curated/glossary/shimmy.md` cite this source
   in a future glossary-focused PR, or should it remain based on the legacy
   reviewed note?

--- a/knowledge/sources/videos/youtube-vcpzwawrrla.md
+++ b/knowledge/sources/videos/youtube-vcpzwawrrla.md
@@ -31,8 +31,9 @@ terminology authority or current-system authority by itself.
 - Source E2E status: caption-level content reviewed on 2026-05-14 through
   no-cookie metadata access and temporary auto-generated Japanese captions in
   repo-external scratch.
-- Useful for: source-derived terminology/concept candidates, review-only
-  fighting-game glossary extraction, and commentary-claim boundary testing.
+- Useful for: source-derived terminology/concept candidates, limited curated
+  glossary promotion with clear boundaries, and commentary-claim boundary
+  testing.
 - Not useful for: accepting official game terminology, exact current-system
   facts, exact frame advantage, guaranteed setup validity, or public answer
   authority without separate review.
@@ -55,10 +56,12 @@ terminology authority or current-system authority by itself.
 
 ## Reviewer Notes
 
-- Treat the extracted terms as review-only community terminology candidates.
-- Caption-derived terminology claims remain review-only because automatic
-  caption transcription can misrecognize Japanese terms, omit speaker nuance, or
-  segment commentary imperfectly.
+- Treat the extracted terms as community terminology. #168 promotes only the
+  low-risk stable boundaries for `重ね`, `めくり`, `キャンセル`, and `リーサル`;
+  other source-derived units remain review-only.
+- Caption-derived claim payloads remain review-only because automatic caption
+  transcription can misrecognize Japanese terms, omit speaker nuance, or segment
+  commentary imperfectly.
 - A later glossary PR may promote stable terms only after review and without
   copying source-local wording.
 - Existing accepted `knowledge/curated/glossary/shimmy.md` was not changed by

--- a/knowledge/sources/videos/youtube-vcpzwawrrla.md
+++ b/knowledge/sources/videos/youtube-vcpzwawrrla.md
@@ -28,8 +28,9 @@ terminology authority or current-system authority by itself.
 - Canonical URL: see the front matter `url` field.
 - Declared format: commentary-only / article-like terminology explainer.
 - Source language: Japanese.
-- Source E2E status: content reviewed on 2026-05-14 through no-cookie metadata
-  access and a temporary Japanese caption review in repo-external scratch.
+- Source E2E status: caption-level content reviewed on 2026-05-14 through
+  no-cookie metadata access and temporary auto-generated Japanese captions in
+  repo-external scratch.
 - Useful for: source-derived terminology/concept candidates, review-only
   fighting-game glossary extraction, and commentary-claim boundary testing.
 - Not useful for: accepting official game terminology, exact current-system
@@ -40,8 +41,14 @@ terminology authority or current-system authority by itself.
 
 - `yt-dlp` was used without cookies, credentials, browser profiles, or
   authenticated state.
-- Temporary Japanese captions were used only as repo-external scratch input and
-  were deleted before commit.
+- Caption review provenance: `yt-dlp --list-subs` reported no uploaded/manual
+  subtitles and available automatic captions. The temporary Japanese caption
+  review used an automatic-caption track as repo-external scratch input.
+- Direct audio reviewed? no.
+- Direct video reviewed? no.
+- Content execution depth: `caption_level_content_review`; not
+  `direct_audio_review` or `direct_video_review`.
+- Temporary Japanese captions were deleted before commit.
 - Raw video, frames, screenshots, contact sheets, raw audio, downloaded media,
   and full captions/transcript are not stored in this repository.
 - Scratch/cache handling followed `workflows/media-scratch-cache-policy.md`.
@@ -49,6 +56,9 @@ terminology authority or current-system authority by itself.
 ## Reviewer Notes
 
 - Treat the extracted terms as review-only community terminology candidates.
+- Caption-derived terminology claims remain review-only because automatic
+  caption transcription can misrecognize Japanese terms, omit speaker nuance, or
+  segment commentary imperfectly.
 - A later glossary PR may promote stable terms only after review and without
   copying source-local wording.
 - Existing accepted `knowledge/curated/glossary/shimmy.md` was not changed by

--- a/knowledge/sources/videos/youtube-vcpzwawrrla.md
+++ b/knowledge/sources/videos/youtube-vcpzwawrrla.md
@@ -1,0 +1,58 @@
+---
+id: source-video-youtube-vcpzwawrrla
+title: "Beginner fighting-game terminology commentary source"
+source_kind: community
+source_role: commentary_only_terminology_source
+url: "https://www.youtube.com/watch?v=VCPzwAwRrLA"
+accessed_at: "2026-05-14"
+captured_at: "2026-05-14"
+copyright_policy: "no raw video, audio, frames, screenshots, contact sheets, captions, subtitles, or full transcript stored"
+review_status: needs_review
+review_after: "2026-08-14"
+---
+
+# Source Summary
+
+Japanese SF6 commentary-only source from SmashlogTV about beginner-oriented
+fighting-game terminology commonly heard in match commentary. The source covers
+ten terms or concept families: `重ね`, `めくり`, `すかし`, `ライン`, `グラップ`,
+`シミー`, `暴れ`, `固め`, `キャンセル`, and `リーサル`.
+
+This source is not final public answer evidence. It is useful as a
+source-derived terminology and concept extraction input, but it is not accepted
+terminology authority or current-system authority by itself.
+
+## Extracted Scope
+
+- Sample ID: `video-link-commentary-only-01`.
+- Canonical URL: see the front matter `url` field.
+- Declared format: commentary-only / article-like terminology explainer.
+- Source language: Japanese.
+- Source E2E status: content reviewed on 2026-05-14 through no-cookie metadata
+  access and a temporary Japanese caption review in repo-external scratch.
+- Useful for: source-derived terminology/concept candidates, review-only
+  fighting-game glossary extraction, and commentary-claim boundary testing.
+- Not useful for: accepting official game terminology, exact current-system
+  facts, exact frame advantage, guaranteed setup validity, or public answer
+  authority without separate review.
+
+## Media Handling
+
+- `yt-dlp` was used without cookies, credentials, browser profiles, or
+  authenticated state.
+- Temporary Japanese captions were used only as repo-external scratch input and
+  were deleted before commit.
+- Raw video, frames, screenshots, contact sheets, raw audio, downloaded media,
+  and full captions/transcript are not stored in this repository.
+- Scratch/cache handling followed `workflows/media-scratch-cache-policy.md`.
+
+## Reviewer Notes
+
+- Treat the extracted terms as review-only community terminology candidates.
+- A later glossary PR may promote stable terms only after review and without
+  copying source-local wording.
+- Existing accepted `knowledge/curated/glossary/shimmy.md` was not changed by
+  this source-unit PR; this source only provides additional review input.
+- Any source-local statements about current SF6 behavior, exact advantage,
+  guaranteed pressure, or setup validity must remain held unless verified
+  through a separate current-fact or reproducible observation path.

--- a/skills/sf6-agent/references/generated-concepts.md
+++ b/skills/sf6-agent/references/generated-concepts.md
@@ -4,6 +4,10 @@ generator: packages/knowledge-generation/build-sf6-agent-knowledge.ps1
 source_paths:
   - knowledge/curated/concepts/frame-timing.md
   - knowledge/curated/concepts/offense-decision-making.md
+  - knowledge/curated/glossary/cancel.md
+  - knowledge/curated/glossary/cross-up.md
+  - knowledge/curated/glossary/lethal.md
+  - knowledge/curated/glossary/meaty.md
   - knowledge/curated/glossary/shimmy.md
   - knowledge/curated/mechanics/combo-scaling.md
 target_path: skills/sf6-agent/references/generated-concepts.md
@@ -87,6 +91,97 @@ Confirm difficulty depends on the situation, visual cue, buffer window, cancel r
 Wake-up pressure means applying offense as the opponent rises from knockdown. Common pressure choices include strikes, throws, delayed actions, movement baits, and waiting to react.
 
 The concept is stable, but the actual setup depends on knockdown type, spacing, recovery timing, available reversals, defensive system choices, and current move behavior. Treat exact meaty setups and guaranteed followups as separate claims that need current verification.
+
+## Cancel
+
+- source: knowledge/curated/glossary/cancel.md
+- claim_kind: stable_concept
+- source_kind: community
+- source_role: community terminology boundary
+- verification_state: partially_verified
+- confidence: 0.62
+- volatility: stable
+- patch_sensitivity: low
+- review_status: accepted
+- review_after: 2026-10-14
+- summary: Cancel, or キャンセル, is community terminology for ending the later recovery of one action into another action, such as a normal into a special, without asserting current move-specific cancel routes.
+
+Cancel, often called `キャンセル` in Japanese SF6 discussion, is community
+terminology for ending the later recovery of one action into another action.
+For example, players often discuss a normal attack being canceled into a special
+move as a general concept.
+
+Use this page for the stable term only. Whether a specific move can cancel, when
+it can cancel, and what routes are valid are current move or route facts that
+need separate evidence.
+
+## Cross-Up
+
+- source: knowledge/curated/glossary/cross-up.md
+- claim_kind: stable_concept
+- source_kind: community
+- source_role: community terminology boundary
+- verification_state: partially_verified
+- confidence: 0.64
+- volatility: stable
+- patch_sensitivity: low
+- review_status: accepted
+- review_after: 2026-10-14
+- summary: Cross-up, or めくり, is community terminology for an attack that crosses or threatens from the opposite side and changes or obscures the defender's guard direction.
+
+Cross-up, often called `めくり` in Japanese SF6 discussion, is community
+terminology for an attack that crosses or threatens from the opposite side and
+therefore changes or obscures the defender's guard direction.
+
+Use this as a terminology boundary. Do not treat it as evidence that a specific
+current jump attack, setup, spacing, or character route crosses up without
+separate verification.
+
+## Lethal
+
+- source: knowledge/curated/glossary/lethal.md
+- claim_kind: stable_concept
+- source_kind: community
+- source_role: community terminology boundary
+- verification_state: partially_verified
+- confidence: 0.62
+- volatility: stable
+- patch_sensitivity: low
+- review_status: accepted
+- review_after: 2026-10-14
+- summary: Lethal, or リーサル, is community terminology for an option or combo that can finish the opponent from the current life total.
+
+Lethal, often called `リーサル` in Japanese SF6 discussion, is community
+terminology for an option, sequence, or combo that can finish the opponent from
+the current life total.
+
+Use this as a stable term only. Whether something is actually lethal depends on
+current health, character, resources, scaling, route damage, positioning, and
+patch-specific behavior.
+
+## Meaty
+
+- source: knowledge/curated/glossary/meaty.md
+- claim_kind: stable_concept
+- source_kind: community
+- source_role: community terminology boundary
+- verification_state: partially_verified
+- confidence: 0.62
+- volatility: stable
+- patch_sensitivity: low
+- review_status: accepted
+- review_after: 2026-10-14
+- summary: Meaty, or 重ね, is community terminology for timing an attack to overlap a defender's wake-up or recovery timing without asserting a specific guaranteed setup.
+
+Meaty, often called `重ね` in Japanese SF6 discussion, is community terminology
+for timing an attack so it overlaps the defender's wake-up or recovery timing.
+The basic idea is that the attacker places an active threat where the defender
+is about to become able to act.
+
+Use this as a stable terminology explanation only. Whether a particular meaty
+setup works depends on knockdown type, spacing, recovery timing, active
+duration, invincible options, defensive system choices, and current move
+behavior.
 
 ## Shimmy
 

--- a/skills/sf6-agent/references/generated-knowledge-index.md
+++ b/skills/sf6-agent/references/generated-knowledge-index.md
@@ -4,6 +4,10 @@ generator: packages/knowledge-generation/build-sf6-agent-knowledge.ps1
 source_paths:
   - knowledge/curated/concepts/frame-timing.md
   - knowledge/curated/concepts/offense-decision-making.md
+  - knowledge/curated/glossary/cancel.md
+  - knowledge/curated/glossary/cross-up.md
+  - knowledge/curated/glossary/lethal.md
+  - knowledge/curated/glossary/meaty.md
   - knowledge/curated/glossary/shimmy.md
   - knowledge/curated/mechanics/combo-scaling.md
 target_path: skills/sf6-agent/references/generated-knowledge-index.md
@@ -24,6 +28,10 @@ It must not contain exact current frame values; exact current move values belong
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Frame Timing And Advantage | Concepts | stable_concept | knowledge/curated/concepts/frame-timing.md | verified | 0.9 | stable | low | accepted |
 | Offensive Decision Concepts | Concepts | stable_concept | knowledge/curated/concepts/offense-decision-making.md | verified | 0.86 | stable | low | accepted |
+| Cancel | Glossary | stable_concept | knowledge/curated/glossary/cancel.md | partially_verified | 0.62 | stable | low | accepted |
+| Cross-Up | Glossary | stable_concept | knowledge/curated/glossary/cross-up.md | partially_verified | 0.64 | stable | low | accepted |
+| Lethal | Glossary | stable_concept | knowledge/curated/glossary/lethal.md | partially_verified | 0.62 | stable | low | accepted |
+| Meaty | Glossary | stable_concept | knowledge/curated/glossary/meaty.md | partially_verified | 0.62 | stable | low | accepted |
 | Shimmy | Glossary | stable_concept | knowledge/curated/glossary/shimmy.md | partially_verified | 0.74 | stable | low | accepted |
 | Combo Scaling | Mechanics | stable_concept | knowledge/curated/mechanics/combo-scaling.md | partially_verified | 0.7 | stable | medium | accepted |
 

--- a/tests/validation/validate-ingest-artifacts.ps1
+++ b/tests/validation/validate-ingest-artifacts.ps1
@@ -230,7 +230,7 @@ else {
       }
     }
 
-    if ($content -notmatch '(?m)^\s+path:\s*"knowledge/sources/articles/') {
+    if ($content -notmatch '(?m)^\s+path:\s*"knowledge/sources/(articles|videos)/') {
       $violations += "$relativePath source_refs must include a reviewable source artifact path"
     }
 

--- a/workflows/review-claims.md
+++ b/workflows/review-claims.md
@@ -45,6 +45,20 @@ Do not encode decisions with legacy source tiers, bracket labels, or old taxonom
 9. Update or create the smallest appropriate curated page only for accepted knowledge.
 10. Preserve unresolved, rejected, or conflicting candidates in `knowledge/review/` with the decision reason.
 
+## Source-Unit Promotion Decision Gate
+
+For source-unit PRs, do not stop at source-derived claim candidates by default.
+
+After extracting knowledge units from a real source, check whether an existing curated surface can safely hold any stable units. For each unit, record one terminal route:
+
+- Promoted to curated knowledge.
+- Routed to current-fact authority or a current-fact candidate surface.
+- Left as review-only hold.
+- Rejected as unsafe or unsupported.
+- Left unresolved / needs_review.
+
+If no unit is promoted, record why each extracted unit remains held or unresolved. Validators and policy changes should be added only when the concrete source execution exposes a failure; do not add speculative constraints before analysis.
+
 ## Acceptance Criteria
 
 A claim may be accepted when all of these are true:


### PR DESCRIPTION
## Summary
- Executed one-source E2E ingest for commentary-only video `VCPzwAwRrLA`.
- Reviewed/analyzed the source content where safe using no-cookie metadata access plus temporary auto-generated Japanese captions in repo-external scratch only.
- Extracted source-derived terminology/concept knowledge units into source, observation, claim, review, and curated glossary artifacts.
- Promoted low-risk stable glossary boundaries for `重ね` / meaty, `めくり` / cross-up, `キャンセル` / cancel, and `リーサル` / lethal.
- Added a narrow source-unit promotion decision gate so future source-unit reviews must decide curated promotion, current-fact routing, review-only hold, rejection, or unresolved status instead of stopping at claim candidates by default.
- Updated only the narrow validator check needed for video-derived claim artifacts to cite `knowledge/sources/videos/*` source metadata.

## Scope
- Implements #168 only.
- References #155 and #158.
- Does not implement #153 or #156.
- Does not implement any other video source issue.
- No raw media, audio, captions, transcripts, screenshots, frames, contact sheets, raw Hermes output, local state, credentials, cookies, or secrets were committed.
- Public generated `sf6-agent` references changed only as derived output from the new accepted curated glossary entries.
- `official_raw` was not bypassed.

## Content execution
- Actual content review occurred at caption level.
- Caption provenance: auto-generated; `yt-dlp --list-subs` reported no uploaded/manual subtitles and available automatic captions.
- Direct audio reviewed: no.
- Direct video reviewed: no.
- Method: `yt-dlp` no-cookie metadata access plus temporary auto-generated Japanese caption review in repo-external scratch.
- Temporary captions/transcript-like material were used only as scratch input and deleted before commit.
- Raw video/audio was not downloaded for this PR because caption-level review was sufficient to extract terminology candidates.
- Nothing transcript-like, media-like, frame-like, or cache-like was committed.
- Caption-derived claim payloads remain review-only because automatic captions can misrecognize Japanese terms, omit speaker nuance, or segment commentary imperfectly.

## Terminal states reached
- accepted curated glossary entries: yes, for `knowledge/curated/glossary/meaty.md`, `cross-up.md`, `cancel.md`, and `lethal.md`.
- source-derived terminology/concept candidate: yes, in `knowledge/evidence/claims/youtube-vcpzwawrrla-terminology.claims.md`.
- review-only hold: yes, remaining terms stay in `knowledge/review/unresolved/youtube-vcpzwawrrla-terminology.review.md`.
- unresolved / needs_review: yes, `すかし`, `ライン`, `グラップ`, `暴れ`, `固め`, and exact setup/current-fact-like details remain held.
- rejected unsafe: no unsupported unsafe claim found; no rejection fabricated.
- metadata-only source artifact only: no; caption-level content review was performed.

## Glossary routing
Promoted stable glossary boundaries:
- `重ね` / meaty: stable terminology only; no exact wake-up setup timing or guaranteed route.
- `めくり` / cross-up: stable terminology only; no current move-specific cross-up list.
- `キャンセル` / cancel: stable terminology only; no move-specific cancelability or exact windows.
- `リーサル` / lethal: stable terminology only; no route-specific kill thresholds.

Held as review-only:
- `すかし`, `ライン`, `グラップ`, `暴れ`, and `固め` remain held for normalization, second-source corroboration, or tighter setup/current-fact boundaries.
- Existing `knowledge/curated/glossary/shimmy.md` was not changed.

## Workflow/schema/policy changes
- Concrete source-unit flow gap: #168 initially created terminology candidates but lacked an explicit promotion decision gate before stopping at review-only claims.
- Change: `workflows/review-claims.md` now includes `Source-Unit Promotion Decision Gate`, requiring each extracted source-derived knowledge unit to be routed to curated promotion, current-fact route, review-only hold, rejection, or unresolved / needs_review.
- Why necessary: source-unit E2E should not stop at claim candidates by default when an existing curated surface can safely hold stable units.
- Concrete validator gap: `tests/validation/validate-ingest-artifacts.ps1` required claim artifacts to cite `knowledge/sources/articles/*` only.
- Change: the same source-ref check now accepts `knowledge/sources/articles/*` or `knowledge/sources/videos/*`.
- Why necessary: #168 creates a review-only claim artifact from an actual video source, and that claim artifact must cite video source metadata.
- Validation impact: `validate-ingest-artifacts.ps1`, `validate-video-artifacts.ps1`, `validate-generated-knowledge.ps1`, and the full validation suite pass.

## Artifacts
- `knowledge/sources/videos/youtube-vcpzwawrrla.md`: source metadata, caption provenance, and media handling boundary.
- `knowledge/evidence/video-observations/youtube-vcpzwawrrla-terminology.observations.md`: sanitized timestamped terminology observations with caption-review limits.
- `knowledge/evidence/claims/youtube-vcpzwawrrla-terminology.claims.md`: review-only terminology/concept claim candidates and curated terminal routing.
- `knowledge/review/unresolved/youtube-vcpzwawrrla-terminology.review.md`: terminal routing, content execution record, caption provenance, glossary promotion decision, and review questions.
- `knowledge/curated/glossary/meaty.md`: accepted stable glossary boundary for `重ね` / meaty.
- `knowledge/curated/glossary/cross-up.md`: accepted stable glossary boundary for `めくり` / cross-up.
- `knowledge/curated/glossary/cancel.md`: accepted stable glossary boundary for `キャンセル` / cancel.
- `knowledge/curated/glossary/lethal.md`: accepted stable glossary boundary for `リーサル` / lethal.
- `skills/sf6-agent/references/generated-knowledge-index.md`: regenerated derived index.
- `skills/sf6-agent/references/generated-concepts.md`: regenerated derived concepts.
- `tests/validation/validate-ingest-artifacts.ps1`: narrow video-source-ref support for claim artifacts.
- `workflows/review-claims.md`: narrow source-unit promotion decision gate.

## Validation
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-no-video-binary-assets.ps1`: `No video binary assets OK`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-video-artifacts.ps1`: `Video artifacts OK`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-ingest-artifacts.ps1`: `Ingest artifacts OK`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-generated-knowledge.ps1`: `Generated knowledge OK`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1`: `V2 validation suite OK`
- `git diff --check`: PASS, no output.
- `git diff --check origin/main...HEAD`: PASS, no output.
- raw/local-state scan: only existing approved Hermes docs/packs/workflows/test paths appeared; no raw media, captions, transcripts, frames, contact sheets, caches, local state, or external binary assets from this PR.
- generated-surface residual diff check after PowerShell git-unavailable warnings: clean outside the intended generated references; no unintended residual diffs or untracked files in `.dist`, frame-current assets, normalization assets, `data/raw`, `data/normalized`, or `data/exports`.

Closes #168
References #155
References #158