### PR TITLE
[v2.6] Add review-only claim artifact metadata

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -6,6 +6,8 @@ Contracts distinguish canonical surfaces from derived surfaces and use generic s
 
 Some contracts describe Markdown front matter or agent-readable artifacts that are enforced by dedicated validators rather than by a generic JSON Schema runtime. Validators under `tests/validation/` are the executable contract layer for the current repo.
 
+`tests/validation/validate-ingest-artifacts.ps1` is the executable contract layer for artifact-level review-only metadata under `knowledge/evidence/claims/*.claims.md`.
+
 `tests/validation/validate-current-fact-boundaries.ps1` is the executable contract layer for review-only current-fact candidate metadata under `knowledge/review/current-fact-candidates/`.
 
 When `source_refs.path` points to a migrated legacy file, `source_revision` identifies the commit where that historical path can be reviewed.

--- a/knowledge/evidence/claims/README.md
+++ b/knowledge/evidence/claims/README.md
@@ -5,3 +5,23 @@
 Each claim should use the generic v2 metadata model: `claim_kind`, `source_kind`, `source_role`, `evidence_basis`, `verification_state`, `confidence`, `volatility`, `patch_sensitivity`, `review_status`, `source_refs`, and `review_after`.
 
 Claims are not final public answer evidence until they are accepted through review and promoted into the appropriate canonical surface.
+
+## Machine-readable authority metadata
+
+Each non-README claim artifact must include these front matter fields with
+these exact values:
+
+```yaml
+authority_status: review_only
+authority_role: review_only_evidence_claim_artifact
+public_answer_allowed: false
+generated_reference_allowed: false
+accepted_current_fact_authority: false
+```
+
+These fields are artifact-level guardrails only. They do not verify, accept,
+promote, reject, or publish any embedded claim. They do not make the claim
+artifact public answer authority. Claim artifacts must not feed generated references directly.
+
+Accepted public use requires normal claim review and promotion into an
+appropriate canonical surface.

--- a/knowledge/evidence/claims/hameko-2023-combo-scaling.claims.md
+++ b/knowledge/evidence/claims/hameko-2023-combo-scaling.claims.md
@@ -8,6 +8,11 @@ confidence: 0.45
 volatility: patch_sensitive
 patch_sensitivity: high
 review_status: needs_review
+authority_status: review_only
+authority_role: review_only_evidence_claim_artifact
+public_answer_allowed: false
+generated_reference_allowed: false
+accepted_current_fact_authority: false
 review_after: "2026-08-01"
 source_refs:
   - label: "Source metadata: Hameko 2023 combo scaling"

--- a/knowledge/evidence/claims/mizen-2025-simple-yomi.claims.md
+++ b/knowledge/evidence/claims/mizen-2025-simple-yomi.claims.md
@@ -8,6 +8,11 @@ confidence: 0.45
 volatility: patch_sensitive
 patch_sensitivity: medium
 review_status: needs_review
+authority_status: review_only
+authority_role: review_only_evidence_claim_artifact
+public_answer_allowed: false
+generated_reference_allowed: false
+accepted_current_fact_authority: false
 review_after: "2026-08-01"
 source_refs:
   - label: "Source metadata: Mizen 2025 simple yomi"

--- a/knowledge/evidence/claims/youtube-vcpzwawrrla-terminology.claims.md
+++ b/knowledge/evidence/claims/youtube-vcpzwawrrla-terminology.claims.md
@@ -8,6 +8,11 @@ confidence: 0.45
 volatility: stable
 patch_sensitivity: medium
 review_status: needs_review
+authority_status: review_only
+authority_role: review_only_evidence_claim_artifact
+public_answer_allowed: false
+generated_reference_allowed: false
+accepted_current_fact_authority: false
 review_after: "2026-08-14"
 source_refs:
   - label: "Source metadata: YouTube VCPzwAwRrLA"

--- a/tests/validation/validate-ingest-artifacts.ps1
+++ b/tests/validation/validate-ingest-artifacts.ps1
@@ -15,6 +15,12 @@ function ConvertFrom-ScalarValue {
   if ($trimmed -eq 'null') {
     return $null
   }
+  if ($trimmed -eq 'true') {
+    return $true
+  }
+  if ($trimmed -eq 'false') {
+    return $false
+  }
   if ($trimmed.Length -ge 2 -and $trimmed.StartsWith('"') -and $trimmed.EndsWith('"')) {
     return $trimmed.Substring(1, $trimmed.Length - 2)
   }
@@ -109,6 +115,35 @@ function Assert-Confidence {
   }
 }
 
+function Assert-ExactMetadata {
+  param(
+    [Parameter(Mandatory = $true)][string]$RelativePath,
+    [Parameter(Mandatory = $true)][System.Collections.IDictionary]$Metadata,
+    [Parameter(Mandatory = $true)][System.Collections.IDictionary]$RequiredMetadata,
+    [Parameter(Mandatory = $true)][ref]$Violations
+  )
+
+  foreach ($field in $RequiredMetadata.Keys) {
+    $expected = $RequiredMetadata[$field]
+    if (-not $Metadata.Contains($field)) {
+      $Violations.Value += "$RelativePath missing metadata field: $field"
+      continue
+    }
+
+    $actual = $Metadata[$field]
+    if ($expected -is [bool]) {
+      if (-not ($actual -is [bool]) -or $actual -ne $expected) {
+        $Violations.Value += "$RelativePath metadata $field must be $($expected.ToString().ToLowerInvariant())"
+      }
+      continue
+    }
+
+    if ($actual -ne $expected) {
+      $Violations.Value += "$RelativePath metadata $field must be $expected"
+    }
+  }
+}
+
 function Assert-NoReviewOnlyBoundaryBreaks {
   param(
     [Parameter(Mandatory = $true)][string]$RelativePath,
@@ -182,9 +217,38 @@ if (-not (Test-Path -LiteralPath $claimsRoot -PathType Container)) {
   $violations += 'Missing claim artifact directory: knowledge/evidence/claims'
 }
 else {
+  $claimsReadme = Join-Path $claimsRoot 'README.md'
+  if (-not (Test-Path -LiteralPath $claimsReadme -PathType Leaf)) {
+    $violations += 'knowledge/evidence/claims must include README.md'
+  }
+  else {
+    $claimsReadmeText = Get-Content -LiteralPath $claimsReadme -Raw -Encoding UTF8
+    foreach ($needle in @(
+      'authority_status: review_only',
+      'authority_role: review_only_evidence_claim_artifact',
+      'public_answer_allowed: false',
+      'generated_reference_allowed: false',
+      'accepted_current_fact_authority: false',
+      'artifact-level guardrails',
+      'must not feed generated references directly'
+    )) {
+      if ($claimsReadmeText -notmatch [regex]::Escape($needle)) {
+        $violations += "knowledge/evidence/claims/README.md missing boundary text: $needle"
+      }
+    }
+  }
+
   $claimFiles = @(Get-ChildItem -LiteralPath $claimsRoot -File -Filter '*.claims.md')
   if ($claimFiles.Count -eq 0) {
     $violations += 'No evidence claim artifacts found under knowledge/evidence/claims'
+  }
+
+  $requiredClaimAuthorityMetadata = [ordered]@{
+    authority_status = 'review_only'
+    authority_role = 'review_only_evidence_claim_artifact'
+    public_answer_allowed = $false
+    generated_reference_allowed = $false
+    accepted_current_fact_authority = $false
   }
 
   $claimRequiredFields = @(
@@ -213,6 +277,7 @@ else {
     Assert-EnumValue $relativePath $metadata 'patch_sensitivity' $allowedPatchSensitivity ([ref]$violations)
     Assert-EnumValue $relativePath $metadata 'review_status' $allowedReviewStatus ([ref]$violations)
     Assert-Confidence $relativePath $metadata ([ref]$violations)
+    Assert-ExactMetadata $relativePath $metadata $requiredClaimAuthorityMetadata ([ref]$violations)
 
     if ($content -notmatch '(?m)^# Candidate Claims\s*$') {
       $violations += "$relativePath missing required section: # Candidate Claims"

--- a/workflows/review-claims.md
+++ b/workflows/review-claims.md
@@ -13,6 +13,22 @@ Review is a separate step from article or video ingest. Ingest records evidence;
 - Exact current-fact exports under `data/exports/` when the claim touches move-specific current facts.
 - Current roster source under `data/roster/current-character-roster.json` when the claim depends on roster membership.
 
+Claim artifacts under `knowledge/evidence/claims/` are review-only artifact
+surfaces. They must carry artifact-level authority metadata:
+
+```yaml
+authority_status: review_only
+authority_role: review_only_evidence_claim_artifact
+public_answer_allowed: false
+generated_reference_allowed: false
+accepted_current_fact_authority: false
+```
+
+This metadata applies to the claim artifact, not to each embedded claim's final
+route. Individual claims may later be promoted through reviewed canonical
+surfaces, but the source claim artifact itself remains review-only provenance
+and must not become direct public answer authority.
+
 ## Decision Values
 
 Use v2 metadata fields:


### PR DESCRIPTION
## Summary

- Add artifact-level review-only authority metadata to all non-README `knowledge/evidence/claims/*.claims.md` files.
- Extend `validate-ingest-artifacts.ps1` so claim artifacts must carry exact review-only metadata values.
- Document the claim-artifact boundary in `knowledge/evidence/claims/README.md`, `workflows/review-claims.md`, and `contracts/README.md`.

Closes #208.

## Hermes-first analysis

Hermes was used as the primary draft analyst for this tranche. Hermes recommended keeping the first claim-artifact pass narrow: artifact-level front matter only, no embedded JSON claim payload changes, and no broad schema churn.

Codex role: Hermes operator, boundary auditor, artifact converter, validator runner, PR executor.

Hermes output status: primary draft input only, not canonical evidence.

No Hermes raw transcript, memory, sessions, local skills, logs, caches, credentials, secrets, tokens, or local state are committed.

## Selected metadata model

```yaml
authority_status: review_only
authority_role: review_only_evidence_claim_artifact
public_answer_allowed: false
generated_reference_allowed: false
accepted_current_fact_authority: false
```

This is intentionally artifact-level metadata. It marks claim files as review-only provenance/review artifacts and does not verify, accept, promote, reject, publish, or canonicalize any embedded claim.

## Not changed

- No claim statements, embedded JSON payloads, terminal decisions, source refs, confidence values, verification states, or review statuses were substantively changed.
- No claims were promoted into `knowledge/curated/`.
- No current facts, `data/exports`, `data/roster`, `official_raw`, generated references, frame-current assets, normalization assets, `.dist`, or public `sf6-agent` behavior changed.
- `validate-current-fact-boundaries.ps1` remains scoped to `knowledge/review/current-fact-candidates/`.

## Validation

- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-ingest-artifacts.ps1` PASS
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-current-fact-boundaries.ps1` PASS
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-v2-contracts.ps1` PASS
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1` PASS
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1` PASS
- `git diff --check` PASS
- `git diff --check origin/main...HEAD` PASS
