### PR TITLE
Define Hermes-first Codex orchestration loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,10 +66,12 @@
 
 - Repo implementation is Codex-first for issue-scoped PRs, validators, contracts, docs, packaging changes, and GitHub workflow operations.
 - Hermes is the repo-local growth engine for repeated knowledge-growth and maintainer-growth workflows when a configured maintainer profile is available.
-- Codex may delegate suitable source analysis, claim decomposition, observation drafting, review drafting, smoke drafting, workflow learning, validator-pattern learning, and procedural skill self-improvement tasks to Hermes.
+- For analysis, review, and growth tasks in scope for Hermes, Codex is the Hermes operator and boundary auditor rather than the primary analyst when a configured Hermes maintainer profile is available.
+- Codex should delegate primary object-level analysis such as source analysis, claim decomposition, observation drafting, review drafting, architecture review drafting, workflow learning, validator-pattern learning, and procedural skill self-improvement to Hermes when configured.
+- Codex-only analysis for Hermes-first tasks is fallback behavior and must record why Hermes delegation was not attempted or could not complete.
 - Hermes memory, sessions, local skills, Curator output, Kanban workers, and checkpoints are non-canonical until promoted through reviewed repository artifacts.
 - End users do not need Hermes; `skills/sf6-agent/` remains the public answer adapter.
-- See `docs/architecture/hermes-v2.1-roadmap.md`.
+- See `docs/architecture/hermes-v2.1-roadmap.md`, `docs/architecture/codex-hermes-bridge-policy.md`, and `workflows/codex-to-hermes-delegation.md`.
 
 ## Workflow Rules
 

--- a/docs/architecture/codex-hermes-bridge-policy.md
+++ b/docs/architecture/codex-hermes-bridge-policy.md
@@ -8,14 +8,67 @@ Codex remains the repo implementation entrypoint for issue-scoped PRs,
 validators, contracts, docs, packaging changes, and GitHub workflow
 operations.
 
-Hermes may be used as a repo-local growth delegate when a configured
-maintainer profile is available. Hermes can help with bounded draft and review
-work, but Hermes output remains draft input until converted into reviewed repo
-artifacts.
+Hermes is the primary repo-local analyst and growth orchestrator for in-scope
+analysis, review, and maintainer-growth tasks when a configured maintainer
+profile is available. Hermes output remains draft input until converted into
+reviewed repo artifacts.
 
 Codex needs repo-local skill and playbook guidance to use Hermes safely. That
 guidance is maintainer-only support. It is not public answer distribution and
 it does not change public `sf6-agent` behavior.
+
+## Hermes-First Analysis Loop
+
+When Hermes is configured, available, and the task is in scope for analysis,
+review, or growth delegation, Codex must not perform the primary object-level
+analysis itself. Codex acts as the maintainer proxy and Hermes operator.
+
+In-scope Hermes-first work includes:
+
+- architecture review drafts
+- directory or source-surface audit drafts
+- source analysis and source summary drafts
+- claim decomposition and observation draft shaping
+- review note and review checklist drafting
+- workflow improvement proposals
+- validator-pattern proposals
+- knowledge-growth and maintainer-growth planning
+- procedural skill self-improvement review
+
+Codex's role in this loop is:
+
+- scope controller
+- Hermes delegation request author
+- Hermes operator on behalf of the maintainer
+- boundary auditor
+- artifact converter
+- validator, diff, GitHub, and PR executor
+- user handoff surface
+
+Hermes's role is:
+
+- primary analyst
+- repo-local orchestrator
+- self-improvement reviewer
+- provider task planner
+- integrator of provider outputs and uncertainty
+
+Hermes may use provider Codex as an executor for file reading, diff drafting,
+validator execution, report skeletons, and other bounded implementation tasks.
+Provider Codex output remains under Hermes orchestration and must not replace
+Hermes as the analysis or decision authority.
+
+Hermes output is non-canonical, but for delegated analysis tasks it is the
+primary draft input. Codex must review that draft against repo boundaries and
+convert only in-scope, supported material into repo artifacts.
+
+Codex-only analysis for Hermes-first work is fallback behavior. It is allowed
+only when Hermes is unavailable or unconfigured, the required Hermes capability
+is unavailable or unverified, the target issue explicitly requests Codex-only
+analysis, the task contains material that must not be passed to Hermes, or the
+task is a narrow implementation/validation step rather than object-level
+analysis. The fallback reason must be recorded in the PR body, issue comment,
+or review artifact.
 
 ## Surface Decision
 
@@ -84,7 +137,10 @@ Future `AGENTS.md` updates should stay minimal.
 `AGENTS.md` should preserve high-level invariants:
 
 - Codex remains the repo implementation entrypoint.
-- Hermes is optional repo-local growth delegation support when configured.
+- Hermes-first analysis applies to in-scope analysis, review, and growth tasks
+  when configured.
+- Codex is the Hermes operator and boundary auditor for those tasks.
+- Codex-only analysis for Hermes-first tasks is recorded fallback behavior.
 - `skills/sf6-agent/` remains the public answer adapter.
 - Hermes local state is non-canonical.
 - Repo artifacts and validators remain authoritative.
@@ -112,7 +168,8 @@ capability, but it is not a public `sf6-agent` requirement.
 ## Tool Selection Policy
 
 Codex-Hermes bridge work must not select a tool only because it is built into
-Hermes.
+Hermes. Hermes-first analysis is about analysis ownership and orchestration,
+not about making every Hermes-native tool authoritative.
 
 For article, video, validation, and review workflows, Codex should choose the
 method that best fits the target issue, expected evidence quality,
@@ -151,7 +208,9 @@ explicitly re-reviews a narrow idea under current contracts and validators.
 
 ## Canonical Boundary
 
-Hermes output is draft input.
+Hermes output is draft input. For Hermes-first delegated analysis, it is the
+primary draft input, not a canonical artifact and not a source of truth by
+itself.
 
 Hermes memory, sessions, local skills, Curator output, browser state, cron
 state, Kanban state, checkpoints, local configs, logs, caches, credentials,

--- a/docs/architecture/codex-hermes-bridge-policy.md
+++ b/docs/architecture/codex-hermes-bridge-policy.md
@@ -2,7 +2,8 @@
 
 ## Purpose
 
-This document defines the repo-local Codex-Hermes bridge policy for v2.3.
+This document defines the repo-local Codex-Hermes bridge policy, including the
+Hermes-first analysis loop.
 
 Codex remains the repo implementation entrypoint for issue-scoped PRs,
 validators, contracts, docs, packaging changes, and GitHub workflow
@@ -95,8 +96,8 @@ A Codex skill or playbook teaches Codex repo-specific maintainer procedures.
 
 It may help Codex:
 
-- decide whether Hermes delegation is appropriate
 - prepare a bounded Hermes delegation request
+- identify whether a documented fallback condition applies
 - review Hermes output against repo authority boundaries
 - preserve issue scope, validators, PR review, and handoff requirements
 
@@ -227,9 +228,7 @@ reviewed and merged into the appropriate repo-local surfaces.
 
 ## Non-Goals For This Policy
 
-This policy does not add the `packs/codex-hermes-sf6/` skeleton, Codex skill
-files, Hermes CLI capability reference, dry-run delegation fixtures, plugin or
-gateway planning, live Hermes execution, runtime config, Hermes operational
-prompts, public `sf6-agent` behavior changes, generated outputs,
+This policy does not add live Hermes execution, runtime config, Hermes
+operational prompts, public `sf6-agent` behavior changes, generated outputs,
 frame-current assets, normalization assets, historical smoke report rewrites,
 or stale PR imports.

--- a/docs/architecture/decisions/0001-hermes-primary-orchestration.md
+++ b/docs/architecture/decisions/0001-hermes-primary-orchestration.md
@@ -53,6 +53,12 @@ Hermes memory, sessions, profile state, browser state, cron state, local managed
 
 Codex, humans, or other agents may still execute the same canonical workflows as fallback executors when Hermes is unavailable or unconfigured.
 
+For in-scope analysis, review, and growth work, fallback execution means
+Codex, humans, or other agents may operate the workflow when Hermes is
+unavailable, unconfigured, explicitly out of scope, or unsafe for the material.
+It does not make Codex the default primary analyst when a configured Hermes
+profile can perform the delegated analysis.
+
 ## Repo Artifact Outputs
 
 Hermes-assisted work must produce reusable output as repository artifacts, such as:

--- a/packs/codex-hermes-sf6/resources/codex-to-hermes-request-template.md
+++ b/packs/codex-hermes-sf6/resources/codex-to-hermes-request-template.md
@@ -7,7 +7,7 @@ primary draft input.
 ```yaml
 analysis_mode: hermes_primary
 target_issue:
-scope_summary:
+target_scope_summary:
 codex_app_role:
   - hermes_operator
   - boundary_auditor
@@ -30,7 +30,8 @@ review_checklist:
 ## Field Guidance
 
 - `target_issue`: the GitHub issue controlling scope and acceptance.
-- `scope_summary`: a short restatement of scope, non-goals, and acceptance.
+- `target_scope_summary`: a short restatement of scope, non-goals, and
+  acceptance.
 - `analysis_mode`: usually `hermes_primary`; use `codex_fallback` only when
   Hermes is unavailable, unconfigured, explicitly out of scope, or unsafe for
   the material.

--- a/packs/codex-hermes-sf6/resources/codex-to-hermes-request-template.md
+++ b/packs/codex-hermes-sf6/resources/codex-to-hermes-request-template.md
@@ -1,11 +1,23 @@
 # Codex-To-Hermes Request Template
 
 Use this concise template when the target issue allows Hermes delegation.
-Hermes output is draft input only.
+Hermes output is draft input only. For Hermes-first analysis, it is the
+primary draft input.
 
 ```yaml
+analysis_mode: hermes_primary
 target_issue:
 scope_summary:
+codex_app_role:
+  - hermes_operator
+  - boundary_auditor
+  - artifact_converter
+  - validator_executor
+hermes_role:
+  - primary_analyst
+  - orchestrator
+provider_codex_role:
+  - executor
 source_material:
 requested_artifact_type:
 allowed_outputs:
@@ -19,6 +31,16 @@ review_checklist:
 
 - `target_issue`: the GitHub issue controlling scope and acceptance.
 - `scope_summary`: a short restatement of scope, non-goals, and acceptance.
+- `analysis_mode`: usually `hermes_primary`; use `codex_fallback` only when
+  Hermes is unavailable, unconfigured, explicitly out of scope, or unsafe for
+  the material.
+- `codex_app_role`: Windows Codex app responsibilities. It operates Hermes,
+  audits boundaries, converts artifacts, runs validators, and reports to the
+  maintainer.
+- `hermes_role`: Hermes responsibilities. Hermes performs primary analysis,
+  orchestration, uncertainty integration, and self-improvement review.
+- `provider_codex_role`: provider Codex responsibilities when Hermes uses it.
+  Provider Codex is an executor, not the final analyst.
 - `source_material`: repo artifacts, links, notes, article/video references,
   or other input. Source material is not automatically canonical.
 - `requested_artifact_type`: draft note, candidate observation, review
@@ -30,6 +52,16 @@ review_checklist:
   and public adapter boundaries that apply.
 - `validators_to_run`: repo validators Codex must run before commit.
 - `review_checklist`: checks Codex must perform before using the draft.
+
+Use this fallback shape only when Hermes-first analysis cannot be used:
+
+```yaml
+analysis_mode: codex_fallback
+hermes_delegation:
+  attempted: false
+  reason:
+debt: hermes_first_analysis_not_validated_for_this_workflow
+```
 
 Reference `workflows/codex-to-hermes-delegation.md` for the canonical
 delegation workflow.

--- a/packs/codex-hermes-sf6/resources/hermes-response-review-checklist.md
+++ b/packs/codex-hermes-sf6/resources/hermes-response-review-checklist.md
@@ -3,6 +3,9 @@
 Use this checklist before converting Hermes output into repo artifacts.
 
 - Hermes output is draft input.
+- For Hermes-first analysis, Hermes output is the primary draft input.
+- Codex did not replace Hermes as primary analyst unless fallback is recorded.
+- Provider Codex, if used by Hermes, remained a bounded executor.
 - Source refs are not canonical evidence by themselves.
 - Candidate claims or observations must identify uncertainty and review
   status.

--- a/packs/codex-hermes-sf6/skill/SKILL.md
+++ b/packs/codex-hermes-sf6/skill/SKILL.md
@@ -11,16 +11,20 @@ behavior.
 
 ## When To Use
 
-Use this playbook when issue scope allows Codex to delegate bounded draft or
-review work to Hermes, such as:
+Use this playbook when issue scope allows Hermes-first analysis or when Codex
+needs to delegate bounded draft or review work to Hermes, such as:
 
 - source analysis drafts
 - claim or observation draft shaping
+- architecture review or directory audit drafts
 - validator-pattern proposals
 - review checklist drafting
 - maintainer workflow improvement proposals
 
-Codex remains the repo implementation entrypoint.
+Codex remains the repo implementation entrypoint. When Hermes is configured
+and the task is in scope for Hermes-first analysis, Codex is the Hermes
+operator, boundary auditor, artifact converter, validator runner, and PR
+executor. Codex must not replace Hermes as the primary object-level analyst.
 
 ## When Not To Use
 
@@ -40,7 +44,7 @@ Do not use this playbook to:
 1. Read the target issue and restate scope, non-goals, and acceptance.
 2. Follow `workflows/maintainer-agent-session.md`.
 3. Use `workflows/codex-to-hermes-delegation.md` for request and response
-   shape when delegation is appropriate.
+   shape when Hermes-first analysis or delegation is appropriate.
 4. Check `docs/architecture/codex-hermes-bridge-policy.md` before deciding
    whether Hermes delegation fits.
 5. Check `docs/architecture/hermes-cli-capability-reference.md` for reviewed
@@ -51,11 +55,18 @@ Do not use this playbook to:
    `docs/architecture/external-frame-atlas-policy.md`.
 8. Convert useful Hermes output into reviewed repo artifacts only when the
    target issue scope allows it.
-9. Run the relevant validators and record results before commit.
+9. If Codex fallback analysis is used, record why Hermes-first delegation was
+   not attempted or could not complete.
+10. Run the relevant validators and record results before commit.
 
 ## Review Checklist
 
 - Hermes output remains draft input.
+- For Hermes-first analysis, Hermes output is the primary draft input.
+- Codex did not perform primary object-level analysis unless a fallback reason
+  is recorded.
+- Provider Codex, when used by Hermes, remained an executor and did not become
+  the final analyst.
 - Source references are review inputs, not canonical evidence by themselves.
 - Exact current facts remain grounded in current-fact authority surfaces.
 - Web, article, video, and external visual atlas inputs do not override

--- a/packs/codex-hermes-sf6/skill/SKILL.md
+++ b/packs/codex-hermes-sf6/skill/SKILL.md
@@ -45,8 +45,8 @@ Do not use this playbook to:
 2. Follow `workflows/maintainer-agent-session.md`.
 3. Use `workflows/codex-to-hermes-delegation.md` for request and response
    shape when Hermes-first analysis or delegation is appropriate.
-4. Check `docs/architecture/codex-hermes-bridge-policy.md` before deciding
-   whether Hermes delegation fits.
+4. Check `docs/architecture/codex-hermes-bridge-policy.md` to confirm
+   Hermes-first delegation applies or to record a documented fallback reason.
 5. Check `docs/architecture/hermes-cli-capability-reference.md` for reviewed
    Hermes capability status. Do not invent command requirements.
 6. For video work, check

--- a/tests/fixtures/codex-hermes-delegation/hermes-first-orchestration-loop.json
+++ b/tests/fixtures/codex-hermes-delegation/hermes-first-orchestration-loop.json
@@ -1,0 +1,142 @@
+{
+  "schema_version": "codex-hermes-delegation-fixture/v1",
+  "scenario_id": "hermes-first-orchestration-loop",
+  "scenario_kind": "hermes_first_orchestration",
+  "codex_request": {
+    "analysis_mode": "hermes_primary",
+    "target_issue": "#199",
+    "target_scope_summary": "Validate the Windows Codex app / Hermes / provider Codex orchestration shape for an architecture review draft without treating Codex app output as primary analysis.",
+    "codex_app_role": [
+      "windows codex app",
+      "human proxy",
+      "hermes operator",
+      "boundary auditor",
+      "artifact converter",
+      "validator executor",
+      "user handoff"
+    ],
+    "hermes_role": [
+      "primary analyst",
+      "orchestrator",
+      "self-improvement reviewer",
+      "provider Codex task planner"
+    ],
+    "provider_codex_role": [
+      "executor",
+      "file reader",
+      "diff builder",
+      "validator runner",
+      "artifact drafter under Hermes instruction"
+    ],
+    "source_material": [
+      {
+        "source_kind": "repo_artifact",
+        "source_role": "reviewed_policy",
+        "ref": "docs/architecture/codex-hermes-bridge-policy.md"
+      },
+      {
+        "source_kind": "repo_artifact",
+        "source_role": "workflow",
+        "ref": "workflows/codex-to-hermes-delegation.md"
+      }
+    ],
+    "requested_artifact_type": "architecture review draft",
+    "allowed_outputs": [
+      "primary draft analysis from Hermes",
+      "provider Codex task summary",
+      "self_improvement_notes",
+      "boundary_notes",
+      "follow_up_recommendations"
+    ],
+    "forbidden_outputs": [
+      "Windows Codex app primary object-level analysis",
+      "provider Codex final architecture decision",
+      "canonical promotion without repo artifact review",
+      "current fact promotion",
+      "Hermes local state",
+      "public sf6-agent behavior"
+    ],
+    "authority_boundaries": [
+      "Hermes output is primary draft input for delegated analysis, not canonical evidence",
+      "Windows Codex app operates Hermes and audits boundaries",
+      "provider Codex is an executor under Hermes instruction",
+      "codex_fallback requires a recorded reason",
+      "exact current facts remain grounded in data exports, roster data, and packaged official_raw"
+    ],
+    "validators_to_run": [
+      "tests/validation/validate-codex-hermes-delegation-fixtures.ps1",
+      "tests/validation/validate-codex-hermes-pack.ps1",
+      "tests/validation/validate-architecture-markers.ps1",
+      "tests/validation/run-all.ps1"
+    ],
+    "review_checklist": [
+      "confirm analysis_mode is hermes_primary or codex_fallback has a reason",
+      "confirm Windows Codex app did not replace Hermes as primary analyst",
+      "confirm provider Codex remained a bounded executor",
+      "confirm Hermes output is treated as primary draft input only",
+      "confirm no current facts or public adapter behavior are promoted"
+    ]
+  },
+  "hermes_draft_response": {
+    "analysis_executor": "hermes_primary",
+    "summary": "The requested architecture review draft should be produced by Hermes as primary analyst, with Windows Codex app acting as Hermes operator and boundary auditor.",
+    "proposed_artifacts": [
+      "architecture review draft",
+      "policy patch proposal",
+      "self-improvement notes for future Hermes-first requests"
+    ],
+    "source_refs": [
+      "docs/architecture/codex-hermes-bridge-policy.md",
+      "workflows/codex-to-hermes-delegation.md"
+    ],
+    "evidence_candidate_notes": [
+      "The orchestration loop separates Windows Codex app from provider Codex.",
+      "Provider Codex can read files, draft diffs, and run validators under Hermes instruction.",
+      "Hermes integrates provider Codex results and remains the primary analyst."
+    ],
+    "uncertainty_or_hold_reasons": [
+      "This is a dry-run fixture and not an executed Hermes session.",
+      "Live Hermes capability remains maintainer-environment dependent."
+    ],
+    "boundary_notes": [
+      "Hermes output is primary draft input only.",
+      "Codex fallback analysis requires a recorded reason.",
+      "No current facts are promoted.",
+      "No public sf6-agent behavior changes."
+    ],
+    "follow_up_recommendations": [
+      "Use this fixture to validate Hermes-first request and response metadata.",
+      "Record provider Codex outputs used or rejected in future executed reports."
+    ],
+    "self_improvement_notes": [
+      "Future Hermes requests should include role separation and fallback fields."
+    ],
+    "provider_codex_tasks": [
+      "list target policy files",
+      "draft scoped documentation changes",
+      "run focused validators"
+    ],
+    "provider_codex_outputs_used": [
+      "file inventory",
+      "validator output"
+    ],
+    "provider_codex_outputs_rejected": [
+      "any final architecture judgment made outside Hermes integration"
+    ],
+    "next_hermes_instruction_suggestions": [
+      "If the first draft is too broad, ask Hermes to reduce scope before Codex edits files."
+    ]
+  },
+  "post_delegation_review": {
+    "hermes_output_is_draft_input": true,
+    "canonical_promotion_allowed": false,
+    "requires_codex_review": true,
+    "requires_validators": true,
+    "local_state_committed": false,
+    "raw_transcript_committed": false
+  },
+  "expected_boundary_outcome": {
+    "status": "accept_draft",
+    "reason": "The fixture records Hermes as primary analyst, Windows Codex app as Hermes operator, provider Codex as executor, and Codex fallback as recorded exception behavior."
+  }
+}

--- a/tests/validation/validate-codex-hermes-delegation-fixtures.ps1
+++ b/tests/validation/validate-codex-hermes-delegation-fixtures.ps1
@@ -92,6 +92,7 @@ $expectedFixtures = [ordered]@{
   'stale-pr-active-source-rejection.json' = 'stale_pr_rejection'
   'video-observed-damage-label-boundary.json' = 'observed_damage_label_boundary'
   'move-frequency-review-only.json' = 'move_frequency_review_only'
+  'hermes-first-orchestration-loop.json' = 'hermes_first_orchestration'
 }
 
 $allowedScenarioKinds = @(
@@ -103,7 +104,8 @@ $allowedScenarioKinds = @(
   'external_atlas_metadata_only',
   'stale_pr_rejection',
   'observed_damage_label_boundary',
-  'move_frequency_review_only'
+  'move_frequency_review_only',
+  'hermes_first_orchestration'
 )
 
 $allowedOutcomeStatuses = @(
@@ -362,6 +364,27 @@ if ($issues.Count -eq 0) {
           if ($rawLower -notmatch [regex]::Escape($requiredText.ToLowerInvariant())) {
             $issues += "$relativePath must include $requiredText"
           }
+        }
+      }
+      'hermes_first_orchestration' {
+        foreach ($requiredText in @(
+          'analysis_mode',
+          'hermes_primary',
+          'windows codex app',
+          'hermes operator',
+          'primary analyst',
+          'provider codex',
+          'executor',
+          'codex_fallback',
+          'primary draft input'
+        )) {
+          if ($rawLower -notmatch [regex]::Escape($requiredText.ToLowerInvariant())) {
+            $issues += "$relativePath must include $requiredText"
+          }
+        }
+
+        if ([string]$fixture.expected_boundary_outcome.status -ne 'accept_draft') {
+          $issues += "$relativePath expected outcome must be accept_draft"
         }
       }
     }

--- a/workflows/codex-to-hermes-delegation.md
+++ b/workflows/codex-to-hermes-delegation.md
@@ -5,14 +5,16 @@
 Use this workflow when Codex delegates a bounded knowledge-growth or
 maintainer-growth subtask to Hermes.
 
-Codex remains the entrypoint and normal repo implementation executor. Hermes
-may act as a repo-local growth workflow delegate when a configured maintainer
+Codex remains the entrypoint and normal repo implementation executor. For
+in-scope analysis, review, and growth tasks, Codex acts as Hermes operator and
+boundary auditor rather than primary analyst when a configured maintainer
 profile is available.
 
-Hermes outputs are drafts until converted into reviewed repository artifacts.
-Hermes memory, sessions, and local skills are not canonical evidence.
-Completion is based on repository artifacts, validators, and review, not
-Hermes confidence.
+Hermes is the primary draft analyst and orchestrator for delegated analysis
+tasks. Hermes outputs are drafts until converted into reviewed repository
+artifacts. Hermes memory, sessions, and local skills are not canonical
+evidence. Completion is based on repository artifacts, validators, and review,
+not Hermes confidence.
 
 This workflow does not replace `workflows/maintainer-agent-session.md`.
 Delegated work must still follow the maintainer session workflow, including
@@ -20,13 +22,16 @@ scope restatement, verification, warnings, unresolved items, and handoff.
 
 ## Suitable Delegation Tasks
 
-Codex may delegate these bounded draft or review tasks to Hermes when the
-target issue allows the work:
+Codex should delegate primary object-level analysis for these bounded draft or
+review tasks to Hermes when the target issue allows the work and Hermes is
+configured:
 
 - source summary draft
 - candidate claims draft
 - observation draft
 - review note draft
+- architecture review draft
+- directory or source-surface audit draft
 - smoke report draft
 - workflow improvement proposal
 - validator-pattern proposal
@@ -36,6 +41,9 @@ target issue allows the work:
 Delegation is most useful when Hermes can inspect source material, identify
 candidate artifacts, summarize uncertainty, or propose maintainer workflow
 improvements without changing canonical surfaces directly.
+
+Codex-only analysis for these tasks is fallback behavior. Record the fallback
+reason when Hermes delegation is not attempted or cannot complete.
 
 ## Forbidden Delegation Tasks
 
@@ -55,15 +63,48 @@ Hermes may propose changes to repo artifacts, but Codex must decide whether
 those proposals belong in the target issue and must run the required checks
 before commit.
 
+## Role Model
+
+Use this loop for Hermes-first analysis:
+
+```text
+maintainer
+  -> Windows Codex app as human proxy and Hermes operator
+  -> Hermes as primary analyst and orchestrator
+  -> provider Codex as Hermes-controlled executor when needed
+  -> Hermes integrated draft response
+  -> Windows Codex app boundary audit, artifact conversion, validation, PR
+```
+
+Codex may read repo files to prepare scope, delegation requests, boundary
+rules, and validators. Codex must not replace Hermes by producing the primary
+object-level analysis when Hermes-first conditions apply.
+
+Provider Codex may do bounded executor work under Hermes direction, such as
+file reading, diff drafting, validator execution, report skeleton drafting, or
+command-output collection. Provider Codex must not become the final analyst,
+promote review-only evidence, override current-fact authority, or expand scope.
+
 ## Delegation Request Template
 
 Use this request shape when handing a subtask to Hermes:
 
 ```yaml
+analysis_mode: hermes_primary
 task_id:
 tracking_issue:
 target_issue:
 target_scope_summary:
+codex_app_role:
+  - hermes_operator
+  - boundary_auditor
+  - artifact_converter
+  - validator_executor
+hermes_role:
+  - primary_analyst
+  - orchestrator
+provider_codex_role:
+  - executor
 source_material:
 requested_artifact_type:
 allowed_outputs:
@@ -90,11 +131,22 @@ after review and which sources remain non-canonical. For SF6 current facts,
 exact authority remains grounded in `data/exports/`, `data/roster/`, and
 derived frame-current assets; delegation alone cannot change that authority.
 
+Use this shape when Codex fallback analysis is necessary:
+
+```yaml
+analysis_mode: codex_fallback
+hermes_delegation:
+  attempted: false
+  reason:
+debt: hermes_first_analysis_not_validated_for_this_workflow
+```
+
 ## Hermes Response Template
 
 Hermes responses should use this shape:
 
 ```yaml
+analysis_executor: hermes_primary
 summary:
 proposed_artifacts:
 source_refs:
@@ -102,6 +154,11 @@ evidence_candidate_notes:
 uncertainty_or_hold_reasons:
 boundary_notes:
 follow_up_recommendations:
+self_improvement_notes:
+provider_codex_tasks:
+provider_codex_outputs_used:
+provider_codex_outputs_rejected:
+next_hermes_instruction_suggestions:
 ```
 
 Do not use `evidence_refs` as a response field name. `source_refs` and
@@ -112,6 +169,9 @@ artifacts.
 Hermes response text is not itself canonical evidence. It becomes useful only
 when converted into an in-scope repo artifact, validated, reviewed, and merged.
 
+`provider_codex_outputs_used` and `provider_codex_outputs_rejected` record how
+Hermes treated provider work. They do not make provider output canonical.
+
 ## Post-Delegation Checks Before Commit
 
 Before committing work that used Hermes output:
@@ -120,13 +180,17 @@ Before committing work that used Hermes output:
 2. Confirm the output remains within the target issue scope.
 3. Confirm no current-fact authority is changed unless the target issue
    explicitly allows it.
-4. Confirm Hermes memory, session, and local skill state are not committed.
-5. Run relevant validators for the changed surfaces.
-6. Run `tests/validation/run-all.ps1` when practical.
-7. Run `git diff --check`.
-8. Verify generated or derived surfaces have no residual diff unless
+4. Confirm Hermes performed primary analysis, or record the Codex fallback
+   reason.
+5. Confirm provider Codex did not become the final analyst or decision
+   authority.
+6. Confirm Hermes memory, session, and local skill state are not committed.
+7. Run relevant validators for the changed surfaces.
+8. Run `tests/validation/run-all.ps1` when practical.
+9. Run `git diff --check`.
+10. Verify generated or derived surfaces have no residual diff unless
    intentionally in scope.
-9. Record warnings, unresolved items, and intentionally not done items.
+11. Record warnings, unresolved items, and intentionally not done items.
 
 If Windows PowerShell reports git-unavailable warnings during generated-surface
 checks, follow `workflows/maintainer-agent-session.md` and separately verify
@@ -138,8 +202,12 @@ frame-current assets, and normalization assets have no residual diff.
 Before opening a PR, check:
 
 - The delegation request included the target issue and target scope summary.
+- The request identifies `analysis_mode` as `hermes_primary` or records
+  `codex_fallback` with a reason.
 - The target issue explicitly allows the delegated artifact type.
-- The PR body identifies that Hermes output was draft input, if relevant.
+- The PR body identifies that Hermes output was primary draft input, if
+  relevant.
+- The PR body identifies whether provider Codex was used by Hermes.
 - `source_refs` and `evidence_candidate_notes` are not presented as canonical
   evidence.
 - Current facts, `official_raw`, and public `sf6-agent` behavior did not

--- a/workflows/maintainer-agent-session.md
+++ b/workflows/maintainer-agent-session.md
@@ -10,6 +10,8 @@ This workflow preserves the v2.2 operating lanes:
 - Codex remains the normal repo implementation executor.
 - Hermes is the repo-local growth engine when a configured maintainer profile
   is available.
+- For in-scope analysis, review, and growth tasks, Codex should operate Hermes
+  instead of performing primary object-level analysis itself.
 - GitHub issues and pull requests are the primary progress state.
 - Private memory is not repo state.
 - Completion is based on verification results, not agent confidence.
@@ -28,6 +30,9 @@ Before implementation starts:
 8. Inspect validators relevant to the changed surfaces.
 9. Confirm dependencies are complete, or explicitly report the missing
    dependency before proceeding.
+10. For analysis, review, or growth tasks, confirm whether Hermes-first
+    delegation applies and record any Codex fallback reason before primary
+    analysis starts.
 
 For issue-scoped implementation PRs, do not begin editing until the target
 scope, non-goals, and acceptance are clear enough to test.


### PR DESCRIPTION
## Summary

- Closes #199.
- Defines Hermes-first analysis as the default for in-scope analysis, review, and growth tasks when a configured Hermes maintainer profile is available.
- Splits roles across Windows Codex app, Hermes, and provider Codex: Codex app operates/audits/converts, Hermes performs primary analysis/orchestration, provider Codex executes bounded work under Hermes direction.
- Adds fallback recording for Codex-only analysis and extends the Codex-Hermes delegation request/response shape.
- Adds a dry-run delegation fixture and validator coverage for the Hermes-first orchestration loop.
- Tightens review feedback: removes stale v2.3/non-goal wording, aligns `target_scope_summary`, shifts playbook language from delegation discretion to documented fallback conditions, and updates the pack SKILL procedure to confirm Hermes-first delegation or record fallback.

## Validation

- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-codex-hermes-delegation-fixtures.ps1` OK
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-codex-hermes-pack.ps1` OK
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-architecture-markers.ps1` OK
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1` OK
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1` OK before the review-feedback wording commits
- `git diff --check` OK
- `git diff --check origin/main...HEAD` OK

## Notes

- `run-all.ps1` emitted the existing PowerShell git-unavailable warnings during generated preflight checks. WSL git status was checked afterward; generated runtime assets were restored to no residual diff.
- The final review-feedback commits only change docs/template/playbook wording; focused validators and doc links were rerun after the broader wording commit, and Codex-Hermes pack/delegation fixture validators were rerun after the final playbook nit.
- This PR does not run live Hermes, change public `sf6-agent` behavior, promote current facts, or commit Hermes local state.