### PR TITLE
[v2.6] Define calculation executor trace contract

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -14,6 +14,7 @@ When `source_refs.path` points to a migrated legacy file, `source_revision` iden
 
 ## Human-Readable Contracts
 
+- `calculation-executor-trace.md`: boundary for calculation tools as executors and trace generators only.
 - `combo-notation.md`: notation rules for `evals/fixtures/combo-damage/*.yaml`.
 - `evidence-gate.md`: answer evidence authority boundaries for current facts, review claims, observations, and Hermes state.
 - `frame-current-runtime-assets.md`: runtime asset boundary for generated frame-current payloads.

--- a/contracts/calculation-executor-trace.md
+++ b/contracts/calculation-executor-trace.md
@@ -1,0 +1,179 @@
+# Calculation Executor Trace Contract
+
+This contract defines how repo-local calculation tools, scripts, skills, or
+agents may produce auditable SF6 calculation traces.
+
+Calculation executors are not SF6 authority. They may run arithmetic and emit
+trace output, but they must not supply input facts, formulas, rounding rules,
+current patch facts, system mechanics, or public answer authority by themselves.
+
+## Executor Boundary
+
+Calculation executors may:
+
+- run arithmetic against explicitly supplied inputs;
+- run reviewed formulas only when a formula policy and rounding policy are
+  referenced;
+- emit ordered calculation steps that a reviewer can audit;
+- check hypothetical or review-only arithmetic consistency while preserving
+  draft or hold status;
+- support future damage-hidden eval experiments when fixture, route, input,
+  formula, and rounding boundaries are all satisfied.
+
+Calculation executors must not:
+
+- become source of truth for damage, frame values, scaling, timing, oki, punish
+  windows, resources, rounding, or current-system behavior;
+- fill missing SF6 formulas from tool memory, third-party skill text, web
+  summaries, or embedded examples;
+- promote review-only candidates, claim artifacts, video observations, smoke
+  reports, or combo fixtures into accepted current facts;
+- treat generated concept references as exact current values or formulas;
+- override `data/exports/`, `data/roster`, packaged `official_raw`, accepted
+  contracts, accepted workflows, or reviewed formula policy;
+- write generated references, frame-current assets, or public adapter behavior
+  unless a separate reviewed issue explicitly allows it.
+
+Third-party or wild math skills are allowed only as executor implementations.
+Their output is a calculation trace candidate, not authority.
+
+## Trace Fields
+
+A calculation trace should include enough structured information to reproduce
+and audit the computation. A later JSON schema may narrow these fields when the
+repo begins storing trace artifacts.
+
+Minimum fields:
+
+- `trace_id`: stable trace artifact ID.
+- `trace_schema_version`: contract version, such as
+  `sf6-calculation-trace/v1`.
+- `executor_id`: name, version, hash, or invocation identity of the tool,
+  script, skill, or agent that produced the trace.
+- `executor_role`: one of `calculation_executor`, `trace_generator`, or
+  `arithmetic_consistency_checker`.
+- `executor_authority_status`: must state that the executor is not SF6
+  authority, formula authority, or current-fact authority.
+- `calculation_intent`: why the calculation was run, such as
+  `hypothetical_arithmetic_check`, `accepted_formula_execution`,
+  `damage_hidden_eval_candidate_check`, `frame_window_arithmetic`,
+  `punish_window_arithmetic`, or `oki_timing_arithmetic`.
+- `question_scope`: short natural-language scope of the calculation.
+- `input_values`: all numeric or symbolic inputs used by the executor.
+- `input_authority_refs`: source refs for every non-hypothetical input.
+- `input_status`: one of `accepted`, `review_only`, `hypothetical`, `mixed`, or
+  `hold`.
+- `formula_policy_ref`: reviewed formula policy used by the calculation, when
+  any formula is being executed as SF6 behavior.
+- `formula_status`: one of `accepted`, `review_only`, `hypothetical`, or
+  `hold`.
+- `rounding_policy_ref`: reviewed rounding, floor, ceiling, truncation, minimum
+  guarantee, or tie-behavior policy when rounding affects output.
+- `rounding_status`: one of `accepted`, `review_only`, `not_applicable`, or
+  `hold`.
+- `operation_steps`: ordered computation steps.
+- `output_values`: computed outputs, explicitly labeled as trace outputs rather
+  than authority.
+- `status`: result status from the list below.
+- `public_answer_allowed`: whether this trace may support a public answer.
+- `generated_reference_allowed`: whether this trace may feed generated
+  references. Default is `false` unless a later reviewed workflow allows it.
+- `accepted_current_fact_authority`: must be `false` for executor traces.
+- `uncertainty_or_hold_reasons`: required when any input, formula, rounding
+  rule, route mapping, timing assumption, or authority path is missing.
+- `created_by`: human, agent, script, or skill that created the trace.
+- `created_at`: timestamp.
+- `repo_revision`: repository commit or revision used for the calculation, when
+  committed.
+- `limitations`: human-readable boundary notes.
+
+Each `operation_steps` entry should include:
+
+- `step_id`
+- `operation_kind`
+- `inputs_used`
+- `output`
+- `rounding_applied`
+- `policy_ref`
+- `notes`
+
+## Status Semantics
+
+Use one of these values for `status`:
+
+- `not_run`: no calculation was executed.
+- `trace_generated`: arithmetic ran and a trace exists, but the result is not an
+  accepted current fact.
+- `hypothetical_arithmetic_only`: values were user-provided, hypothetical, or
+  review-only; the executor checked arithmetic consistency only.
+- `accepted_formula_execution`: the executor ran only against accepted inputs,
+  accepted formula policy, and accepted rounding policy. The output may support
+  an answer, but the trace is still not authority by itself.
+- `blocked_missing_input_authority`: an input is absent from `data/exports/`,
+  `data/roster`, packaged `official_raw`, or another accepted authority
+  surface.
+- `blocked_missing_formula_policy`: formula, scaling rule, timing rule, or
+  exception policy is not accepted.
+- `blocked_missing_rounding_policy`: rounding, floor, ceiling, truncation,
+  minimum guarantee, or tie behavior matters but no reviewed policy exists.
+- `blocked_ambiguous_route`: combo route, action mapping, hit mapping, timing,
+  or move identity is unresolved.
+- `blocked_public_answer_boundary`: a calculation may exist for maintainer
+  review but cannot support public answer behavior.
+- `invalid_input`: inputs are contradictory, malformed, or unsupported by this
+  contract.
+- `executor_error`: the tool failed or produced non-auditable output.
+- `out_of_scope`: the request asks the executor to decide authority, scrape
+  facts, infer formulas, or answer beyond arithmetic execution.
+
+## Public Answer Rules
+
+Executor traces may support public answers only when all of these are true:
+
+- non-hypothetical inputs cite accepted authority refs;
+- formula policy and rounding policy are accepted and cited;
+- route, hit, action, timing, and unit assumptions are explicit when relevant;
+- `status` is `accepted_formula_execution`;
+- `public_answer_allowed` is `true`;
+- no hold reason remains.
+
+Executor traces must not support public answers when any required input,
+formula, rounding policy, route mapping, timing assumption, or authority path is
+missing. In those cases, use hold or unresolved behavior.
+
+For hypothetical questions, the adapter may compute arithmetic consistency only
+if it states that the values are hypothetical or review-only and not accepted
+current SF6 truth.
+
+For exact current move facts, public answers remain grounded in packaged
+frame-current authority derived from `data/exports/` and `data/roster`. For
+route-level formulas, combo damage, meaty or oki timing, punish windows,
+resource/damage calculations, or rounding questions, hold unless accepted
+authority exists.
+
+## Non-Authority Inputs
+
+These sources may help route review work but must not become calculator
+authority by themselves:
+
+- generated concept references;
+- review-only claim artifacts;
+- current-fact candidates;
+- video observations;
+- combo-damage fixtures;
+- smoke reports;
+- Hermes memory, sessions, local skills, or raw transcripts;
+- third-party or wild calculation skills.
+
+## Future Validation
+
+This docs-only contract does not create stored trace artifacts or a trace JSON
+schema. A later PR may add:
+
+- `contracts/calculation-trace.schema.json`;
+- `tests/validation/validate-calculation-traces.ps1`;
+- validators that reject `accepted_current_fact_authority: true`;
+- validators requiring formula and rounding refs for
+  `accepted_formula_execution`;
+- validators blocking `public_answer_allowed: true` for hypothetical, blocked,
+  invalid, or executor-error traces.

--- a/workflows/system-mechanics-fact-workflow.md
+++ b/workflows/system-mechanics-fact-workflow.md
@@ -129,6 +129,20 @@ For combo scaling, this means:
 - Use frame-current runtime assets for packaged move-specific damage and scaling fields when available.
 - Hold route-level final damage formulas, minimum guarantee values, and exception rules unless a future accepted system-mechanics authority path exists.
 
+## Calculation executor boundary
+
+Calculation tools, math skills, scripts, and agents may help run arithmetic only
+as executors. They do not define SF6 input authority, formula authority,
+rounding policy, current facts, or system mechanics.
+
+Before a calculation output can support a public answer, all non-hypothetical
+inputs must cite accepted authority refs, formula and rounding policy must be
+reviewed, and the output must be captured as an auditable trace. If any input,
+formula, rounding rule, route mapping, timing assumption, or authority path is
+missing, use `unresolved / hold` instead of letting the executor guess.
+
+See `contracts/calculation-executor-trace.md`.
+
 ## Future contract decision
 
 A dedicated system-mechanics current-fact contract or data surface is likely needed before these facts can be accepted as runtime authority.


### PR DESCRIPTION
## Summary

- Add `contracts/calculation-executor-trace.md` as a docs-only boundary for math/calculation tools.
- Define calculation tools as executors and trace generators only, not SF6 authority.
- Define trace fields, status semantics, public answer rules, non-authority inputs, and future validation hooks.
- Cross-link the contract from `contracts/README.md` and `workflows/system-mechanics-fact-workflow.md`.

Closes #210.

## Hermes-first analysis

Hermes was used as the primary draft analyst for this contract. Hermes recommended a docs-only tranche before installing or relying on any third-party / wild calculation skill.

Codex role: Hermes operator, boundary auditor, artifact converter, validator runner, PR executor.

Hermes output status: primary draft input only, not canonical evidence.

No Hermes raw transcript, memory, sessions, local skills, logs, caches, credentials, secrets, tokens, or local state are committed.

## Boundary model

Calculation tools may run arithmetic and emit auditable traces. They must not supply SF6 input facts, formulas, rounding rules, current patch facts, system mechanics, or public answer authority by themselves.

Executor traces can support public answers only when accepted input authority refs, accepted formula policy, accepted rounding policy, explicit assumptions, and no hold reasons are present. Otherwise the answer path must hold or remain unresolved.

## Not changed

- No third-party calculation skill was installed or adopted.
- No SF6 combo damage formulas, scaling tables, frame timing formulas, punish-window rules, meaty/oki rules, resource formulas, or rounding policy were accepted.
- No review-only formula, source claim, video observation, or fixture value was promoted.
- No public `sf6-agent` behavior changed.
- No `data/exports`, `data/roster`, `official_raw`, generated references, frame-current assets, normalization assets, `.dist`, or current facts changed.

## Validation

- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1` PASS
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-v2-contracts.ps1` PASS
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1` PASS
- `git diff --check` PASS
- `git diff --check origin/main...HEAD` PASS
