### PR TITLE
[v2.6] Add review-only current-fact metadata

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -6,6 +6,8 @@ Contracts distinguish canonical surfaces from derived surfaces and use generic s
 
 Some contracts describe Markdown front matter or agent-readable artifacts that are enforced by dedicated validators rather than by a generic JSON Schema runtime. Validators under `tests/validation/` are the executable contract layer for the current repo.
 
+`tests/validation/validate-current-fact-boundaries.ps1` is the executable contract layer for review-only current-fact candidate metadata under `knowledge/review/current-fact-candidates/`.
+
 When `source_refs.path` points to a migrated legacy file, `source_revision` identifies the commit where that historical path can be reviewed.
 
 ## Human-Readable Contracts

--- a/contracts/evidence-gate.md
+++ b/contracts/evidence-gate.md
@@ -18,6 +18,17 @@ Video observations are observation-only evidence. They must not be used to infer
 
 Hermes memory, sessions, profile state, browser state, cron state, local managed skills, local config, secrets, and chat transcripts must not be answer evidence.
 
+### Current-Fact Candidate Metadata
+
+Artifacts under `knowledge/review/current-fact-candidates/` are review-only
+current-fact candidates. Non-README candidate artifacts must carry
+machine-readable metadata marking them as `review_only`, disallowing public
+answers, disallowing generated references, and denying accepted current-fact
+authority.
+
+Those metadata fields are guardrails only. They do not verify, accept, promote,
+or publish current facts, and they do not create a current-fact authority path.
+
 ## Hold Behavior
 
 Hold or unresolved mode is required when evidence is missing, ambiguous, stale, unsupported, outside authority, or conflicting across authority boundaries.

--- a/knowledge/review/current-fact-candidates/README.md
+++ b/knowledge/review/current-fact-candidates/README.md
@@ -12,4 +12,22 @@ System-mechanics current fact candidates also stay here until a dedicated accept
 
 Examples include combo-scaling numeric values that are not already packaged as move-specific frame-current fields, route-level damage formulas, minimum guarantee values, system action modifiers, and patch-sensitive exception rules.
 
+## Machine-readable authority metadata
+
+Each non-README candidate artifact must include these front matter fields with
+these exact values:
+
+```yaml
+authority_status: review_only
+authority_role: review_only_current_fact_candidate
+public_answer_allowed: false
+generated_reference_allowed: false
+accepted_current_fact_authority: false
+```
+
+These fields are guardrails only.
+They do not verify, accept, promote, or publish current facts.
+Changing them is not a promotion path. Accepted use requires a separate
+current-fact authority path and review.
+
 See `workflows/system-mechanics-fact-workflow.md`.

--- a/knowledge/review/current-fact-candidates/hameko-2023-combo-scaling-system-mechanics.md
+++ b/knowledge/review/current-fact-candidates/hameko-2023-combo-scaling-system-mechanics.md
@@ -13,6 +13,11 @@ confidence: 0.25
 volatility: patch_sensitive
 patch_sensitivity: high
 review_status: needs_review
+authority_status: review_only
+authority_role: review_only_current_fact_candidate
+public_answer_allowed: false
+generated_reference_allowed: false
+accepted_current_fact_authority: false
 source_refs:
   - label: "Source metadata: Hameko 2023 combo scaling"
     path: "knowledge/sources/articles/hameko-2023-combo-scaling.md"

--- a/tests/validation/validate-current-fact-boundaries.ps1
+++ b/tests/validation/validate-current-fact-boundaries.ps1
@@ -42,6 +42,75 @@ $forbiddenPatterns = @(
   '(startup|block advantage|hit advantage)\s*[:=]\s*[+-]?\d+'
 )
 
+function ConvertFrom-ScalarValue {
+  param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Value)
+
+  $trimmed = $Value.Trim()
+  if ($trimmed -eq 'null') {
+    return $null
+  }
+  if ($trimmed -eq 'true') {
+    return $true
+  }
+  if ($trimmed -eq 'false') {
+    return $false
+  }
+  if ($trimmed.Length -ge 2 -and $trimmed.StartsWith('"') -and $trimmed.EndsWith('"')) {
+    return $trimmed.Substring(1, $trimmed.Length - 2)
+  }
+  return $trimmed
+}
+
+function Read-FrontMatter {
+  param([Parameter(Mandatory = $true)][System.IO.FileInfo]$File)
+
+  $relativePath = $File.FullName.Substring($repoRoot.Length + 1).Replace('\', '/')
+  $raw = Get-Content -LiteralPath $File.FullName -Raw -Encoding UTF8
+  $normalized = $raw -replace "`r`n", "`n"
+
+  if (-not $normalized.StartsWith("---`n")) {
+    throw "$relativePath is missing front matter"
+  }
+
+  $frontMatterEnd = $normalized.IndexOf("`n---`n", 4)
+  if ($frontMatterEnd -lt 0) {
+    throw "$relativePath front matter is not closed"
+  }
+
+  $frontMatter = $normalized.Substring(4, $frontMatterEnd - 4)
+  $metadata = [ordered]@{}
+  $currentKey = $null
+
+  foreach ($line in ($frontMatter -split "`n")) {
+    if ($line -match '^([A-Za-z0-9_]+):\s*(.*)$') {
+      $currentKey = $Matches[1]
+      $metadata[$currentKey] = ConvertFrom-ScalarValue $Matches[2]
+      continue
+    }
+
+    if ($null -ne $currentKey -and $line -match '^\s+-\s+(.+)$') {
+      if (-not ($metadata[$currentKey] -is [System.Collections.IList])) {
+        $previous = $metadata[$currentKey]
+        $metadata[$currentKey] = @()
+        if ($null -ne $previous -and "$previous".Trim().Length -gt 0) {
+          $metadata[$currentKey] += $previous
+        }
+      }
+      $metadata[$currentKey] += ConvertFrom-ScalarValue $Matches[1]
+    }
+  }
+
+  return $metadata
+}
+
+$requiredCandidateMetadata = [ordered]@{
+  authority_status = 'review_only'
+  authority_role = 'review_only_current_fact_candidate'
+  public_answer_allowed = $false
+  generated_reference_allowed = $false
+  accepted_current_fact_authority = $false
+}
+
 $violations = @()
 foreach ($file in $files) {
   $relativePath = $file.FullName.Substring($repoRoot.Length + 1).Replace('\', '/')
@@ -64,7 +133,13 @@ if (Test-Path -LiteralPath $candidateRoot -PathType Container) {
     foreach ($needle in @(
       'not final public answer evidence',
       'must not feed generated knowledge references',
-      'resolved into the current-fact data surfaces or kept on hold'
+      'resolved into the current-fact data surfaces or kept on hold',
+      'authority_status: review_only',
+      'authority_role: review_only_current_fact_candidate',
+      'public_answer_allowed: false',
+      'generated_reference_allowed: false',
+      'accepted_current_fact_authority: false',
+      'do not verify, accept, promote, or publish current facts'
     )) {
       if ($candidateReadmeText -notmatch [regex]::Escape($needle)) {
         $violations += "knowledge/review/current-fact-candidates/README.md missing boundary text: $needle"
@@ -73,7 +148,10 @@ if (Test-Path -LiteralPath $candidateRoot -PathType Container) {
   }
 
   $candidateFiles = Get-ChildItem -LiteralPath $candidateRoot -Recurse -File |
-    Where-Object { $_.Extension -in @('.md', '.yaml', '.yml', '.json') }
+    Where-Object {
+      ($_.Name -ne 'README.md') -and
+      ($_.Extension -in @('.md', '.yaml', '.yml', '.json'))
+    }
   foreach ($candidateFile in $candidateFiles) {
     $relativePath = $candidateFile.FullName.Substring($repoRoot.Length + 1).Replace('\', '/')
     $content = Get-Content -LiteralPath $candidateFile.FullName -Raw -Encoding UTF8
@@ -85,6 +163,34 @@ if (Test-Path -LiteralPath $candidateRoot -PathType Container) {
     )) {
       if ($content -match $pattern) {
         $violations += "$relativePath violates current-fact candidate review-only boundary: $pattern"
+      }
+    }
+
+    try {
+      $metadata = Read-FrontMatter $candidateFile
+    }
+    catch {
+      $violations += $_.Exception.Message
+      continue
+    }
+
+    foreach ($field in $requiredCandidateMetadata.Keys) {
+      $expected = $requiredCandidateMetadata[$field]
+      if (-not $metadata.Contains($field)) {
+        $violations += "$relativePath missing current-fact candidate metadata: $field"
+        continue
+      }
+
+      $actual = $metadata[$field]
+      if ($expected -is [bool]) {
+        if (-not ($actual -is [bool]) -or $actual -ne $expected) {
+          $violations += "$relativePath metadata $field must be $($expected.ToString().ToLowerInvariant())"
+        }
+        continue
+      }
+
+      if ($actual -ne $expected) {
+        $violations += "$relativePath metadata $field must be $expected"
       }
     }
   }

--- a/workflows/system-mechanics-fact-workflow.md
+++ b/workflows/system-mechanics-fact-workflow.md
@@ -70,8 +70,27 @@ Minimum fields:
 - `volatility`
 - `patch_sensitivity`
 - `review_status`
+- `authority_status`
+- `authority_role`
+- `public_answer_allowed`
+- `generated_reference_allowed`
+- `accepted_current_fact_authority`
 - `source_refs`
 - `review_after`
+
+Required authority metadata values:
+
+```yaml
+authority_status: review_only
+authority_role: review_only_current_fact_candidate
+public_answer_allowed: false
+generated_reference_allowed: false
+accepted_current_fact_authority: false
+```
+
+These values are machine-readable guardrails. They do not verify, accept,
+promote, or publish current facts. Accepted use requires a separate current-fact
+authority path; it is not created by flipping these fields.
 
 Recommended boundary text:
 


### PR DESCRIPTION
## Summary

- Add machine-readable review-only authority metadata to the first high-risk current-fact candidate surface: `knowledge/review/current-fact-candidates/`.
- Require current-fact candidate artifacts to declare `authority_status: review_only`, `authority_role: review_only_current_fact_candidate`, and false public/generated/accepted-authority flags.
- Extend `validate-current-fact-boundaries.ps1` so the metadata is validator-backed, and document the model in the current-fact candidate README, system-mechanics workflow, and evidence-gate contract.

Closes #206.

## Hermes-first analysis

Hermes was used as the primary draft analyst for #206 planning. The selected tranche follows the Hermes recommendation to start with `knowledge/review/current-fact-candidates/` instead of migrating every review-only surface at once.

Codex role: Hermes operator, boundary auditor, artifact converter, validator runner, PR executor.

Hermes output status: primary draft input only, not canonical evidence.

No Hermes raw transcript, memory, sessions, local skills, logs, caches, credentials, secrets, tokens, or local state are committed.

## Selected metadata model

```yaml
authority_status: review_only
authority_role: review_only_current_fact_candidate
public_answer_allowed: false
generated_reference_allowed: false
accepted_current_fact_authority: false
```

This is intentionally narrow for the first tranche: it applies to non-README artifacts under `knowledge/review/current-fact-candidates/`, currently the Hameko combo-scaling system-mechanics candidate. The metadata is a guardrail only; it does not verify, accept, promote, publish, or canonicalize current facts.

## Not changed

- No current facts promoted, rejected, or verified.
- No `data/exports`, `data/roster`, `official_raw`, generated references, frame-current assets, normalization assets, or `.dist` changes.
- No public `skills/sf6-agent` behavior changes.
- No broad migration of `knowledge/evidence/claims/`, `knowledge/evidence/video-observations/`, or `knowledge/review/unresolved/`; those remain follow-up candidates.

## Validation

- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-current-fact-boundaries.ps1` PASS
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-knowledge-schema.ps1` PASS
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1` PASS
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1` PASS
- `git diff --check` PASS
- `git diff --check origin/main...HEAD` PASS
