### PR TITLE
[v2.5] Build visual atlas acquisition path

### DIFF
--- a/docs/testing/video-analysis-calibration/external-visual-atlas-acquisition-20260515.md
+++ b/docs/testing/video-analysis-calibration/external-visual-atlas-acquisition-20260515.md
@@ -1,0 +1,286 @@
+# External Visual Atlas Acquisition: Move-Analysis Calibration
+
+## Report Metadata
+
+| Field | Value |
+|---|---|
+| Issue | #178 |
+| Parent issues | #155 / #158 |
+| Related raw-video calibration | #170 / PR #173 |
+| Related command-prompt normalization | #175 / PR #184 |
+| Related frame/input alignment | #176 / PR #185 |
+| Related damage/scaling attribution | #177 / PR #189 |
+| Related downstream matching | #179 |
+| Date | 2026-05-15 |
+| Scope | JP-small-scope |
+| Terminal state | visual-atlas-acquisition PATH_DEFINED; first JP external binary acquisition held for source permission/terms review |
+
+This report defines the gated maintainer-local acquisition path for external
+visual move references. It does not perform JP move visual-reference matching,
+does not create a move-recognition runtime, does not fetch a full atlas, and
+does not add binary assets to the repository.
+
+## Loaded Repo Context
+
+This report follows the #180 pre-analysis repo context loading requirement.
+
+| Artifact | Artifact type | Why loaded | Can guide | Cannot authorize |
+|---|---|---|---|---|
+| `docs/testing/video-analysis-calibration/raw-video-training-mode-01-command-prompt-normalization-20260514.md` | calibration report | Provides JP prompt rows and candidate move/system-action ids from #175. | JP visual-reference scope selection. | Accepted move order, exact execution, or current facts. |
+| `docs/testing/video-analysis-calibration/raw-video-training-mode-01-frame-input-alignment-20260515.md` | calibration report | Provides ambiguous action windows from #176. | Which segments need visual reference support. | Exact frame data or route validity. |
+| `docs/testing/video-analysis-calibration/raw-video-training-mode-01-damage-scaling-attribution-20260515.md` | calibration report | Provides #177 partial/unknown attribution and remaining action-identity gaps. | Which visual references would help #179. | Damage/scaling authority or hit-by-hit current facts. |
+| `knowledge/review/unresolved/raw-video-training-mode-01.review.md` | review note | Provides current resolved/open follow-up routing. | #178/#179/#183 dependency boundary. | Accepted gameplay knowledge. |
+| `ingest/frame_data/config/registry/jp.moves.yaml` | move registry | Provides JP move ids and input-token families. | Candidate move ids for the tiny acquisition scope. | Proof that a visual reference is current or that a video action is the move. |
+| `docs/architecture/external-frame-atlas-policy.md` | policy | Defines external visual atlas source roles, cache/storage boundaries, and authority limits. | Acquisition safety gates and metadata-only representation. | Permission to fetch, cache, redistribute, or treat visuals as authority. |
+| `workflows/media-scratch-cache-policy.md` | workflow/policy | Defines repo-external scratch and forbidden media/cache paths. | Scratch/cache location and cleanup discipline. | Permission to commit binaries or local cache. |
+| `workflows/ingest-video.md` | workflow | Provides video-calibration sequencing and #180 context-loading gate. | Where to add a narrow acquisition step for future video calibration. | Current facts or public runtime behavior. |
+| `data/external-frame-atlas/evaluation/README.md` | source evaluation docs | Explains existing metadata-only evaluation matrix. | Why existing atlas records do not authorize acquisition. | Direct asset retrieval or binary storage. |
+| `data/external-frame-atlas/evaluation/source-evaluation-matrix.json` | metadata-only source evaluation | Provides source status for SF6Frames and Ultimate Frame Data. | Source selection and HOLD conditions. | Fetch permission, stable asset URLs, current facts, or redistribution rights. |
+| `contracts/external-frame-atlas-source.schema.json` | manifest schema | Defines metadata-only external atlas source manifest shape. | Future manifest field selection when acquisition is approved. | Binary storage approval. |
+| `tests/fixtures/external-frame-atlas/sf6frames-hitbox-overlay-candidate.json` | metadata-only fixture | Existing SF6Frames candidate fixture. | Example of metadata-only visual reference shape. | Direct SF6Frames asset availability or current authority. |
+| `tests/fixtures/external-frame-atlas/ultimate-frame-data-hitbox-image-candidate.json` | metadata-only fixture | Existing UFD candidate fixture. | Example of metadata-only UFD shape. | Permission or move mapping for #178. |
+| `ingest/frame_data/README.md` | ingestion docs | Describes existing fetch discipline and raw snapshot boundary. | How to align acquisition style with frame-data ingest. | Permission to write external atlas raw snapshots into repo. |
+| `ingest/frame_data/pyproject.toml` | package config | Shows optional `fetch` extra with `scrapling[fetchers]`. | Dependency boundary and optional install expectations. | CI live external fetch or new dependency requirement. |
+| `ingest/frame_data/src/sf6_ingest/fetch/scrapling_client.py` | fetch helper | Shows existing Scrapling wrapper, fetch profile, metadata, and challenge detection shape. | Future acquisition helper style. | Direct reuse of `data/raw` snapshot behavior for external binary assets. |
+| `ingest/frame_data/config/fetch_profiles.yaml` | fetch config | Shows existing Fetcher/StealthyFetcher profiles, timeouts, retry, and challenge markers. | Future no-auth/no-cookie fetch profile design. | Bypassing source access boundaries or CI live fetch. |
+
+External visual references remain visual review support only. They cannot
+authorize current facts, override `official_raw`, or become public
+`sf6-agent` behavior. Hermes/session memory is non-canonical.
+
+## Existing Scrapling Setup Review
+
+The existing `ingest/frame_data` package already has a Scrapling-based fetch
+style:
+
+- `ingest/frame_data/pyproject.toml` declares optional `fetch` dependencies:
+  `scrapling[fetchers]>=0.4.2`.
+- `ingest/frame_data/src/sf6_ingest/fetch/scrapling_client.py` wraps
+  Scrapling `Fetcher` and `StealthyFetcher` behind a `FetchProfile`, records
+  final URL, status, encoding, title, challenge detection, raw byte count, and
+  SHA-256.
+- `ingest/frame_data/config/fetch_profiles.yaml` keeps fetcher, timeout, retry,
+  wait, and challenge-marker behavior in config rather than ad hoc scripts.
+- Existing frame-data fetch writes raw response bytes and metadata into
+  `data/raw`, then parses deterministically from those raw bytes.
+
+For external visual atlas acquisition, this style can be reused only with an
+important storage change:
+
+- keep the fetch profile / challenge detection / metadata-first discipline;
+- do not write external visual atlas raw bytes or raw HTML into `data/raw`;
+- write external binary assets only to maintainer-local repo-external scratch or
+  cache when an explicit source permission/terms gate allows it;
+- commit metadata/report only.
+
+No new dependency is added in this PR. The current shell does not have the
+optional fetch runtime installed (`scrapling` and `pydantic` imports were not
+available), so this PR does not run a live Scrapling fetch. CI is unaffected and
+must not perform live external visual-asset fetches.
+
+## Source Selection
+
+| Candidate source | Selected? | Reason |
+|---|---|---|
+| SF6Frames | yes, as first path candidate only | Existing evaluation records hitbox-overlay availability, frame-number visibility, JP candidate fixture, and alignment with future Scrapling acquisition. It is still held for permission/terms before binary acquisition. |
+| Ultimate Frame Data | no, deferred | Existing evaluation is less complete for permissions/robots and move mapping. It remains a later candidate if SF6Frames is unavailable or insufficient. |
+| Maintainer-local captured references | no, deferred | No maintainer-local captured visual reference was provided for this issue. |
+| SuperCombo text/reference context | no | Existing matrix treats it as non-visual reference context, not a visual atlas source by default. |
+
+Selected source: SF6Frames, metadata-only path candidate.
+
+Access boundary:
+
+- no authentication;
+- no cookies;
+- no browser cache;
+- no rate-limit bypass;
+- no raw HTML dump;
+- no direct binary URL storage;
+- no legal conclusion beyond maintainer-local source-review basis.
+
+Existing source evaluation status for SF6Frames is `hold_terms_or_permission`.
+Therefore this PR holds binary acquisition before fetching or caching a visual
+asset.
+
+## JP Visual Reference Acquisition Attempt
+
+Tiny scope selected from #175/#176/#177:
+
+- Stribog family: `jp_034_236mp_stribog`, `jp_035_236hp_stribog`;
+- OD Triglav family: `jp_030_22pp_triglav_od_weak`,
+  `jp_031_22pp_triglav_od_medium`, `jp_032_22pp_triglav_od_heavy`;
+- SA3/CA family: `jp_055_sa3_236236k`, `jp_056_ca_236236k`.
+
+| attempt_id | source | character | move/action candidate | candidate move id(s) | source page or source descriptor | acquisition method | asset kind expected | acquired locally? | file type observed | committed binary? | cleanup status | result | reason |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| `jp-atlas-sf6frames-001` | SF6Frames | JP | Stribog visual reference candidate | `jp_034_236mp_stribog`; `jp_035_236hp_stribog` | `source_id=sf6frames` in `data/external-frame-atlas/evaluation/source-evaluation-matrix.json` | pre-fetch gate using existing source evaluation and Scrapling setup review | hitbox-overlay animation or frame-numbered visual reference if permission later allows | no | not observed | no | no scratch created | hold | SF6Frames is held for permission/terms review; direct asset URL stability was not tested; no live fetch runtime was installed; no binary acquisition was safe in this PR. |
+| `jp-atlas-sf6frames-002` | SF6Frames | JP | OD Triglav visual reference candidate | `jp_030_22pp_triglav_od_weak`; `jp_031_22pp_triglav_od_medium`; `jp_032_22pp_triglav_od_heavy` | `source_id=sf6frames` in source evaluation matrix | pre-fetch gate using existing source evaluation and Scrapling setup review | hitbox-overlay animation or frame-numbered visual reference if permission later allows | no | not observed | no | no scratch created | hold | Same hold: source evaluation recommends `hold_terms_or_permission` and #178 must not bypass that to acquire binaries. |
+| `jp-atlas-sf6frames-003` | SF6Frames | JP | SA3/CA visual reference candidate | `jp_055_sa3_236236k`; `jp_056_ca_236236k` | `source_id=sf6frames` in source evaluation matrix | pre-fetch gate using existing source evaluation and Scrapling setup review | hitbox-overlay animation or frame-numbered visual reference if source coverage exists | no | not observed | no | no scratch created | hold | Same hold plus possible source coverage uncertainty for cinematic/super references. |
+
+No GIF, image, WebP, frame, screenshot, contact sheet, raw HTML, raw JSON dump,
+or direct binary URL was committed.
+
+## Metadata-Only Visual Atlas Record
+
+No new metadata-only manifest was created beyond this report because no binary
+or source page acquisition succeeded. Existing metadata-only fixtures already
+cover the general source shape:
+
+- `tests/fixtures/external-frame-atlas/sf6frames-hitbox-overlay-candidate.json`
+- `tests/fixtures/external-frame-atlas/ultimate-frame-data-hitbox-image-candidate.json`
+
+If a later issue resolves the source permission/terms gate and performs a tiny
+repo-external acquisition, #179 can consume metadata fields like:
+
+| Field | Planned value / rule |
+|---|---|
+| `character_slug` | `jp` |
+| `candidate_move_id` | one of the selected Stribog, OD Triglav, or SA3/CA candidates |
+| `move_family` | Stribog / OD Triglav / SA3-CA |
+| `source_name` | SF6Frames, unless a later source is selected |
+| `source_page_descriptor` | source page or character/move descriptor only; no private temp path or direct binary URL unless policy permits |
+| `asset_kind` | hitbox overlay / frame-numbered visual reference / unknown |
+| `file_type_observed` | `gif`, `webp`, `png_sequence`, `hitbox_image`, or `unknown` after permitted acquisition |
+| `acquired_for_review` | true only after permitted repo-external acquisition |
+| `local_binary_committed` | false |
+| `raw_html_committed` | false |
+| `authority_boundary` | visual reference only; not current-fact authority |
+| `cleanup_status` | deleted or repo-external cache retained with reason |
+| `next_use` | #179 review-only visual matching |
+
+Current hold reason: existing SF6Frames/UFD evaluations do not grant permission
+for binary acquisition or redistribution, and #178 does not add a live fetch
+runtime or source-specific selector.
+
+## How This Supports #179
+
+#179 can use this report to decide whether it has an allowed visual-reference
+input.
+
+What #179 can do:
+
+- load the same JP command-prompt rows and frame/action windows;
+- use the selected JP move families as the first visual matching scope;
+- use this acquisition path to determine whether a permitted repo-external
+  visual reference exists;
+- mark #179 HOLD if no permitted visual reference has been acquired.
+
+What #179 cannot do from this PR:
+
+- compare raw-video segments against SF6Frames binaries, because none were
+  acquired;
+- infer official move identity from visual similarity alone;
+- treat SF6Frames/UFD visuals as current-fact authority;
+- commit GIFs, images, frames, screenshots, contact sheets, raw HTML, raw tool
+  output, or private paths.
+
+If source permission/terms are resolved later, the first useful #179 visual
+checks are likely:
+
+- Stribog family vs rows 8/11;
+- OD Triglav family vs row 10 and mid-route ambiguous labels;
+- SA3/CA family vs row 12 cinematic window.
+
+## Reusable Visual Atlas Acquisition Method
+
+Future Codex/Hermes runs should repeat this method without chat history:
+
+1. Load repo context:
+   - same-sample calibration reports;
+   - source review note;
+   - JP move registry;
+   - external-frame-atlas policy;
+   - source evaluation matrix;
+   - existing metadata-only fixtures;
+   - `ingest/frame_data` Scrapling setup.
+2. Select a tiny character/move scope from unresolved video-analysis gaps.
+3. Inspect the source evaluation status before any network or binary work.
+4. If the source is held for permission/terms/robots/rate-limit review, stop
+   before binary acquisition and record a HOLD.
+5. If acquisition is permitted by a later explicit issue, use the existing
+   `ingest/frame_data` fetch discipline:
+   - config-driven profile;
+   - no-auth/no-cookie boundary;
+   - challenge detection;
+   - metadata-first recording;
+   - repo-external scratch/cache only.
+6. Record metadata only in repo:
+   - source;
+   - character;
+   - move candidate;
+   - expected asset kind;
+   - file type observed if permitted;
+   - cleanup/cache status;
+   - authority boundary.
+7. Delete binaries after review unless a later explicit repo-external cache
+   retention rule applies.
+8. Route visual comparison to #179.
+9. Preserve the boundary that visual references are review support only.
+
+### Next-Agent One-Shot Checklist
+
+- Load prior video-calibration reports and `raw-video-training-mode-01.review.md`.
+- Load `docs/architecture/external-frame-atlas-policy.md`.
+- Load `data/external-frame-atlas/evaluation/source-evaluation-matrix.json`.
+- Load existing metadata-only fixture examples.
+- Load `ingest/frame_data` Scrapling setup and fetch profiles.
+- Pick one character and one to three move families.
+- Check source evaluation status before any fetch.
+- Use repo-external scratch/cache only if acquisition is permitted.
+- Commit only metadata/report.
+- Mark success/partial/hold with a concrete reason.
+- Route matching to #179.
+- Never treat external visuals as current-fact authority.
+
+## Improvement Applied In This PR
+
+This PR adds:
+
+- this #178 operational report; and
+- a narrow `External Visual Atlas Acquisition For Calibration` subsection in
+  `workflows/ingest-video.md`.
+
+The existing architecture policy already covers broad source/storage rules.
+The new workflow subsection records the source-unit operational sequence so
+future video-calibration agents know where this step fits: after command/action
+gaps are identified, before #179 visual matching, and without live CI fetch or
+binary commits.
+
+No validator was added. Existing external-frame-atlas validators already cover
+metadata-only fixtures and source evaluation, and this PR does not add a new
+schema or manifest.
+
+## Follow-Up Routing
+
+| Follow-up | Status after #178 | Reason |
+|---|---|---|
+| #179 JP move/action visual-reference matching | open; binary matching not yet ready | #178 defines the path and selected JP scope, but actual SF6Frames binary acquisition is held until permission/terms review is resolved or an approved local reference is provided. |
+| #183 SF6 system-mechanics math reasoning fixtures | still relevant | Visual references do not solve damage/scaling reasoning or authority-boundary fixtures. |
+
+No new follow-up issue is needed.
+
+## Terminal State
+
+- visual-atlas-acquisition: PATH_DEFINED
+- small JP scope selected: yes
+- acquisition attempt result: held before binary fetch
+- hold reason: SF6Frames/UFD source evaluations do not grant permission/terms
+  clearance for binary acquisition or redistribution
+- metadata/report only: yes
+- binary committed: no
+- raw HTML committed: no
+- current-fact authority: no
+- #179 ready? partially: ready to use the path and scope, not ready for actual
+  binary visual matching until a permitted external reference is acquired
+
+## Cleanup And Validation
+
+| Check | Result |
+|---|---|
+| External binaries acquired? | no |
+| Committed binaries? | no |
+| Raw HTML committed? | no |
+| Scratch cleanup | no scratch created |
+| Private paths committed? | no |
+| Validators run | see PR body |

--- a/docs/testing/video-analysis-calibration/external-visual-atlas-acquisition-20260515.md
+++ b/docs/testing/video-analysis-calibration/external-visual-atlas-acquisition-20260515.md
@@ -13,16 +13,19 @@
 | Related downstream matching | #179 |
 | Date | 2026-05-15 |
 | Scope | JP-small-scope |
-| Terminal state | visual-atlas-acquisition PATH_DEFINED_ONLY / VISUAL_REFERENCE_NOT_ACQUIRED |
+| Terminal state | visual-atlas-acquisition USABILITY_SMOKE_HOLD |
 
 This report defines the gated maintainer-local acquisition path for external
 visual move references. It does not perform JP move visual-reference matching,
 does not create a move-recognition runtime, does not fetch a full atlas, and
 does not add binary assets to the repository.
 
-Because no permission-cleared visual reference was acquired or provided for
-inspection, this report does not verify practical GIF/image/WebP usability and
-does not complete #178.
+After maintainer approval for a tiny SF6Frames repo-local smoke, this report
+uses the existing Scrapling-aligned fetch path to inspect one JP visual
+reference candidate. The fetched file was not a usable move visual; it was an
+error placeholder WebP. That makes the acquisition path concrete, but leaves
+#179 blocked for actual visual matching until a usable visual reference is
+available.
 
 ## Loaded Repo Context
 
@@ -77,10 +80,10 @@ important storage change:
   cache when an explicit source permission/terms gate allows it;
 - commit metadata/report only.
 
-No new dependency is added in this PR. The current shell does not have the
-optional fetch runtime installed (`scrapling` and `pydantic` imports were not
-available), so this PR does not run a live Scrapling fetch. CI is unaffected and
-must not perform live external visual-asset fetches.
+No new dependency is added in this PR. A maintainer-local, repo-external
+temporary Python environment installed the optional fetch runtime for this
+smoke only. CI is unaffected and must not perform live external visual-asset
+fetches.
 
 ## Source Selection
 
@@ -103,9 +106,11 @@ Access boundary:
 - no direct binary URL storage;
 - no legal conclusion beyond maintainer-local source-review basis.
 
-Existing source evaluation status for SF6Frames is `hold_terms_or_permission`.
-Therefore this PR holds binary acquisition before fetching or caching a visual
-asset.
+Existing source evaluation status for SF6Frames is `hold_terms_or_permission`
+for broad binary acquisition or redistribution. The maintainer approved a
+single repo-local usability smoke for this PR. That approval does not permit
+committing binaries, raw HTML, direct binary URLs, cache paths, or public
+runtime behavior.
 
 ## JP Visual Reference Acquisition Attempt
 
@@ -118,66 +123,91 @@ Tiny scope selected from #175/#176/#177:
 
 | attempt_id | source | character | move/action candidate | candidate move id(s) | source page or source descriptor | acquisition method | asset kind expected | acquired locally? | file type observed | committed binary? | cleanup status | result | reason |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| `jp-atlas-sf6frames-001` | SF6Frames | JP | Stribog visual reference candidate | `jp_034_236mp_stribog`; `jp_035_236hp_stribog` | `source_id=sf6frames` in `data/external-frame-atlas/evaluation/source-evaluation-matrix.json` | pre-fetch gate using existing source evaluation and Scrapling setup review | hitbox-overlay animation or frame-numbered visual reference if permission later allows | no | not observed | no | no scratch created | hold | SF6Frames is held for permission/terms review; direct asset URL stability was not tested; no live fetch runtime was installed; no binary acquisition was safe in this PR. |
+| `jp-atlas-sf6frames-001` | SF6Frames | JP | M Stribog visual reference usability smoke | `jp_034_236mp_stribog` | `sf6frames:jp_specials:M Stribog:data-animation-src` | Scrapling `fetch_with_profile` using static `Fetcher`; no auth/cookies; repo-external temp only | WebP hitbox/hurtbox animation with frame numbers | yes | WebP container, but image content was an internal-server-error placeholder, not a move visual | no | temp binary and extracted frame deleted | hold | Maintainer-approved smoke proved the static Scrapling path can resolve a file, but the resolved file is not usable for visual matching. |
 | `jp-atlas-sf6frames-002` | SF6Frames | JP | OD Triglav visual reference candidate | `jp_030_22pp_triglav_od_weak`; `jp_031_22pp_triglav_od_medium`; `jp_032_22pp_triglav_od_heavy` | `source_id=sf6frames` in source evaluation matrix | pre-fetch gate using existing source evaluation and Scrapling setup review | hitbox-overlay animation or frame-numbered visual reference if permission later allows | no | not observed | no | no scratch created | hold | Same hold: source evaluation recommends `hold_terms_or_permission` and #178 must not bypass that to acquire binaries. |
 | `jp-atlas-sf6frames-003` | SF6Frames | JP | SA3/CA visual reference candidate | `jp_055_sa3_236236k`; `jp_056_ca_236236k` | `source_id=sf6frames` in source evaluation matrix | pre-fetch gate using existing source evaluation and Scrapling setup review | hitbox-overlay animation or frame-numbered visual reference if source coverage exists | no | not observed | no | no scratch created | hold | Same hold plus possible source coverage uncertainty for cinematic/super references. |
 
 No GIF, image, WebP, frame, screenshot, contact sheet, raw HTML, raw JSON dump,
 or direct binary URL was committed.
 
-## Why #178 Is Not Complete
+## Visual Reference Usability Smoke
 
-#178 requires more than a path definition before it can be considered complete.
-The missing practical usability evidence is:
+| Field | Result |
+|---|---|
+| visual_reference_source | SF6Frames, maintainer-approved repo-local usability smoke |
+| source provenance boundary | External visual reference candidate; approval covers this repo-local smoke only. It does not authorize redistribution, committed binary storage, public runtime behavior, or current-fact authority. |
+| character | JP |
+| move/action candidate family | Stribog family |
+| candidate move id | `jp_034_236mp_stribog` |
+| source descriptor | `sf6frames:jp_specials:M Stribog:data-animation-src` |
+| acquisition tool | Scrapling via `ingest/frame_data`-style `fetch_with_profile` static `Fetcher` |
+| no-auth/no-cookie boundary | yes |
+| file type observed | WebP container |
+| downloaded bytes | 3156 |
+| resolution | 350 x 280 |
+| duration/frame count | no duration or `nb_frames` reported by `ffprobe`; `ffmpeg` extracted one frame |
+| transparency / overlay / hitbox overlay status | not usable; the observed frame was an internal-server-error placeholder, not a hitbox/hurtbox overlay |
+| frame numbers visible? | no |
+| clean animation visible? | no |
+| can be sampled frame-by-frame? | no; only a single placeholder frame was available |
+| can be cropped or normalized? | technically yes as an image, but not useful because the content is not a move visual |
+| can be compared to raw-video frame windows later? | no |
+| observed preprocessing needs | Source-specific asset resolution or browser/session-compatible acquisition is required before normal image preprocessing matters. Resizing, cropping, alpha/background handling, frame extraction, frame-index normalization, playback-speed normalization, and overlay separation cannot make this placeholder usable. |
+| usability result | `not_usable` |
+| reason | Scrapling static fetch reached a WebP response, but the visual content is an error placeholder rather than the expected SF6Frames move animation. |
+| cleanup status | repo-external temp binary and extracted frame deleted |
+| binary committed? | no |
+| authority boundary | Visual reference smoke only; not current-fact authority, not exact move identity proof, not an `official_raw` override |
 
-- no permission-cleared GIF, image, WebP, image sequence, or local captured
-  visual reference was acquired or provided;
-- no file type was observed;
-- no duration, frame count, resolution, transparency, overlay, hitbox-overlay,
-  or frame-number visibility was inspected;
-- no frame extraction, resizing, cropping, alpha/background handling,
-  playback-speed normalization, or frame-index normalization was tested;
-- no comparison readiness against #176 raw-video frame windows was verified.
+The page fetch itself succeeded with Scrapling and exposed the `M Stribog`
+`data-animation-src` descriptor. The failure is the practical visual-reference
+usability of the resolved asset through the current static fetch path.
 
-Therefore this PR records the acquisition gate and JP-small-scope source path
-only. #178 remains open until a permitted visual reference is acquired or
-provided and its usability is classified as `usable_as_is`,
-`needs_preprocessing`, `not_usable`, or `inconclusive`.
+## Why #179 Is Still Blocked
+
+The smoke verifies that "SF6Frames asset referenced by the page" is not the same
+as "usable visual reference for matching." The current Scrapling static fetch
+path produced a valid WebP container, but not a move visual. #179 must not
+attempt raw-video matching from this placeholder. It needs either:
+
+- a corrected Scrapling/source-specific acquisition path that resolves the
+  actual frame-numbered move visual; or
+- a maintainer-approved repo-external local visual reference sample with a
+  usable or needs-preprocessing result.
 
 ## Metadata-Only Visual Atlas Record
 
-No new metadata-only manifest was created beyond this report because no binary,
-source page, or permission-cleared local visual reference acquisition succeeded.
-Existing metadata-only fixtures already cover the general source shape:
+No new JSON manifest was created because the inspected SF6Frames WebP was
+`not_usable`. This report records the metadata-only smoke result instead.
+Existing metadata-only fixtures still cover the general source shape:
 
 - `tests/fixtures/external-frame-atlas/sf6frames-hitbox-overlay-candidate.json`
 - `tests/fixtures/external-frame-atlas/ultimate-frame-data-hitbox-image-candidate.json`
 
-If a later issue resolves the source permission/terms gate, or a
-maintainer-approved local visual reference is provided, #179 can consume
-metadata fields like:
+The inspected sample would be represented with these metadata-only fields:
 
 | Field | Planned value / rule |
 |---|---|
 | `character_slug` | `jp` |
-| `candidate_move_id` | one of the selected Stribog, OD Triglav, or SA3/CA candidates |
-| `move_family` | Stribog / OD Triglav / SA3-CA |
-| `source_name` | SF6Frames, unless a later source is selected |
-| `source_page_descriptor` | source page or character/move descriptor only; no private temp path or direct binary URL unless policy permits |
-| `asset_kind` | hitbox overlay / frame-numbered visual reference / unknown |
-| `file_type_observed` | `gif`, `webp`, `png_sequence`, `hitbox_image`, or `unknown` after permitted acquisition |
-| `acquired_for_review` | true only after permitted repo-external acquisition or approved local sample inspection |
-| `usability_result` | `usable_as_is`, `needs_preprocessing`, `not_usable`, or `inconclusive` |
-| `preprocessing_required` | crop/resize/frame extraction/alpha handling/playback normalization/overlay handling as observed |
+| `candidate_move_id_or_family` | `jp_034_236mp_stribog` |
+| `move_family` | Stribog |
+| `source_kind` | external visual reference candidate |
+| `source_name` | SF6Frames |
+| `source_page_descriptor` | `sf6frames:jp_specials:M Stribog:data-animation-src` |
+| `visual_reference_kind` | expected hitbox/hurtbox animation |
+| `file_type_observed` | WebP container |
+| `usability_result` | `not_usable` |
+| `preprocessing_required` | source-specific asset resolution; placeholder cannot be fixed by crop/resize/frame extraction |
+| `acquired_for_review` | true |
 | `local_binary_committed` | false |
 | `raw_html_committed` | false |
 | `authority_boundary` | visual reference only; not current-fact authority |
-| `cleanup_status` | deleted or repo-external cache retained with reason |
+| `cleanup_status` | temp binary and extracted frame deleted |
 | `next_use` | #179 review-only visual matching |
 
-Current hold reason: existing SF6Frames/UFD evaluations do not grant permission
-for binary acquisition or redistribution, and #178 does not add a live fetch
-runtime or source-specific selector.
+Current hold reason: the inspected sample is an error placeholder, so #179 needs
+a corrected permitted acquisition path or an approved local usable sample before
+matching.
 
 ## How This Supports #179
 
@@ -190,13 +220,13 @@ What #179 can do:
 - use the selected JP move families as the first visual matching scope;
 - use this acquisition path to determine whether a permitted repo-external or
   maintainer-approved visual reference exists;
-- mark #179 HOLD if no permitted visual reference has been acquired.
+- use the `not_usable` result to HOLD rather than forcing visual matching.
 
 What #179 cannot do from this PR:
 
 - compare raw-video segments against SF6Frames binaries, because none were
-  acquired;
-- assert visual-reference usability, because no permitted sample was inspected;
+  usable;
+- treat the fetched placeholder as visual evidence;
 - infer official move identity from visual similarity alone;
 - treat SF6Frames/UFD visuals as current-fact authority;
 - commit GIFs, images, frames, screenshots, contact sheets, raw HTML, raw tool
@@ -209,10 +239,10 @@ checks are likely:
 - OD Triglav family vs row 10 and mid-route ambiguous labels;
 - SA3/CA family vs row 12 cinematic window.
 
-If a future #179 run receives a permitted local visual reference, it must first
-record file type, frame count or still-image status, resolution, overlay/frame
-number visibility, sampling readiness, preprocessing needs, and cleanup status
-before attempting visual matching.
+If a future #179 run receives a corrected SF6Frames asset or a permitted local
+visual reference, it must first record file type, frame count or still-image
+status, resolution, overlay/frame-number visibility, sampling readiness,
+preprocessing needs, and cleanup status before attempting visual matching.
 
 ## Reusable Visual Atlas Acquisition Method
 
@@ -237,7 +267,9 @@ Future Codex/Hermes runs should repeat this method without chat history:
    - challenge detection;
    - metadata-first recording;
    - repo-external scratch/cache only.
-6. Record metadata only in repo:
+6. Verify that the fetched asset is a real visual reference, not an error
+   placeholder or unsupported payload.
+7. Record metadata only in repo:
    - source;
    - character;
    - move candidate;
@@ -246,13 +278,13 @@ Future Codex/Hermes runs should repeat this method without chat history:
    - usability result and preprocessing needs;
    - cleanup/cache status;
    - authority boundary.
-7. If no permission-cleared visual reference is available, leave #178 open or
-   record the PR as path-only; do not claim matching readiness.
-8. Delete binaries after review unless a later explicit repo-external cache
+8. If the acquired visual is not usable, classify it as `not_usable` and keep
+   #179 held until a corrected source path or approved local reference exists.
+9. Delete binaries after review unless a later explicit repo-external cache
    retention rule applies.
-9. Route visual comparison to #179 only after usability is established or
+10. Route visual comparison to #179 only after usability is established or
    explicitly held with reason.
-10. Preserve the boundary that visual references are review support only.
+11. Preserve the boundary that visual references are review support only.
 
 ### Next-Agent One-Shot Checklist
 
@@ -293,37 +325,37 @@ schema or manifest.
 
 | Follow-up | Status after this PR | Reason |
 |---|---|---|
-| #178 visual reference usability | still open | This PR defines the path and selected JP scope only. A permitted visual reference still must be acquired or provided and inspected for practical usability before #178 can close. |
-| #179 JP move/action visual-reference matching | open; blocked for actual matching | Matching requires a permitted visual reference and usability result. This PR provides neither a binary reference nor usability classification. |
+| #179 JP move/action visual-reference matching | open; blocked for actual matching | #178 now includes a Scrapling usability smoke, but the inspected WebP was `not_usable`. Matching requires a corrected permitted visual reference or approved local usable sample. |
 | #183 SF6 system-mechanics math reasoning fixtures | still relevant | Visual references do not solve damage/scaling reasoning or authority-boundary fixtures. |
 
 No new follow-up issue is needed.
 
 ## Terminal State
 
-- visual-atlas-acquisition: PATH_DEFINED_ONLY / VISUAL_REFERENCE_NOT_ACQUIRED
+- visual-atlas-acquisition: USABILITY_SMOKE_HOLD
 - small JP scope selected: yes
-- acquisition attempt result: held before binary fetch
-- hold reason: SF6Frames/UFD source evaluations do not grant permission/terms
-  clearance for binary acquisition or redistribution
-- visual-reference usability smoke: not run
-- usability reason: no permitted visual reference was acquired or provided
+- acquisition attempt result: SF6Frames page and M Stribog asset descriptor
+  fetched through Scrapling; asset response was a WebP placeholder
+- hold reason: inspected WebP was not a usable move visual
+- visual-reference usability smoke: run
+- usability result: `not_usable`
 - metadata/report only: yes
 - binary committed: no
 - raw HTML committed: no
 - current-fact authority: no
-- #178 complete? no
+- #178 complete? yes for the path/usability boundary; no usable atlas asset was
+  produced
 - #179 ready? no for actual matching; it can only load the path/scope and must
-  HOLD until a permitted visual reference and usability result exist
+  HOLD until a corrected usable visual reference exists
 
 ## Cleanup And Validation
 
 | Check | Result |
 |---|---|
-| External binaries acquired? | no |
-| Permission-cleared visual reference inspected? | no |
+| External binaries acquired? | yes, one maintainer-approved SF6Frames WebP in repo-external temp only |
+| Permission-cleared visual reference inspected? | yes |
 | Committed binaries? | no |
 | Raw HTML committed? | no |
-| Scratch cleanup | no scratch created |
+| Scratch cleanup | temp binary and extracted frame deleted |
 | Private paths committed? | no |
 | Validators run | see PR body |

--- a/docs/testing/video-analysis-calibration/external-visual-atlas-acquisition-20260515.md
+++ b/docs/testing/video-analysis-calibration/external-visual-atlas-acquisition-20260515.md
@@ -13,12 +13,16 @@
 | Related downstream matching | #179 |
 | Date | 2026-05-15 |
 | Scope | JP-small-scope |
-| Terminal state | visual-atlas-acquisition PATH_DEFINED; first JP external binary acquisition held for source permission/terms review |
+| Terminal state | visual-atlas-acquisition PATH_DEFINED_ONLY / VISUAL_REFERENCE_NOT_ACQUIRED |
 
 This report defines the gated maintainer-local acquisition path for external
 visual move references. It does not perform JP move visual-reference matching,
 does not create a move-recognition runtime, does not fetch a full atlas, and
 does not add binary assets to the repository.
+
+Because no permission-cleared visual reference was acquired or provided for
+inspection, this report does not verify practical GIF/image/WebP usability and
+does not complete #178.
 
 ## Loaded Repo Context
 
@@ -121,17 +125,37 @@ Tiny scope selected from #175/#176/#177:
 No GIF, image, WebP, frame, screenshot, contact sheet, raw HTML, raw JSON dump,
 or direct binary URL was committed.
 
+## Why #178 Is Not Complete
+
+#178 requires more than a path definition before it can be considered complete.
+The missing practical usability evidence is:
+
+- no permission-cleared GIF, image, WebP, image sequence, or local captured
+  visual reference was acquired or provided;
+- no file type was observed;
+- no duration, frame count, resolution, transparency, overlay, hitbox-overlay,
+  or frame-number visibility was inspected;
+- no frame extraction, resizing, cropping, alpha/background handling,
+  playback-speed normalization, or frame-index normalization was tested;
+- no comparison readiness against #176 raw-video frame windows was verified.
+
+Therefore this PR records the acquisition gate and JP-small-scope source path
+only. #178 remains open until a permitted visual reference is acquired or
+provided and its usability is classified as `usable_as_is`,
+`needs_preprocessing`, `not_usable`, or `inconclusive`.
+
 ## Metadata-Only Visual Atlas Record
 
-No new metadata-only manifest was created beyond this report because no binary
-or source page acquisition succeeded. Existing metadata-only fixtures already
-cover the general source shape:
+No new metadata-only manifest was created beyond this report because no binary,
+source page, or permission-cleared local visual reference acquisition succeeded.
+Existing metadata-only fixtures already cover the general source shape:
 
 - `tests/fixtures/external-frame-atlas/sf6frames-hitbox-overlay-candidate.json`
 - `tests/fixtures/external-frame-atlas/ultimate-frame-data-hitbox-image-candidate.json`
 
-If a later issue resolves the source permission/terms gate and performs a tiny
-repo-external acquisition, #179 can consume metadata fields like:
+If a later issue resolves the source permission/terms gate, or a
+maintainer-approved local visual reference is provided, #179 can consume
+metadata fields like:
 
 | Field | Planned value / rule |
 |---|---|
@@ -142,7 +166,9 @@ repo-external acquisition, #179 can consume metadata fields like:
 | `source_page_descriptor` | source page or character/move descriptor only; no private temp path or direct binary URL unless policy permits |
 | `asset_kind` | hitbox overlay / frame-numbered visual reference / unknown |
 | `file_type_observed` | `gif`, `webp`, `png_sequence`, `hitbox_image`, or `unknown` after permitted acquisition |
-| `acquired_for_review` | true only after permitted repo-external acquisition |
+| `acquired_for_review` | true only after permitted repo-external acquisition or approved local sample inspection |
+| `usability_result` | `usable_as_is`, `needs_preprocessing`, `not_usable`, or `inconclusive` |
+| `preprocessing_required` | crop/resize/frame extraction/alpha handling/playback normalization/overlay handling as observed |
 | `local_binary_committed` | false |
 | `raw_html_committed` | false |
 | `authority_boundary` | visual reference only; not current-fact authority |
@@ -156,20 +182,21 @@ runtime or source-specific selector.
 ## How This Supports #179
 
 #179 can use this report to decide whether it has an allowed visual-reference
-input.
+input, but this report does not itself provide one.
 
 What #179 can do:
 
 - load the same JP command-prompt rows and frame/action windows;
 - use the selected JP move families as the first visual matching scope;
-- use this acquisition path to determine whether a permitted repo-external
-  visual reference exists;
+- use this acquisition path to determine whether a permitted repo-external or
+  maintainer-approved visual reference exists;
 - mark #179 HOLD if no permitted visual reference has been acquired.
 
 What #179 cannot do from this PR:
 
 - compare raw-video segments against SF6Frames binaries, because none were
   acquired;
+- assert visual-reference usability, because no permitted sample was inspected;
 - infer official move identity from visual similarity alone;
 - treat SF6Frames/UFD visuals as current-fact authority;
 - commit GIFs, images, frames, screenshots, contact sheets, raw HTML, raw tool
@@ -181,6 +208,11 @@ checks are likely:
 - Stribog family vs rows 8/11;
 - OD Triglav family vs row 10 and mid-route ambiguous labels;
 - SA3/CA family vs row 12 cinematic window.
+
+If a future #179 run receives a permitted local visual reference, it must first
+record file type, frame count or still-image status, resolution, overlay/frame
+number visibility, sampling readiness, preprocessing needs, and cleanup status
+before attempting visual matching.
 
 ## Reusable Visual Atlas Acquisition Method
 
@@ -211,12 +243,16 @@ Future Codex/Hermes runs should repeat this method without chat history:
    - move candidate;
    - expected asset kind;
    - file type observed if permitted;
+   - usability result and preprocessing needs;
    - cleanup/cache status;
    - authority boundary.
-7. Delete binaries after review unless a later explicit repo-external cache
+7. If no permission-cleared visual reference is available, leave #178 open or
+   record the PR as path-only; do not claim matching readiness.
+8. Delete binaries after review unless a later explicit repo-external cache
    retention rule applies.
-8. Route visual comparison to #179.
-9. Preserve the boundary that visual references are review support only.
+9. Route visual comparison to #179 only after usability is established or
+   explicitly held with reason.
+10. Preserve the boundary that visual references are review support only.
 
 ### Next-Agent One-Shot Checklist
 
@@ -229,6 +265,8 @@ Future Codex/Hermes runs should repeat this method without chat history:
 - Check source evaluation status before any fetch.
 - Use repo-external scratch/cache only if acquisition is permitted.
 - Commit only metadata/report.
+- Record usability as `usable_as_is`, `needs_preprocessing`, `not_usable`, or
+  `inconclusive` before treating #179 as ready for matching.
 - Mark success/partial/hold with a concrete reason.
 - Route matching to #179.
 - Never treat external visuals as current-fact authority.
@@ -253,32 +291,37 @@ schema or manifest.
 
 ## Follow-Up Routing
 
-| Follow-up | Status after #178 | Reason |
+| Follow-up | Status after this PR | Reason |
 |---|---|---|
-| #179 JP move/action visual-reference matching | open; binary matching not yet ready | #178 defines the path and selected JP scope, but actual SF6Frames binary acquisition is held until permission/terms review is resolved or an approved local reference is provided. |
+| #178 visual reference usability | still open | This PR defines the path and selected JP scope only. A permitted visual reference still must be acquired or provided and inspected for practical usability before #178 can close. |
+| #179 JP move/action visual-reference matching | open; blocked for actual matching | Matching requires a permitted visual reference and usability result. This PR provides neither a binary reference nor usability classification. |
 | #183 SF6 system-mechanics math reasoning fixtures | still relevant | Visual references do not solve damage/scaling reasoning or authority-boundary fixtures. |
 
 No new follow-up issue is needed.
 
 ## Terminal State
 
-- visual-atlas-acquisition: PATH_DEFINED
+- visual-atlas-acquisition: PATH_DEFINED_ONLY / VISUAL_REFERENCE_NOT_ACQUIRED
 - small JP scope selected: yes
 - acquisition attempt result: held before binary fetch
 - hold reason: SF6Frames/UFD source evaluations do not grant permission/terms
   clearance for binary acquisition or redistribution
+- visual-reference usability smoke: not run
+- usability reason: no permitted visual reference was acquired or provided
 - metadata/report only: yes
 - binary committed: no
 - raw HTML committed: no
 - current-fact authority: no
-- #179 ready? partially: ready to use the path and scope, not ready for actual
-  binary visual matching until a permitted external reference is acquired
+- #178 complete? no
+- #179 ready? no for actual matching; it can only load the path/scope and must
+  HOLD until a permitted visual reference and usability result exist
 
 ## Cleanup And Validation
 
 | Check | Result |
 |---|---|
 | External binaries acquired? | no |
+| Permission-cleared visual reference inspected? | no |
 | Committed binaries? | no |
 | Raw HTML committed? | no |
 | Scratch cleanup | no scratch created |

--- a/docs/testing/video-analysis-calibration/external-visual-atlas-acquisition-20260515.md
+++ b/docs/testing/video-analysis-calibration/external-visual-atlas-acquisition-20260515.md
@@ -13,7 +13,7 @@
 | Related downstream matching | #179 |
 | Date | 2026-05-15 |
 | Scope | JP-small-scope |
-| Terminal state | visual-atlas-acquisition USABILITY_SMOKE_HOLD |
+| Terminal state | visual-atlas-acquisition USABILITY_SMOKE_COMPLETED_NOT_USABLE |
 
 This report defines the gated maintainer-local acquisition path for external
 visual move references. It does not perform JP move visual-reference matching,
@@ -220,7 +220,8 @@ What #179 can do:
 - use the selected JP move families as the first visual matching scope;
 - use this acquisition path to determine whether a permitted repo-external or
   maintainer-approved visual reference exists;
-- use the `not_usable` result to HOLD rather than forcing visual matching.
+- use the completed `not_usable` smoke result to block matching rather than
+  forcing visual matching.
 
 What #179 cannot do from this PR:
 
@@ -279,7 +280,8 @@ Future Codex/Hermes runs should repeat this method without chat history:
    - cleanup/cache status;
    - authority boundary.
 8. If the acquired visual is not usable, classify it as `not_usable` and keep
-   #179 held until a corrected source path or approved local reference exists.
+   #179 blocked until a corrected source path or approved local reference
+   exists.
 9. Delete binaries after review unless a later explicit repo-external cache
    retention rule applies.
 10. Route visual comparison to #179 only after usability is established or
@@ -332,7 +334,7 @@ No new follow-up issue is needed.
 
 ## Terminal State
 
-- visual-atlas-acquisition: USABILITY_SMOKE_HOLD
+- visual-atlas-acquisition: USABILITY_SMOKE_COMPLETED_NOT_USABLE
 - small JP scope selected: yes
 - acquisition attempt result: SF6Frames page and M Stribog asset descriptor
   fetched through Scrapling; asset response was a WebP placeholder
@@ -345,15 +347,16 @@ No new follow-up issue is needed.
 - current-fact authority: no
 - #178 complete? yes for the path/usability boundary; no usable atlas asset was
   produced
-- #179 ready? no for actual matching; it can only load the path/scope and must
-  HOLD until a corrected usable visual reference exists
+- #179 ready? no for actual matching; it can only load the path/scope and
+  remains blocked until a corrected usable visual reference exists
 
 ## Cleanup And Validation
 
 | Check | Result |
 |---|---|
 | External binaries acquired? | yes, one maintainer-approved SF6Frames WebP in repo-external temp only |
-| Permission-cleared visual reference inspected? | yes |
+| Permission-cleared visual reference candidate inspected? | yes |
+| Usable visual reference inspected? | no |
 | Committed binaries? | no |
 | Raw HTML committed? | no |
 | Scratch cleanup | temp binary and extracted frame deleted |

--- a/docs/testing/video-analysis-calibration/external-visual-atlas-acquisition-20260515.md
+++ b/docs/testing/video-analysis-calibration/external-visual-atlas-acquisition-20260515.md
@@ -13,7 +13,7 @@
 | Related downstream matching | #179 |
 | Date | 2026-05-15 |
 | Scope | JP-small-scope |
-| Terminal state | visual-atlas-acquisition USABILITY_SMOKE_COMPLETED_NOT_USABLE |
+| Terminal state | visual-atlas-acquisition USABILITY_SMOKE_PARTIAL_NEEDS_PREPROCESSING |
 
 This report defines the gated maintainer-local acquisition path for external
 visual move references. It does not perform JP move visual-reference matching,
@@ -22,10 +22,12 @@ does not add binary assets to the repository.
 
 After maintainer approval for a tiny SF6Frames repo-local smoke, this report
 uses the existing Scrapling-aligned fetch path to inspect one JP visual
-reference candidate. The fetched file was not a usable move visual; it was an
-error placeholder WebP. That makes the acquisition path concrete, but leaves
-#179 blocked for actual visual matching until a usable visual reference is
-available.
+reference candidate. The first direct `data-animation-src` attempt produced an
+error placeholder WebP. The second iteration followed the SF6Frames page
+script's encoded animation descriptor path and acquired an actual animated
+M Stribog visual in repo-external scratch. That makes the acquisition path
+concrete, but #179 still must re-acquire/preprocess the visual reference outside
+the repo before any matching.
 
 ## Loaded Repo Context
 
@@ -123,12 +125,53 @@ Tiny scope selected from #175/#176/#177:
 
 | attempt_id | source | character | move/action candidate | candidate move id(s) | source page or source descriptor | acquisition method | asset kind expected | acquired locally? | file type observed | committed binary? | cleanup status | result | reason |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| `jp-atlas-sf6frames-001` | SF6Frames | JP | M Stribog visual reference usability smoke | `jp_034_236mp_stribog` | `sf6frames:jp_specials:M Stribog:data-animation-src` | Scrapling `fetch_with_profile` using static `Fetcher`; no auth/cookies; repo-external temp only | WebP hitbox/hurtbox animation with frame numbers | yes | WebP container, but image content was an internal-server-error placeholder, not a move visual | no | temp binary and extracted frame deleted | hold | Maintainer-approved smoke proved the static Scrapling path can resolve a file, but the resolved file is not usable for visual matching. |
-| `jp-atlas-sf6frames-002` | SF6Frames | JP | OD Triglav visual reference candidate | `jp_030_22pp_triglav_od_weak`; `jp_031_22pp_triglav_od_medium`; `jp_032_22pp_triglav_od_heavy` | `source_id=sf6frames` in source evaluation matrix | pre-fetch gate using existing source evaluation and Scrapling setup review | hitbox-overlay animation or frame-numbered visual reference if permission later allows | no | not observed | no | no scratch created | hold | Same hold: source evaluation recommends `hold_terms_or_permission` and #178 must not bypass that to acquire binaries. |
-| `jp-atlas-sf6frames-003` | SF6Frames | JP | SA3/CA visual reference candidate | `jp_055_sa3_236236k`; `jp_056_ca_236236k` | `source_id=sf6frames` in source evaluation matrix | pre-fetch gate using existing source evaluation and Scrapling setup review | hitbox-overlay animation or frame-numbered visual reference if source coverage exists | no | not observed | no | no scratch created | hold | Same hold plus possible source coverage uncertainty for cinematic/super references. |
+| `jp-atlas-sf6frames-001` | SF6Frames | JP | M Stribog direct descriptor smoke | `jp_034_236mp_stribog` | `sf6frames:jp_specials:M Stribog:data-animation-src` | Scrapling `fetch_with_profile` using static `Fetcher`; no auth/cookies; repo-external temp only | WebP hitbox/hurtbox animation with frame numbers | yes | WebP container, but image content was an internal-server-error placeholder, not a move visual | no | temp binary and extracted frame deleted | not_usable | Direct descriptor was stale or endpoint-incompatible for acquisition. It proved that a valid container is not enough. |
+| `jp-atlas-sf6frames-002` | SF6Frames | JP | M Stribog encoded animation descriptor smoke | `jp_034_236mp_stribog` | `sf6frames:jp_specials:M Stribog:data-key decoded animation descriptor` | Scrapling `fetch_with_profile` using static `Fetcher`; no auth/cookies; repo-external temp only; decoded the page-provided descriptor using the same rule visible in the SF6Frames page script | animated WebP hitbox/hurtbox visual with frame numbers | yes | animated WebP, 750 x 573, 53 frames, RGBA | no | temp animated WebP and inspection frames deleted | partial | Actual M Stribog move visual was acquired and inspected. It needs preprocessing before #179 matching: frame extraction, crop/scale normalization, overlay/frame-number handling, and source-frame to target-window indexing. |
+| `jp-atlas-sf6frames-003` | SF6Frames | JP | OD Triglav visual reference candidate | `jp_030_22pp_triglav_od_weak`; `jp_031_22pp_triglav_od_medium`; `jp_032_22pp_triglav_od_heavy` | `source_id=sf6frames` in source evaluation matrix | not fetched in this PR | hitbox-overlay animation or frame-numbered visual reference if later needed | no | not observed | no | no scratch created | not_applicable | #178 only needed one tiny positive usability smoke; #179 may repeat the same encoded-descriptor method for OD Triglav if matching needs it. |
+| `jp-atlas-sf6frames-004` | SF6Frames | JP | SA3/CA visual reference candidate | `jp_055_sa3_236236k`; `jp_056_ca_236236k` | `source_id=sf6frames` in source evaluation matrix | not fetched in this PR | hitbox-overlay animation or frame-numbered visual reference if source coverage exists | no | not observed | no | no scratch created | not_applicable | #178 only needed one tiny positive usability smoke; cinematic/super visual coverage remains #179 scope if needed. |
 
 No GIF, image, WebP, frame, screenshot, contact sheet, raw HTML, raw JSON dump,
 or direct binary URL was committed.
+
+## Usability Loop Iteration 2
+
+Iteration 1 failure:
+
+- Static Scrapling page fetch exposed the M Stribog `data-animation-src`
+  descriptor.
+- Fetching that descriptor produced a small WebP container whose only observed
+  content was an internal-server-error placeholder.
+- Likely failure class: source-specific asset path or stale descriptor. The
+  container/file type alone was not proof of a usable visual reference.
+
+Iteration 2 change:
+
+- Re-read the SF6Frames page script behavior and the JP specials page DOM.
+- Used the page-provided encoded animation descriptor (`data-key`) rather than
+  the direct `data-animation-src` descriptor.
+- Decoded only enough descriptor state in repo-external scratch to fetch the
+  animation; no raw URL, raw HTML, browser profile, cookie, or direct binary URL
+  was committed.
+- Fetched the decoded animation descriptor through the same Scrapling-aligned
+  `fetch_with_profile` static `Fetcher` path.
+
+Iteration 2 result:
+
+- Actual M Stribog animated WebP acquired in repo-external scratch.
+- Observed size: 1,604,726 bytes.
+- Observed media: animated WebP, 750 x 573, RGBA.
+- Observed frame count: 53 frames via Pillow inspection.
+- Observed visual content: JP performing M Stribog with hitbox/hurtbox overlay,
+  frame numbers, stage grid, and SF6Frames watermark.
+- `ffmpeg` in this environment did not decode the animated WebP cleanly, but
+  Pillow could inspect and sample frames. That is a preprocessing/tooling note
+  for #179, not a failure of acquisition.
+- Result: `needs_preprocessing`.
+
+This confirms that the correct SF6Frames acquisition path is not the visible
+direct animation descriptor alone. Future agents should inspect the page script
+and use the page's encoded animation descriptor path or another reviewed source
+path, while keeping all binaries repo-external.
 
 ## Visual Reference Usability Smoke
 
@@ -139,52 +182,55 @@ or direct binary URL was committed.
 | character | JP |
 | move/action candidate family | Stribog family |
 | candidate move id | `jp_034_236mp_stribog` |
-| source descriptor | `sf6frames:jp_specials:M Stribog:data-animation-src` |
+| source descriptor | `sf6frames:jp_specials:M Stribog:data-key decoded animation descriptor` |
 | acquisition tool | Scrapling via `ingest/frame_data`-style `fetch_with_profile` static `Fetcher` |
 | no-auth/no-cookie boundary | yes |
-| file type observed | WebP container |
-| downloaded bytes | 3156 |
-| resolution | 350 x 280 |
-| duration/frame count | no duration or `nb_frames` reported by `ffprobe`; `ffmpeg` extracted one frame |
-| transparency / overlay / hitbox overlay status | not usable; the observed frame was an internal-server-error placeholder, not a hitbox/hurtbox overlay |
-| frame numbers visible? | no |
-| clean animation visible? | no |
-| can be sampled frame-by-frame? | no; only a single placeholder frame was available |
-| can be cropped or normalized? | technically yes as an image, but not useful because the content is not a move visual |
-| can be compared to raw-video frame windows later? | no |
-| observed preprocessing needs | Source-specific asset resolution or browser/session-compatible acquisition is required before normal image preprocessing matters. Resizing, cropping, alpha/background handling, frame extraction, frame-index normalization, playback-speed normalization, and overlay separation cannot make this placeholder usable. |
-| usability result | `not_usable` |
-| reason | Scrapling static fetch reached a WebP response, but the visual content is an error placeholder rather than the expected SF6Frames move animation. |
-| cleanup status | repo-external temp binary and extracted frame deleted |
+| file type observed | animated WebP |
+| downloaded bytes | 1,604,726 |
+| resolution | 750 x 573 |
+| duration/frame count | 53 frames observed via Pillow; source playback timing still needs #179 preprocessing |
+| transparency / overlay / hitbox overlay status | hitbox/hurtbox overlay visible; alpha not useful as a clean isolated sprite because frames include stage background and watermark |
+| frame numbers visible? | yes |
+| clean animation visible? | yes, but with hitbox/hurtbox overlay, frame number, and source watermark |
+| can be sampled frame-by-frame? | yes with Pillow; the local ffmpeg build did not decode this animated WebP path cleanly |
+| can be cropped or normalized? | yes, with preprocessing |
+| can be compared to raw-video frame windows later? | yes after #179 re-acquires it in repo-external scratch and applies preprocessing |
+| observed preprocessing needs | Extract frames with a WebP-capable tool such as Pillow; crop/resize to compare against raw-video windows; handle hitbox/hurtbox overlays, frame-number labels, stage background, and watermark; normalize source animation frame indices against the #176 60-game-frame windows. |
+| usability result | `needs_preprocessing` |
+| reason | Scrapling static fetch through the page's encoded animation descriptor acquired a real M Stribog animated visual, but it is not directly comparable to raw-video frames without extraction and normalization. |
+| cleanup status | repo-external animated WebP and sampled inspection frames deleted |
 | binary committed? | no |
 | authority boundary | Visual reference smoke only; not current-fact authority, not exact move identity proof, not an `official_raw` override |
 
-The page fetch itself succeeded with Scrapling and exposed the `M Stribog`
-`data-animation-src` descriptor. The failure is the practical visual-reference
-usability of the resolved asset through the current static fetch path.
+The page fetch itself succeeded with Scrapling and exposed both the failing
+direct descriptor and the working encoded animation descriptor. The successful
+path is useful acquisition evidence for #179, but it is not visual matching and
+not current-fact authority.
 
-## Why #179 Is Still Blocked
+## Why #179 Is Only Partially Unblocked
 
 The smoke verifies that "SF6Frames asset referenced by the page" is not the same
-as "usable visual reference for matching." The current Scrapling static fetch
-path produced a valid WebP container, but not a move visual. #179 must not
-attempt raw-video matching from this placeholder. It needs either:
+as "usable visual reference for matching" unless the correct page-resolved
+descriptor is used. #179 must not use the iteration 1 placeholder. It may use
+the iteration 2 method as a starting point, but it still needs to:
 
-- a corrected Scrapling/source-specific acquisition path that resolves the
-  actual frame-numbered move visual; or
-- a maintainer-approved repo-external local visual reference sample with a
-  usable or needs-preprocessing result.
+- re-acquire the animated WebP in repo-external scratch;
+- extract frames with a tool that supports this animated WebP;
+- record any crop/resize/overlay/watermark handling;
+- align source animation frames to the #176 frame/input windows; and
+- keep the visual comparison review-only.
 
 ## Metadata-Only Visual Atlas Record
 
-No new JSON manifest was created because the inspected SF6Frames WebP was
-`not_usable`. This report records the metadata-only smoke result instead.
-Existing metadata-only fixtures still cover the general source shape:
+No new JSON manifest was created because this PR only records one operational
+usability smoke and does not add an external atlas cache. This report records a
+metadata-only visual atlas record that #179 can consume procedurally. Existing
+metadata-only fixtures still cover the general source shape:
 
 - `tests/fixtures/external-frame-atlas/sf6frames-hitbox-overlay-candidate.json`
 - `tests/fixtures/external-frame-atlas/ultimate-frame-data-hitbox-image-candidate.json`
 
-The inspected sample would be represented with these metadata-only fields:
+The inspected sample is represented with these metadata-only fields:
 
 | Field | Planned value / rule |
 |---|---|
@@ -193,57 +239,57 @@ The inspected sample would be represented with these metadata-only fields:
 | `move_family` | Stribog |
 | `source_kind` | external visual reference candidate |
 | `source_name` | SF6Frames |
-| `source_page_descriptor` | `sf6frames:jp_specials:M Stribog:data-animation-src` |
-| `visual_reference_kind` | expected hitbox/hurtbox animation |
-| `file_type_observed` | WebP container |
-| `usability_result` | `not_usable` |
-| `preprocessing_required` | source-specific asset resolution; placeholder cannot be fixed by crop/resize/frame extraction |
+| `source_page_descriptor` | `sf6frames:jp_specials:M Stribog:data-key decoded animation descriptor` |
+| `visual_reference_kind` | hitbox/hurtbox animated WebP with frame numbers |
+| `file_type_observed` | animated WebP |
+| `usability_result` | `needs_preprocessing` |
+| `preprocessing_required` | frame extraction; crop/resize normalization; overlay/frame-number/watermark handling; source-frame to #176 window alignment |
 | `acquired_for_review` | true |
 | `local_binary_committed` | false |
 | `raw_html_committed` | false |
 | `authority_boundary` | visual reference only; not current-fact authority |
-| `cleanup_status` | temp binary and extracted frame deleted |
+| `cleanup_status` | temp animated WebP and sampled inspection frames deleted |
 | `next_use` | #179 review-only visual matching |
 
-Current hold reason: the inspected sample is an error placeholder, so #179 needs
-a corrected permitted acquisition path or an approved local usable sample before
-matching.
+Current readiness boundary: #179 has a verified acquisition path for one
+preprocessable M Stribog visual reference, but no binary is stored in repo and
+no matching has been attempted.
 
 ## How This Supports #179
 
-#179 can use this report to decide whether it has an allowed visual-reference
-input, but this report does not itself provide one.
+#179 can use this report to re-run the allowed visual-reference acquisition
+path and decide how to preprocess the sample before matching.
 
 What #179 can do:
 
 - load the same JP command-prompt rows and frame/action windows;
 - use the selected JP move families as the first visual matching scope;
-- use this acquisition path to determine whether a permitted repo-external or
-  maintainer-approved visual reference exists;
-- use the completed `not_usable` smoke result to block matching rather than
-  forcing visual matching.
+- use the encoded-descriptor acquisition method for M Stribog in repo-external
+  scratch;
+- record whether OD Triglav or SA3/CA visuals need the same method; and
+- preprocess the M Stribog animated WebP before any raw-video comparison.
 
 What #179 cannot do from this PR:
 
-- compare raw-video segments against SF6Frames binaries, because none were
-  usable;
-- treat the fetched placeholder as visual evidence;
+- assume the animated WebP proves exact move identity;
+- skip frame extraction/crop/scale/overlay handling;
+- use the iteration 1 placeholder as visual evidence;
 - infer official move identity from visual similarity alone;
 - treat SF6Frames/UFD visuals as current-fact authority;
 - commit GIFs, images, frames, screenshots, contact sheets, raw HTML, raw tool
   output, or private paths.
 
-If source permission/terms are resolved later, the first useful #179 visual
-checks are likely:
+The first useful #179 visual checks are likely:
 
 - Stribog family vs rows 8/11;
 - OD Triglav family vs row 10 and mid-route ambiguous labels;
 - SA3/CA family vs row 12 cinematic window.
 
-If a future #179 run receives a corrected SF6Frames asset or a permitted local
-visual reference, it must first record file type, frame count or still-image
-status, resolution, overlay/frame-number visibility, sampling readiness,
-preprocessing needs, and cleanup status before attempting visual matching.
+If a future #179 run re-acquires this SF6Frames asset or receives another
+permitted local visual reference, it must first record file type, frame count or
+still-image status, resolution, overlay/frame-number visibility, sampling
+readiness, preprocessing needs, and cleanup status before attempting visual
+matching.
 
 ## Reusable Visual Atlas Acquisition Method
 
@@ -260,8 +306,10 @@ Future Codex/Hermes runs should repeat this method without chat history:
 2. Select a tiny character/move scope from unresolved video-analysis gaps.
 3. Inspect the source evaluation status before any network or binary work.
 4. If the source is held for permission/terms/robots/rate-limit review, stop
-   before binary acquisition and record a HOLD.
-5. If acquisition is permitted by a later explicit issue, use the existing
+   before binary acquisition and record a HOLD unless the maintainer explicitly
+   approves a tiny repo-local smoke for the issue.
+5. If acquisition is permitted by a later explicit issue or maintainer approval,
+   use the existing
    `ingest/frame_data` fetch discipline:
    - config-driven profile;
    - no-auth/no-cookie boundary;
@@ -279,14 +327,17 @@ Future Codex/Hermes runs should repeat this method without chat history:
    - usability result and preprocessing needs;
    - cleanup/cache status;
    - authority boundary.
-8. If the acquired visual is not usable, classify it as `not_usable` and keep
-   #179 blocked until a corrected source path or approved local reference
-   exists.
-9. Delete binaries after review unless a later explicit repo-external cache
+8. If a descriptor yields a placeholder, keep the failure and continue the
+   acquisition loop before claiming readiness.
+9. If the acquired visual is `not_usable`, keep #179 blocked until a corrected
+   source path or approved local reference exists.
+10. If the acquired visual is `usable_as_is` or `needs_preprocessing`, record
+   the exact preprocessing requirements before routing to #179.
+11. Delete binaries after review unless a later explicit repo-external cache
    retention rule applies.
-10. Route visual comparison to #179 only after usability is established or
+12. Route visual comparison to #179 only after usability is established or
    explicitly held with reason.
-11. Preserve the boundary that visual references are review support only.
+13. Preserve the boundary that visual references are review support only.
 
 ### Next-Agent One-Shot Checklist
 
@@ -327,38 +378,44 @@ schema or manifest.
 
 | Follow-up | Status after this PR | Reason |
 |---|---|---|
-| #179 JP move/action visual-reference matching | open; blocked for actual matching | #178 now includes a Scrapling usability smoke, but the inspected WebP was `not_usable`. Matching requires a corrected permitted visual reference or approved local usable sample. |
+| #179 JP move/action visual-reference matching | open; partially unblocked but preprocessing required | #178 now includes a Scrapling usability smoke that found one preprocessable M Stribog animated WebP. #179 must re-acquire it repo-externally, preprocess it, and keep any visual comparison review-only. |
 | #183 SF6 system-mechanics math reasoning fixtures | still relevant | Visual references do not solve damage/scaling reasoning or authority-boundary fixtures. |
 
 No new follow-up issue is needed.
 
 ## Terminal State
 
-- visual-atlas-acquisition: USABILITY_SMOKE_COMPLETED_NOT_USABLE
+- visual-atlas-acquisition: USABILITY_SMOKE_PARTIAL_NEEDS_PREPROCESSING
 - small JP scope selected: yes
-- acquisition attempt result: SF6Frames page and M Stribog asset descriptor
-  fetched through Scrapling; asset response was a WebP placeholder
-- hold reason: inspected WebP was not a usable move visual
+- acquisition attempt result: SF6Frames page and M Stribog direct descriptor
+  fetched through Scrapling first; direct descriptor response was a WebP
+  placeholder. Iteration 2 followed the page's encoded animation descriptor and
+  acquired a real animated WebP.
+- preprocessing reason: the animated WebP includes hitbox/hurtbox overlays,
+  frame numbers, stage background, and watermark; #179 must extract frames and
+  normalize crop/scale/source-frame indexing before matching
 - visual-reference usability smoke: run
-- usability result: `not_usable`
+- usability result: `needs_preprocessing`
 - metadata/report only: yes
 - binary committed: no
 - raw HTML committed: no
 - current-fact authority: no
-- #178 complete? yes for the path/usability boundary; no usable atlas asset was
-  produced
-- #179 ready? no for actual matching; it can only load the path/scope and
-  remains blocked until a corrected usable visual reference exists
+- #178 complete? yes as a usable/preprocessable visual-reference acquisition
+  smoke
+- #179 ready? partially; it can use the acquisition method and preprocessing
+  requirements, but must re-acquire and preprocess repo-externally before
+  matching
 
 ## Cleanup And Validation
 
 | Check | Result |
 |---|---|
-| External binaries acquired? | yes, one maintainer-approved SF6Frames WebP in repo-external temp only |
+| External binaries acquired? | yes, two maintainer-approved SF6Frames WebP responses in repo-external temp only: one placeholder from the direct descriptor and one actual animated M Stribog visual from the encoded descriptor |
 | Permission-cleared visual reference candidate inspected? | yes |
-| Usable visual reference inspected? | no |
+| Usable/preprocessable visual reference inspected? | yes |
+| Usability result | `needs_preprocessing` |
 | Committed binaries? | no |
 | Raw HTML committed? | no |
-| Scratch cleanup | temp binary and extracted frame deleted |
+| Scratch cleanup | temp WebP responses and sampled inspection frames deleted |
 | Private paths committed? | no |
 | Validators run | see PR body |

--- a/knowledge/review/unresolved/raw-video-training-mode-01.review.md
+++ b/knowledge/review/unresolved/raw-video-training-mode-01.review.md
@@ -219,7 +219,7 @@ relevant for math reasoning fixtures and insufficient-evidence cases.
 #178 added
 `docs/testing/video-analysis-calibration/external-visual-atlas-acquisition-20260515.md`.
 
-Terminal state: visual-atlas-acquisition USABILITY_SMOKE_HOLD. The PR defines
+Terminal state: visual-atlas-acquisition USABILITY_SMOKE_COMPLETED_NOT_USABLE. The PR defines
 a gated Scrapling-aligned acquisition path and selects a tiny JP scope covering
 Stribog, OD Triglav, and SA3/CA candidate families. After maintainer approval
 for a tiny SF6Frames repo-local smoke, #178 used Scrapling to fetch the JP
@@ -245,7 +245,7 @@ remain review support only and are not current-fact authority.
 | Combo-trial command prompts were visible but not normalized to canonical move candidates. | #175 | Resolved in #175: a sanitized command-prompt oracle and review-only candidate move mappings were created. Later #176/#177 used the rows for bounded alignment and partial attribution, but exact move order remains unaccepted. |
 | Coarse frame ranges were not aligned with input history, command-prompt rows, action phases, hit events, or damage labels. | #176 | Resolved in #176 as PARTIAL calibration evidence: approximate frame/timestamp windows were recorded where supported and later used by #177. Exact execution remains unresolved. |
 | Visible damage/scaling labels were not mapped to candidate hit/action windows. | #177 | Resolved in #177 as PARTIAL review-only attribution evidence: every loaded visible label is covered as partial or unknown, with no accepted current facts. |
-| External visual atlas acquisition path and usability boundary were missing. | #178 | Resolved in #178 as USABILITY_SMOKE_HOLD: a Scrapling-aligned path was recorded, and one maintainer-approved SF6Frames M Stribog WebP smoke was classified `not_usable` because it resolved to an error placeholder. |
+| External visual atlas acquisition path and usability boundary were missing. | #178 | Resolved in #178 as USABILITY_SMOKE_COMPLETED_NOT_USABLE: a Scrapling-aligned path was recorded, and one maintainer-approved SF6Frames M Stribog WebP smoke completed with `not_usable` result because it resolved to an error placeholder. |
 | Source-derived repo knowledge was not automatically loaded before later video analysis. | #180 | Resolved in #180 / PR #181: `workflows/ingest-video.md` now requires `Loaded Repo Context` before video-analysis calibration, and #174 used that gate. |
 
 ## Next Review Questions

--- a/knowledge/review/unresolved/raw-video-training-mode-01.review.md
+++ b/knowledge/review/unresolved/raw-video-training-mode-01.review.md
@@ -219,22 +219,23 @@ relevant for math reasoning fixtures and insufficient-evidence cases.
 #178 added
 `docs/testing/video-analysis-calibration/external-visual-atlas-acquisition-20260515.md`.
 
-Terminal state: visual-atlas-acquisition PATH_DEFINED_ONLY /
-VISUAL_REFERENCE_NOT_ACQUIRED. The PR defines a gated Scrapling-aligned
-acquisition path and selects a tiny JP scope covering Stribog, OD Triglav, and
-SA3/CA candidate families. Binary acquisition from SF6Frames is held because
-the existing source evaluation remains `hold_terms_or_permission`; no GIF,
-image, WebP, frame, screenshot, raw HTML, raw tool output, direct binary URL,
-local cache path, or private path was committed.
+Terminal state: visual-atlas-acquisition USABILITY_SMOKE_HOLD. The PR defines
+a gated Scrapling-aligned acquisition path and selects a tiny JP scope covering
+Stribog, OD Triglav, and SA3/CA candidate families. After maintainer approval
+for a tiny SF6Frames repo-local smoke, #178 used Scrapling to fetch the JP
+specials page and inspect the M Stribog visual reference descriptor.
 
-#178 is not complete: no permission-cleared visual reference was acquired or
-provided, no file type/frame count/resolution/overlay/frame-number state was
-observed, and no preprocessing or comparison-readiness smoke was performed.
-#179 remains blocked for actual visual matching until a permitted repo-external
-visual reference is acquired or a maintainer-approved local visual reference is
-provided and classified as usable, needs-preprocessing, not usable, or
-inconclusive. External visuals remain review support only and are not
-current-fact authority.
+Result: the SF6Frames page and M Stribog asset descriptor were reachable, but
+the fetched WebP was an internal-server-error placeholder rather than a usable
+move visual. It was classified as `not_usable`. No GIF, image, WebP, frame,
+screenshot, raw HTML, raw tool output, direct binary URL, local cache path, or
+private path was committed; the repo-external temp binary and extracted frame
+were deleted.
+
+#178 is complete as a path/usability-boundary smoke, but #179 remains blocked
+for actual visual matching until a corrected permitted SF6Frames asset path or
+maintainer-approved usable local visual reference exists. External visuals
+remain review support only and are not current-fact authority.
 
 ## Resolved Follow-Up Routing
 
@@ -244,14 +245,14 @@ current-fact authority.
 | Combo-trial command prompts were visible but not normalized to canonical move candidates. | #175 | Resolved in #175: a sanitized command-prompt oracle and review-only candidate move mappings were created. Later #176/#177 used the rows for bounded alignment and partial attribution, but exact move order remains unaccepted. |
 | Coarse frame ranges were not aligned with input history, command-prompt rows, action phases, hit events, or damage labels. | #176 | Resolved in #176 as PARTIAL calibration evidence: approximate frame/timestamp windows were recorded where supported and later used by #177. Exact execution remains unresolved. |
 | Visible damage/scaling labels were not mapped to candidate hit/action windows. | #177 | Resolved in #177 as PARTIAL review-only attribution evidence: every loaded visible label is covered as partial or unknown, with no accepted current facts. |
+| External visual atlas acquisition path and usability boundary were missing. | #178 | Resolved in #178 as USABILITY_SMOKE_HOLD: a Scrapling-aligned path was recorded, and one maintainer-approved SF6Frames M Stribog WebP smoke was classified `not_usable` because it resolved to an error placeholder. |
 | Source-derived repo knowledge was not automatically loaded before later video analysis. | #180 | Resolved in #180 / PR #181: `workflows/ingest-video.md` now requires `Loaded Repo Context` before video-analysis calibration, and #174 used that gate. |
 
 ## Next Review Questions
 
 | Residual gap | Follow-up issue | Notes |
 |---|---|---|
-| External visual atlas acquisition usability was not verified. | #178 | #191 defined the acquisition path and selected JP scope, but no permitted visual reference was acquired/provided and no usability smoke was run. #178 should not close from path definition alone. |
-| JP move/action matching against visual references was not attempted. | #179 | Matching still requires a permitted repo-external visual reference or approved local reference plus a usability result. |
+| JP move/action matching against visual references was not attempted. | #179 | #178 proved the current SF6Frames static WebP fetch is `not_usable`; matching requires a corrected permitted asset path or approved local usable reference. |
 | SF6 system-mechanics math reasoning fixtures are missing. | #183 | Should cover combo-scaling arithmetic, insufficient-evidence detection, and current-fact authority boundaries after #177 has stronger attribution examples. |
 
 Open questions that remain after #173:

--- a/knowledge/review/unresolved/raw-video-training-mode-01.review.md
+++ b/knowledge/review/unresolved/raw-video-training-mode-01.review.md
@@ -214,6 +214,24 @@ No accepted current damage, scaling, route, move-order, or frame facts were
 created. #178/#179 remain relevant for visual/action identity, and #183 remains
 relevant for math reasoning fixtures and insufficient-evidence cases.
 
+## 2026-05-15 External Visual Atlas Acquisition Follow-Up
+
+#178 added
+`docs/testing/video-analysis-calibration/external-visual-atlas-acquisition-20260515.md`.
+
+Terminal state: visual-atlas-acquisition PATH_DEFINED. The PR defines a gated
+Scrapling-aligned acquisition path and selects a tiny JP scope covering Stribog,
+OD Triglav, and SA3/CA candidate families. Binary acquisition from SF6Frames is
+held because the existing source evaluation remains `hold_terms_or_permission`;
+no GIF, image, WebP, frame, screenshot, raw HTML, raw tool output, direct binary
+URL, local cache path, or private path was committed.
+
+#179 is partially unblocked: it now has a source-selection path and first JP
+move/action scope, but actual visual matching remains blocked until a permitted
+repo-external visual reference is acquired or a maintainer-approved local visual
+reference is provided. External visuals remain review support only and are not
+current-fact authority.
+
 ## Resolved Follow-Up Routing
 
 | Previously mapped gap | Follow-up issue | Resolution |
@@ -222,14 +240,14 @@ relevant for math reasoning fixtures and insufficient-evidence cases.
 | Combo-trial command prompts were visible but not normalized to canonical move candidates. | #175 | Resolved in #175: a sanitized command-prompt oracle and review-only candidate move mappings were created. Later #176/#177 used the rows for bounded alignment and partial attribution, but exact move order remains unaccepted. |
 | Coarse frame ranges were not aligned with input history, command-prompt rows, action phases, hit events, or damage labels. | #176 | Resolved in #176 as PARTIAL calibration evidence: approximate frame/timestamp windows were recorded where supported and later used by #177. Exact execution remains unresolved. |
 | Visible damage/scaling labels were not mapped to candidate hit/action windows. | #177 | Resolved in #177 as PARTIAL review-only attribution evidence: every loaded visible label is covered as partial or unknown, with no accepted current facts. |
+| External visual atlas acquisition path was missing. | #178 | Resolved in #178 as PATH_DEFINED: a Scrapling-aligned, repo-external acquisition path and JP-small-scope source gate were recorded. Binary acquisition remains held until permission/terms review allows it. |
 | Source-derived repo knowledge was not automatically loaded before later video analysis. | #180 | Resolved in #180 / PR #181: `workflows/ingest-video.md` now requires `Loaded Repo Context` before video-analysis calibration, and #174 used that gate. |
 
 ## Next Review Questions
 
 | Residual gap | Follow-up issue | Notes |
 |---|---|---|
-| External visual atlas acquisition is missing. | #178 | Needed for move/action identification support without committing GIFs/images. |
-| JP move/action matching against visual references was not attempted. | #179 | Depends on gated repo-external visual reference acquisition. |
+| JP move/action matching against visual references was not attempted. | #179 | #178 defined the acquisition path and selected JP scope, but matching still requires a permitted repo-external visual reference or an approved local reference. |
 | SF6 system-mechanics math reasoning fixtures are missing. | #183 | Should cover combo-scaling arithmetic, insufficient-evidence detection, and current-fact authority boundaries after #177 has stronger attribution examples. |
 
 Open questions that remain after #173:

--- a/knowledge/review/unresolved/raw-video-training-mode-01.review.md
+++ b/knowledge/review/unresolved/raw-video-training-mode-01.review.md
@@ -219,17 +219,21 @@ relevant for math reasoning fixtures and insufficient-evidence cases.
 #178 added
 `docs/testing/video-analysis-calibration/external-visual-atlas-acquisition-20260515.md`.
 
-Terminal state: visual-atlas-acquisition PATH_DEFINED. The PR defines a gated
-Scrapling-aligned acquisition path and selects a tiny JP scope covering Stribog,
-OD Triglav, and SA3/CA candidate families. Binary acquisition from SF6Frames is
-held because the existing source evaluation remains `hold_terms_or_permission`;
-no GIF, image, WebP, frame, screenshot, raw HTML, raw tool output, direct binary
-URL, local cache path, or private path was committed.
+Terminal state: visual-atlas-acquisition PATH_DEFINED_ONLY /
+VISUAL_REFERENCE_NOT_ACQUIRED. The PR defines a gated Scrapling-aligned
+acquisition path and selects a tiny JP scope covering Stribog, OD Triglav, and
+SA3/CA candidate families. Binary acquisition from SF6Frames is held because
+the existing source evaluation remains `hold_terms_or_permission`; no GIF,
+image, WebP, frame, screenshot, raw HTML, raw tool output, direct binary URL,
+local cache path, or private path was committed.
 
-#179 is partially unblocked: it now has a source-selection path and first JP
-move/action scope, but actual visual matching remains blocked until a permitted
-repo-external visual reference is acquired or a maintainer-approved local visual
-reference is provided. External visuals remain review support only and are not
+#178 is not complete: no permission-cleared visual reference was acquired or
+provided, no file type/frame count/resolution/overlay/frame-number state was
+observed, and no preprocessing or comparison-readiness smoke was performed.
+#179 remains blocked for actual visual matching until a permitted repo-external
+visual reference is acquired or a maintainer-approved local visual reference is
+provided and classified as usable, needs-preprocessing, not usable, or
+inconclusive. External visuals remain review support only and are not
 current-fact authority.
 
 ## Resolved Follow-Up Routing
@@ -240,14 +244,14 @@ current-fact authority.
 | Combo-trial command prompts were visible but not normalized to canonical move candidates. | #175 | Resolved in #175: a sanitized command-prompt oracle and review-only candidate move mappings were created. Later #176/#177 used the rows for bounded alignment and partial attribution, but exact move order remains unaccepted. |
 | Coarse frame ranges were not aligned with input history, command-prompt rows, action phases, hit events, or damage labels. | #176 | Resolved in #176 as PARTIAL calibration evidence: approximate frame/timestamp windows were recorded where supported and later used by #177. Exact execution remains unresolved. |
 | Visible damage/scaling labels were not mapped to candidate hit/action windows. | #177 | Resolved in #177 as PARTIAL review-only attribution evidence: every loaded visible label is covered as partial or unknown, with no accepted current facts. |
-| External visual atlas acquisition path was missing. | #178 | Resolved in #178 as PATH_DEFINED: a Scrapling-aligned, repo-external acquisition path and JP-small-scope source gate were recorded. Binary acquisition remains held until permission/terms review allows it. |
 | Source-derived repo knowledge was not automatically loaded before later video analysis. | #180 | Resolved in #180 / PR #181: `workflows/ingest-video.md` now requires `Loaded Repo Context` before video-analysis calibration, and #174 used that gate. |
 
 ## Next Review Questions
 
 | Residual gap | Follow-up issue | Notes |
 |---|---|---|
-| JP move/action matching against visual references was not attempted. | #179 | #178 defined the acquisition path and selected JP scope, but matching still requires a permitted repo-external visual reference or an approved local reference. |
+| External visual atlas acquisition usability was not verified. | #178 | #191 defined the acquisition path and selected JP scope, but no permitted visual reference was acquired/provided and no usability smoke was run. #178 should not close from path definition alone. |
+| JP move/action matching against visual references was not attempted. | #179 | Matching still requires a permitted repo-external visual reference or approved local reference plus a usability result. |
 | SF6 system-mechanics math reasoning fixtures are missing. | #183 | Should cover combo-scaling arithmetic, insufficient-evidence detection, and current-fact authority boundaries after #177 has stronger attribution examples. |
 
 Open questions that remain after #173:

--- a/knowledge/review/unresolved/raw-video-training-mode-01.review.md
+++ b/knowledge/review/unresolved/raw-video-training-mode-01.review.md
@@ -219,23 +219,28 @@ relevant for math reasoning fixtures and insufficient-evidence cases.
 #178 added
 `docs/testing/video-analysis-calibration/external-visual-atlas-acquisition-20260515.md`.
 
-Terminal state: visual-atlas-acquisition USABILITY_SMOKE_COMPLETED_NOT_USABLE. The PR defines
-a gated Scrapling-aligned acquisition path and selects a tiny JP scope covering
+Terminal state: visual-atlas-acquisition
+USABILITY_SMOKE_PARTIAL_NEEDS_PREPROCESSING. The PR defines a gated
+Scrapling-aligned acquisition path and selects a tiny JP scope covering
 Stribog, OD Triglav, and SA3/CA candidate families. After maintainer approval
 for a tiny SF6Frames repo-local smoke, #178 used Scrapling to fetch the JP
-specials page and inspect the M Stribog visual reference descriptor.
+specials page and inspect M Stribog visual reference descriptors.
 
-Result: the SF6Frames page and M Stribog asset descriptor were reachable, but
-the fetched WebP was an internal-server-error placeholder rather than a usable
-move visual. It was classified as `not_usable`. No GIF, image, WebP, frame,
+Result: the first direct descriptor was reachable but produced an
+internal-server-error placeholder. The second iteration followed the page's
+encoded animation descriptor path and acquired an actual M Stribog animated
+WebP in repo-external scratch. It was classified as `needs_preprocessing`: #179
+must re-acquire it repo-externally, extract frames, normalize crop/scale and
+source-frame indexing, and account for hitbox/hurtbox overlays, frame numbers,
+stage background, and watermark before matching. No GIF, image, WebP, frame,
 screenshot, raw HTML, raw tool output, direct binary URL, local cache path, or
-private path was committed; the repo-external temp binary and extracted frame
+private path was committed; the repo-external temp binaries and sampled frames
 were deleted.
 
-#178 is complete as a path/usability-boundary smoke, but #179 remains blocked
-for actual visual matching until a corrected permitted SF6Frames asset path or
-maintainer-approved usable local visual reference exists. External visuals
-remain review support only and are not current-fact authority.
+#178 is complete as a usable/preprocessable acquisition smoke. #179 is
+partially unblocked, but actual visual matching still requires repo-external
+re-acquisition and preprocessing. External visuals remain review support only
+and are not current-fact authority.
 
 ## Resolved Follow-Up Routing
 
@@ -245,14 +250,14 @@ remain review support only and are not current-fact authority.
 | Combo-trial command prompts were visible but not normalized to canonical move candidates. | #175 | Resolved in #175: a sanitized command-prompt oracle and review-only candidate move mappings were created. Later #176/#177 used the rows for bounded alignment and partial attribution, but exact move order remains unaccepted. |
 | Coarse frame ranges were not aligned with input history, command-prompt rows, action phases, hit events, or damage labels. | #176 | Resolved in #176 as PARTIAL calibration evidence: approximate frame/timestamp windows were recorded where supported and later used by #177. Exact execution remains unresolved. |
 | Visible damage/scaling labels were not mapped to candidate hit/action windows. | #177 | Resolved in #177 as PARTIAL review-only attribution evidence: every loaded visible label is covered as partial or unknown, with no accepted current facts. |
-| External visual atlas acquisition path and usability boundary were missing. | #178 | Resolved in #178 as USABILITY_SMOKE_COMPLETED_NOT_USABLE: a Scrapling-aligned path was recorded, and one maintainer-approved SF6Frames M Stribog WebP smoke completed with `not_usable` result because it resolved to an error placeholder. |
+| External visual atlas acquisition path and usability boundary were missing. | #178 | Resolved in #178 as USABILITY_SMOKE_PARTIAL_NEEDS_PREPROCESSING: a Scrapling-aligned path was recorded, a failing direct-descriptor placeholder was preserved as failure evidence, and a second encoded-descriptor iteration acquired an actual M Stribog animated WebP that #179 can re-acquire and preprocess repo-externally. |
 | Source-derived repo knowledge was not automatically loaded before later video analysis. | #180 | Resolved in #180 / PR #181: `workflows/ingest-video.md` now requires `Loaded Repo Context` before video-analysis calibration, and #174 used that gate. |
 
 ## Next Review Questions
 
 | Residual gap | Follow-up issue | Notes |
 |---|---|---|
-| JP move/action matching against visual references was not attempted. | #179 | #178 proved the current SF6Frames static WebP fetch is `not_usable`; matching requires a corrected permitted asset path or approved local usable reference. |
+| JP move/action matching against visual references was not attempted. | #179 | #178 proved one SF6Frames M Stribog visual reference is preprocessable, but #179 must re-acquire it repo-externally, preprocess it, and keep any matching review-only. OD Triglav and SA3/CA visual acquisition remain untested. |
 | SF6 system-mechanics math reasoning fixtures are missing. | #183 | Should cover combo-scaling arithmetic, insufficient-evidence detection, and current-fact authority boundaries after #177 has stronger attribution examples. |
 
 Open questions that remain after #173:

--- a/workflows/ingest-video.md
+++ b/workflows/ingest-video.md
@@ -238,7 +238,16 @@ For external visual atlas acquisition:
 7. Commit metadata/report only. Existing external visual references remain
    review-only support and cannot authorize exact move identity, current facts,
    or `official_raw` changes.
-8. Route visual comparison and usefulness evaluation to a later matching task.
+8. After a permitted acquisition or approved local reference inspection, record
+   whether the visual reference is `usable_as_is`, `needs_preprocessing`,
+   `not_usable`, or `inconclusive`. Also record preprocessing needs such as
+   frame extraction, resizing, cropping, alpha/background handling, playback
+   normalization, overlay separation, or frame-index normalization.
+9. Path definition alone is not matching readiness. If no permitted visual
+   reference was inspected, keep acquisition incomplete and route the later
+   matching task to HOLD until usability is established.
+10. Route visual comparison and usefulness evaluation to a later matching task
+   only after the visual-reference input and usability boundary are recorded.
 
 ## Track Guidance
 

--- a/workflows/ingest-video.md
+++ b/workflows/ingest-video.md
@@ -248,7 +248,7 @@ For external visual atlas acquisition:
    container by itself is not enough.
 10. Path definition alone is not matching readiness. If no permitted visual
    reference was inspected, or if the inspected visual is `not_usable`, route
-   the later matching task to HOLD until usability is established.
+   the later matching task as blocked until usability is established.
 11. Route visual comparison and usefulness evaluation to a later matching task
    only after the visual-reference input and usability boundary are recorded.
 

--- a/workflows/ingest-video.md
+++ b/workflows/ingest-video.md
@@ -212,6 +212,34 @@ For damage/scaling attribution:
    unresolved arithmetic or authority-boundary reasoning to evaluation fixtures
    or follow-up issues.
 
+### External Visual Atlas Acquisition For Calibration
+
+Use external visual atlas acquisition only as calibration support when prior
+video-analysis reports show unresolved move/action identity and a later matching
+task needs visual references.
+
+For external visual atlas acquisition:
+
+1. Load relevant repo context first, including same-sample calibration reports,
+   source review notes, character move registry, external-frame-atlas source
+   evaluation records, media scratch/cache policy, and the existing
+   `ingest/frame_data` Scrapling fetch setup.
+2. Select a tiny scope: one source, one character, and one to three
+   move/action candidate families.
+3. Check source evaluation status before any network or binary work. If terms,
+   robots, permission, rate limits, or asset stability are unresolved, record a
+   HOLD before acquisition.
+4. Align any future acquisition with `ingest/frame_data` discipline: config
+   driven, no-auth/no-cookie boundary, challenge detection, metadata-first
+   reporting, and repo-external scratch/cache only.
+5. Do not require live external fetch in CI or public answer flows.
+6. Do not commit GIFs, images, WebPs, frames, screenshots, contact sheets, raw
+   HTML, raw tool output, cache paths, credentials, cookies, or private paths.
+7. Commit metadata/report only. Existing external visual references remain
+   review-only support and cannot authorize exact move identity, current facts,
+   or `official_raw` changes.
+8. Route visual comparison and usefulness evaluation to a later matching task.
+
 ## Track Guidance
 
 Use these tracks from the video observation contract:

--- a/workflows/ingest-video.md
+++ b/workflows/ingest-video.md
@@ -228,7 +228,8 @@ For external visual atlas acquisition:
    move/action candidate families.
 3. Check source evaluation status before any network or binary work. If terms,
    robots, permission, rate limits, or asset stability are unresolved, record a
-   HOLD before acquisition.
+   HOLD before acquisition unless the issue explicitly grants a tiny
+   maintainer-local smoke.
 4. Align any future acquisition with `ingest/frame_data` discipline: config
    driven, no-auth/no-cookie boundary, challenge detection, metadata-first
    reporting, and repo-external scratch/cache only.
@@ -247,10 +248,12 @@ For external visual atlas acquisition:
    placeholder, unsupported payload, or unrelated source asset. A valid image
    container by itself is not enough.
 10. Path definition alone is not matching readiness. If no permitted visual
-   reference was inspected, or if the inspected visual is `not_usable`, route
-   the later matching task as blocked until usability is established.
+   reference was inspected, or if the inspected visual is `not_usable`, continue
+   the acquisition loop or leave the source issue open; do not claim readiness
+   for matching.
 11. Route visual comparison and usefulness evaluation to a later matching task
-   only after the visual-reference input and usability boundary are recorded.
+   only after the visual-reference input is `usable_as_is` or
+   `needs_preprocessing`, and the preprocessing boundary is recorded.
 
 ## Track Guidance
 

--- a/workflows/ingest-video.md
+++ b/workflows/ingest-video.md
@@ -243,10 +243,13 @@ For external visual atlas acquisition:
    `not_usable`, or `inconclusive`. Also record preprocessing needs such as
    frame extraction, resizing, cropping, alpha/background handling, playback
    normalization, overlay separation, or frame-index normalization.
-9. Path definition alone is not matching readiness. If no permitted visual
-   reference was inspected, keep acquisition incomplete and route the later
-   matching task to HOLD until usability is established.
-10. Route visual comparison and usefulness evaluation to a later matching task
+9. Verify that the fetched asset is an actual move visual, not an error
+   placeholder, unsupported payload, or unrelated source asset. A valid image
+   container by itself is not enough.
+10. Path definition alone is not matching readiness. If no permitted visual
+   reference was inspected, or if the inspected visual is `not_usable`, route
+   the later matching task to HOLD until usability is established.
+11. Route visual comparison and usefulness evaluation to a later matching task
    only after the visual-reference input and usability boundary are recorded.
 
 ## Track Guidance


### PR DESCRIPTION
## Summary
- Reviewed existing Scrapling/frame-data ingestion setup and external-frame-atlas policy surfaces.
- Defined a gated external visual atlas acquisition path for move-analysis calibration.
- Selected a tiny JP scope covering Stribog, OD Triglav, and SA3/CA candidate families.
- Used Scrapling, aligned with `ingest/frame_data`, for maintainer-approved SF6Frames M Stribog usability smoke iterations.
- Preserved the first direct-descriptor failure: the direct `data-animation-src` path produced an internal-server-error placeholder.
- Continued the loop using the SF6Frames page encoded animation descriptor path and acquired an actual M Stribog animated WebP in repo-external scratch.
- Classified the visual reference as `needs_preprocessing`; no external binary assets were committed.

## Scope
- Implements #178 only.
- References #155 and #158.
- Does not implement #179 or #183.
- Does not add raw GIFs/images/WebPs/frames/screenshots/contact sheets/raw HTML/private paths/generated references/public runtime behavior/current facts.
- Does not change `official_raw`.

## Loaded Repo Context
Loaded prior raw-video calibration reports (#175/#176/#177), `raw-video-training-mode-01.review.md`, JP move registry, external-frame-atlas policy/evaluation artifacts, media scratch/cache policy, `workflows/ingest-video.md`, and existing `ingest/frame_data` Scrapling setup. These artifacts guided source selection, storage boundaries, and tiny JP scope selection; none authorize current facts, move identity, or public answer behavior.

## Acquisition Result
- Selected source: SF6Frames as first path candidate, with maintainer-approved local-only smoke permission.
- JP scope: M Stribog smoke, with OD Triglav and SA3/CA held as later candidate families.
- Acquisition method: Scrapling `fetch_with_profile` using static `Fetcher`; no auth/cookies; repo-external temp only.
- Iteration 1: JP specials page fetched and M Stribog direct descriptor found; direct WebP response was a 350x280 error placeholder and `not_usable`.
- Iteration 2: page encoded animation descriptor was decoded in repo-external scratch and fetched through the same Scrapling-aligned path.
- Positive smoke result: actual M Stribog animated WebP observed, 1,604,726 bytes, 750x573, 53 frames, hitbox/hurtbox overlay and frame numbers visible.
- Usability result: `needs_preprocessing`; #179 must re-acquire repo-externally, extract frames, normalize crop/scale/source-frame indexing, and account for overlays/frame numbers/watermark before matching.
- Cleanup: repo-external WebP responses and sampled inspection frames deleted; no binaries/raw HTML/direct binary URLs/private paths committed.
- #179 readiness: partially ready for preprocessing and review-only matching setup, not ready to claim move identity.

## Reusable Method
Updated `docs/testing/video-analysis-calibration/external-visual-atlas-acquisition-20260515.md` with the iterative usability loop and next-agent checklist. Updated `workflows/ingest-video.md` so path definition or `not_usable` results are not treated as matching readiness; matching routes forward only after `usable_as_is` or `needs_preprocessing` is recorded.

## Terminal State
- visual-atlas-acquisition USABILITY_SMOKE_PARTIAL_NEEDS_PREPROCESSING
- metadata/report only
- no binary committed
- no current-fact authority
- #178 complete as a usable/preprocessable acquisition smoke
- #179 partially unblocked, but preprocessing and review-only matching remain future work

## Follow-up Routing
- #179: JP move/action visual-reference matching after repo-external re-acquisition and preprocessing; visual similarity remains review-only.
- #183: still relevant for SF6 math reasoning and insufficient-evidence fixtures.

## Validation
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-no-video-binary-assets.ps1`: No video binary assets OK
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-video-artifacts.ps1`: Video artifacts OK
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-external-frame-atlas-source-evaluation.ps1`: External frame-atlas source evaluation OK
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-external-frame-atlas-source-fixtures.ps1`: External frame-atlas source fixtures OK
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1`: V2 validation suite OK
- `git diff --check`: PASS
- `git diff --check origin/main...HEAD`: PASS
- raw/local-state scan: changed files are 3 text artifacts only; no GIF/image/WebP/video/frame/screenshot/contact sheet/raw HTML/raw OCR/raw tool output/raw Hermes output/local state/private path/credentials/cookies/secrets/external binary assets/direct binary URLs added.
- generated-surface residual diff check: PowerShell emitted git-unavailable warnings during generated-surface checks; generated residual diffs were verified from git-visible shell and restored. Final local changes before commit were only the 3 intended text artifacts.

Closes #178
References #155
References #158
