### PR TITLE
[v2.6] Add deterministic calculation executor

### DIFF
--- a/contracts/calculation-trace.schema.json
+++ b/contracts/calculation-trace.schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SF6 Calculation Trace",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "trace_id",
+    "trace_schema_version",
+    "executor_id",
+    "executor_role",
+    "executor_authority_status",
+    "calculation_intent",
+    "question_scope",
+    "input_values",
+    "input_authority_refs",
+    "input_status",
+    "formula_policy_ref",
+    "formula_status",
+    "rounding_policy_ref",
+    "rounding_status",
+    "operation_steps",
+    "output_values",
+    "status",
+    "public_answer_allowed",
+    "generated_reference_allowed",
+    "accepted_current_fact_authority",
+    "uncertainty_or_hold_reasons",
+    "created_by",
+    "created_at",
+    "repo_revision",
+    "limitations"
+  ],
+  "properties": {
+    "trace_id": { "type": "string", "minLength": 1 },
+    "trace_schema_version": { "const": "sf6-calculation-trace/v1" },
+    "executor_id": { "type": "string", "minLength": 1 },
+    "executor_role": {
+      "enum": ["calculation_executor", "trace_generator", "arithmetic_consistency_checker"]
+    },
+    "executor_authority_status": {
+      "type": "array",
+      "items": {
+        "enum": ["not_sf6_authority", "not_formula_authority", "not_current_fact_authority"]
+      },
+      "minItems": 3
+    },
+    "calculation_intent": {
+      "enum": [
+        "hypothetical_arithmetic_check",
+        "accepted_formula_execution",
+        "damage_hidden_eval_candidate_check",
+        "frame_window_arithmetic",
+        "punish_window_arithmetic",
+        "oki_timing_arithmetic"
+      ]
+    },
+    "question_scope": { "type": "string" },
+    "input_values": { "type": "object", "additionalProperties": { "type": "string" } },
+    "input_authority_refs": { "type": "array" },
+    "input_status": { "enum": ["accepted", "review_only", "hypothetical", "mixed", "hold"] },
+    "formula_policy_ref": { "type": ["string", "null"] },
+    "formula_status": { "enum": ["accepted", "review_only", "hypothetical", "hold"] },
+    "rounding_policy_ref": { "type": ["string", "null"] },
+    "rounding_status": { "enum": ["accepted", "review_only", "not_applicable", "hold"] },
+    "operation_steps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["step_id", "operation_kind", "inputs_used", "output", "rounding_applied", "policy_ref", "notes"],
+        "properties": {
+          "step_id": { "type": "string" },
+          "operation_kind": { "type": "string" },
+          "inputs_used": { "type": "array" },
+          "output": { "type": "object" },
+          "rounding_applied": { "type": "string" },
+          "policy_ref": { "type": ["string", "null"] },
+          "notes": { "type": "string" }
+        }
+      }
+    },
+    "output_values": { "type": "object", "additionalProperties": { "type": "string" } },
+    "status": {
+      "enum": [
+        "not_run",
+        "trace_generated",
+        "hypothetical_arithmetic_only",
+        "accepted_formula_execution",
+        "blocked_missing_input_authority",
+        "blocked_missing_formula_policy",
+        "blocked_missing_rounding_policy",
+        "blocked_ambiguous_route",
+        "blocked_public_answer_boundary",
+        "invalid_input",
+        "executor_error",
+        "out_of_scope"
+      ]
+    },
+    "public_answer_allowed": { "type": "boolean" },
+    "generated_reference_allowed": { "type": "boolean" },
+    "accepted_current_fact_authority": { "const": false },
+    "uncertainty_or_hold_reasons": { "type": "array", "items": { "type": "string" } },
+    "created_by": { "type": "string" },
+    "created_at": { "type": ["string", "null"] },
+    "repo_revision": { "type": ["string", "null"] },
+    "limitations": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/packages/README.md
+++ b/packages/README.md
@@ -5,3 +5,6 @@ Shared executable infrastructure for packaging, validation, and installers.
 Use `packages/` only after a second real consumer exists.
 
 Keep skill-specific logic inside its skill directory until shared demand is real.
+
+- `calculation-executor/`: deterministic repo-local arithmetic trace executor
+  used by validation fixtures and Codex/Hermes maintainer playbook calls.

--- a/packages/calculation-executor/README.md
+++ b/packages/calculation-executor/README.md
@@ -1,0 +1,49 @@
+# SF6 Calculation Executor
+
+This package contains a repo-owned deterministic calculation executor for
+maintainer workflows.
+
+The executor exists to reduce LLM arithmetic errors. It is not SF6 authority,
+formula authority, rounding authority, current-fact authority, or public answer
+behavior.
+
+Use it only with explicit JSON inputs and audited authority boundaries from
+`contracts/calculation-executor-trace.md`.
+
+## Run
+
+```bash
+python packages/calculation-executor/sf6_calculation_executor.py \
+  --input tests/fixtures/calculation-executor/hypothetical-addition.json \
+  --pretty
+```
+
+The script reads a JSON request and writes a calculation trace JSON object to
+stdout.
+
+## First-tranche scope
+
+Supported operations are generic arithmetic only:
+
+- `add`
+- `subtract`
+- `multiply`
+- `divide`
+- `sum`
+- `min`
+- `max`
+- `difference`
+- `compare`
+- `percent_of`
+
+The executor does not implement SF6 combo damage formulas, scaling tables,
+minimum guarantees, frame advantage interpretation, punish-window logic,
+meaty/oki timing, resource formulas, or SF6 rounding rules.
+
+## Authority boundary
+
+The executor must not look up or infer current facts. It does not read
+`data/exports/`, `data/roster/`, generated frame-current assets, generated
+references, web pages, Hermes state, or local skill memory.
+
+Trace output always keeps `accepted_current_fact_authority: false`.

--- a/packages/calculation-executor/sf6_calculation_executor.py
+++ b/packages/calculation-executor/sf6_calculation_executor.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Deterministic arithmetic trace executor for SF6 maintainer workflows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from decimal import Decimal, DivisionByZero, InvalidOperation, getcontext
+from pathlib import Path
+from typing import Any
+
+
+EXECUTOR_ID = "sf6_calculation_executor.py@v1"
+TRACE_SCHEMA_VERSION = "sf6-calculation-trace/v1"
+AUTHORITY_STATUS = [
+    "not_sf6_authority",
+    "not_formula_authority",
+    "not_current_fact_authority",
+]
+
+
+class CalculationError(Exception):
+    """Raised when arithmetic cannot produce a valid trace step."""
+
+
+def decimal_to_string(value: Decimal) -> str:
+    if value.is_zero():
+        return "0"
+    normalized = value.normalize()
+    text = format(normalized, "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return text
+
+
+def parse_decimal(name: str, raw: Any) -> Decimal:
+    if isinstance(raw, bool):
+        raise CalculationError(f"{name} must be a decimal string or number")
+    try:
+        return Decimal(str(raw))
+    except (InvalidOperation, ValueError) as exc:
+        raise CalculationError(f"{name} is not a valid decimal: {raw}") from exc
+
+
+def resolve_input(name: str, values: dict[str, Decimal]) -> Decimal:
+    if name not in values:
+        raise CalculationError(f"missing input or previous output: {name}")
+    return values[name]
+
+
+def require_input_count(step_id: str, inputs: list[str], expected: int) -> None:
+    if len(inputs) != expected:
+        raise CalculationError(f"{step_id} requires {expected} input(s)")
+
+
+def compute_operation(
+    operation_kind: str,
+    inputs: list[str],
+    values: dict[str, Decimal],
+    step_id: str,
+) -> tuple[Decimal, str]:
+    resolved = [resolve_input(input_name, values) for input_name in inputs]
+
+    if operation_kind in {"add", "sum"}:
+        if not resolved:
+            raise CalculationError(f"{step_id} requires at least one input")
+        return sum(resolved, Decimal("0")), "sum supplied inputs"
+
+    if operation_kind == "subtract":
+        require_input_count(step_id, inputs, 2)
+        return resolved[0] - resolved[1], "subtract second input from first"
+
+    if operation_kind == "multiply":
+        if not resolved:
+            raise CalculationError(f"{step_id} requires at least one input")
+        result = Decimal("1")
+        for value in resolved:
+            result *= value
+        return result, "multiply supplied inputs"
+
+    if operation_kind == "divide":
+        require_input_count(step_id, inputs, 2)
+        if resolved[1].is_zero():
+            raise CalculationError(f"{step_id} cannot divide by zero")
+        try:
+            return resolved[0] / resolved[1], "divide first input by second"
+        except DivisionByZero as exc:
+            raise CalculationError(f"{step_id} cannot divide by zero") from exc
+
+    if operation_kind == "min":
+        if not resolved:
+            raise CalculationError(f"{step_id} requires at least one input")
+        return min(resolved), "minimum of supplied inputs"
+
+    if operation_kind == "max":
+        if not resolved:
+            raise CalculationError(f"{step_id} requires at least one input")
+        return max(resolved), "maximum of supplied inputs"
+
+    if operation_kind == "difference":
+        require_input_count(step_id, inputs, 2)
+        return abs(resolved[0] - resolved[1]), "absolute difference"
+
+    if operation_kind == "compare":
+        require_input_count(step_id, inputs, 2)
+        if resolved[0] < resolved[1]:
+            return Decimal("-1"), "first input is less than second"
+        if resolved[0] > resolved[1]:
+            return Decimal("1"), "first input is greater than second"
+        return Decimal("0"), "inputs are equal"
+
+    if operation_kind == "percent_of":
+        require_input_count(step_id, inputs, 2)
+        return (resolved[0] * resolved[1]) / Decimal("100"), (
+            "first input as percent of second input"
+        )
+
+    raise CalculationError(f"unsupported operation: {operation_kind}")
+
+
+def determine_block_status(request: dict[str, Any]) -> tuple[str | None, list[str]]:
+    hold_reasons: list[str] = []
+    intent = request.get("calculation_intent")
+    formula_status = request.get("formula_status")
+    rounding_status = request.get("rounding_status")
+    input_status = request.get("input_status")
+
+    if input_status == "hold":
+        hold_reasons.append("input authority is missing or held")
+        return "blocked_missing_input_authority", hold_reasons
+
+    if request.get("route_status") == "ambiguous":
+        hold_reasons.append("route, hit, action, timing, or move mapping is ambiguous")
+        return "blocked_ambiguous_route", hold_reasons
+
+    if intent == "accepted_formula_execution" and formula_status != "accepted":
+        hold_reasons.append("accepted formula policy is required")
+        return "blocked_missing_formula_policy", hold_reasons
+
+    if request.get("rounding_required") and rounding_status != "accepted":
+        hold_reasons.append("accepted rounding policy is required")
+        return "blocked_missing_rounding_policy", hold_reasons
+
+    return None, hold_reasons
+
+
+def determine_success_status(request: dict[str, Any], operations_run: bool) -> str:
+    if not operations_run:
+        return "not_run"
+
+    if request.get("input_status") == "hypothetical" or request.get("formula_status") == "hypothetical":
+        return "hypothetical_arithmetic_only"
+
+    if (
+        request.get("calculation_intent") == "accepted_formula_execution"
+        and request.get("input_status") == "accepted"
+        and request.get("formula_status") == "accepted"
+        and request.get("rounding_status") in {"accepted", "not_applicable"}
+    ):
+        return "accepted_formula_execution"
+
+    return "trace_generated"
+
+
+def build_trace(request: dict[str, Any]) -> dict[str, Any]:
+    getcontext().prec = int(request.get("decimal_precision", 28))
+
+    input_values_raw = request.get("input_values", {})
+    if not isinstance(input_values_raw, dict):
+        input_values_raw = {}
+
+    values: dict[str, Decimal] = {}
+    input_values: dict[str, str] = {}
+    status, hold_reasons = determine_block_status(request)
+
+    try:
+        for name, raw in input_values_raw.items():
+            parsed = parse_decimal(name, raw)
+            values[name] = parsed
+            input_values[name] = decimal_to_string(parsed)
+    except CalculationError as exc:
+        status = "invalid_input"
+        hold_reasons.append(str(exc))
+
+    operation_steps: list[dict[str, Any]] = []
+    output_values: dict[str, str] = {}
+
+    if status is None:
+        try:
+            operations = request.get("operations", [])
+            if not isinstance(operations, list):
+                raise CalculationError("operations must be an array")
+
+            for index, operation in enumerate(operations, start=1):
+                if not isinstance(operation, dict):
+                    raise CalculationError(f"operation {index} must be an object")
+                step_id = str(operation.get("step_id") or f"step-{index}")
+                operation_kind = str(operation.get("operation_kind", ""))
+                inputs = operation.get("inputs", [])
+                if not isinstance(inputs, list) or not all(isinstance(item, str) for item in inputs):
+                    raise CalculationError(f"{step_id} inputs must be an array of names")
+                output_name = str(operation.get("output_name") or step_id)
+
+                result, notes = compute_operation(operation_kind, inputs, values, step_id)
+                result_text = decimal_to_string(result)
+                values[output_name] = result
+                output_values[output_name] = result_text
+                operation_steps.append(
+                    {
+                        "step_id": step_id,
+                        "operation_kind": operation_kind,
+                        "inputs_used": [
+                            {"name": input_name, "value": decimal_to_string(resolve_input(input_name, values))}
+                            for input_name in inputs
+                        ],
+                        "output": {"name": output_name, "value": result_text},
+                        "rounding_applied": "none",
+                        "policy_ref": operation.get("policy_ref"),
+                        "notes": operation.get("notes", notes),
+                    }
+                )
+
+            status = determine_success_status(request, bool(operation_steps))
+        except CalculationError as exc:
+            status = "invalid_input"
+            hold_reasons.append(str(exc))
+
+    public_answer_allowed = bool(
+        status == "accepted_formula_execution"
+        and request.get("public_answer_allowed") is True
+        and not hold_reasons
+    )
+
+    limitations = [
+        "Executor output is an arithmetic trace, not SF6 authority.",
+        "The executor does not look up SF6 facts, formulas, rounding rules, or current patch data.",
+    ]
+    if status != "accepted_formula_execution":
+        limitations.append("Trace must not support public current-fact answers.")
+
+    return {
+        "trace_id": request.get("trace_id", "calculation-trace"),
+        "trace_schema_version": TRACE_SCHEMA_VERSION,
+        "executor_id": EXECUTOR_ID,
+        "executor_role": "calculation_executor",
+        "executor_authority_status": AUTHORITY_STATUS,
+        "calculation_intent": request.get("calculation_intent", "hypothetical_arithmetic_check"),
+        "question_scope": request.get("question_scope", ""),
+        "input_values": input_values,
+        "input_authority_refs": request.get("input_authority_refs", []),
+        "input_status": request.get("input_status", "hypothetical"),
+        "formula_policy_ref": request.get("formula_policy_ref"),
+        "formula_status": request.get("formula_status", "hypothetical"),
+        "rounding_policy_ref": request.get("rounding_policy_ref"),
+        "rounding_status": request.get("rounding_status", "not_applicable"),
+        "operation_steps": operation_steps,
+        "output_values": output_values,
+        "status": status,
+        "public_answer_allowed": public_answer_allowed,
+        "generated_reference_allowed": False,
+        "accepted_current_fact_authority": False,
+        "uncertainty_or_hold_reasons": hold_reasons,
+        "created_by": request.get("created_by", "unknown"),
+        "created_at": request.get("created_at"),
+        "repo_revision": request.get("repo_revision"),
+        "limitations": limitations,
+    }
+
+
+def load_request(path: str | None) -> dict[str, Any]:
+    if path:
+        text = Path(path).read_text(encoding="utf-8")
+    else:
+        text = sys.stdin.read()
+    data = json.loads(text)
+    if not isinstance(data, dict):
+        raise ValueError("input JSON must be an object")
+    return data
+
+
+def invalid_request_trace(message: str) -> dict[str, Any]:
+    return {
+        "trace_id": "invalid-request",
+        "trace_schema_version": TRACE_SCHEMA_VERSION,
+        "executor_id": EXECUTOR_ID,
+        "executor_role": "calculation_executor",
+        "executor_authority_status": AUTHORITY_STATUS,
+        "calculation_intent": "hypothetical_arithmetic_check",
+        "question_scope": "Invalid calculation request.",
+        "input_values": {},
+        "input_authority_refs": [],
+        "input_status": "hold",
+        "formula_policy_ref": None,
+        "formula_status": "hold",
+        "rounding_policy_ref": None,
+        "rounding_status": "hold",
+        "operation_steps": [],
+        "output_values": {},
+        "status": "invalid_input",
+        "public_answer_allowed": False,
+        "generated_reference_allowed": False,
+        "accepted_current_fact_authority": False,
+        "uncertainty_or_hold_reasons": [message],
+        "created_by": "sf6_calculation_executor.py",
+        "created_at": None,
+        "repo_revision": None,
+        "limitations": ["Input request could not be parsed."],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run deterministic SF6 calculation trace arithmetic.")
+    parser.add_argument("--input", help="Path to request JSON. Reads stdin when omitted.")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output.")
+    args = parser.parse_args()
+
+    try:
+        request = load_request(args.input)
+        trace = build_trace(request)
+    except Exception as exc:  # noqa: BLE001 - deterministic error trace for CLI callers.
+        trace = invalid_request_trace(str(exc))
+
+    indent = 2 if args.pretty else None
+    print(json.dumps(trace, ensure_ascii=False, indent=indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packs/codex-hermes-sf6/guards/calculation-executor-boundary.md
+++ b/packs/codex-hermes-sf6/guards/calculation-executor-boundary.md
@@ -1,0 +1,17 @@
+# Calculation Executor Boundary
+
+Calculation tools are executors only.
+
+They must not:
+
+- become SF6 authority;
+- become formula authority;
+- become current-fact authority;
+- override `data/exports`, `data/roster`, or packaged `official_raw`;
+- promote review-only claims, current-fact candidates, video observations,
+  combo fixtures, smoke reports, or Hermes output;
+- feed generated references by default;
+- change public `sf6-agent` behavior.
+
+Use `packages/calculation-executor/sf6_calculation_executor.py` for deterministic
+arithmetic traces and keep `accepted_current_fact_authority: false`.

--- a/packs/codex-hermes-sf6/resources/calculation-executor-playbook.md
+++ b/packs/codex-hermes-sf6/resources/calculation-executor-playbook.md
@@ -1,0 +1,36 @@
+# Calculation Executor Playbook
+
+This playbook is repo-local maintainer support only. It does not define public
+`sf6-agent` answer behavior.
+
+Use the deterministic executor when Hermes, Codex, or provider Codex needs to
+avoid LLM arithmetic errors while preserving SF6 authority boundaries.
+
+## Command
+
+```bash
+python packages/calculation-executor/sf6_calculation_executor.py \
+  --input tests/fixtures/calculation-executor/hypothetical-addition.json \
+  --pretty
+```
+
+## Required boundary
+
+- The executor is a calculation executor and trace generator only.
+- The executor output is not SF6 authority, formula authority, or current-fact
+  authority.
+- Hermes may request arithmetic, but provider Codex should run the repo-owned
+  script rather than doing arithmetic in natural language.
+- Codex must audit the trace against `contracts/calculation-executor-trace.md`
+  and `contracts/calculation-trace.schema.json`.
+- Missing input, formula, rounding, route, timing, or authority context must
+  produce blocked or hold behavior.
+- Do not use the executor to discover SF6 facts, infer formulas, scrape data, or
+  make public answers.
+
+## First-tranche use
+
+Use the executor for generic arithmetic and hypothetical consistency checks
+only. Do not encode combo damage, scaling tables, minimum guarantees, frame
+advantage interpretation, punish-window logic, or meaty/oki timing rules until
+accepted authority exists.

--- a/packs/codex-hermes-sf6/skill/SKILL.md
+++ b/packs/codex-hermes-sf6/skill/SKILL.md
@@ -53,11 +53,14 @@ Do not use this playbook to:
    `docs/architecture/sf6-video-analysis-protocol.md`.
 7. For external visual atlas work, check
    `docs/architecture/external-frame-atlas-policy.md`.
-8. Convert useful Hermes output into reviewed repo artifacts only when the
+8. For calculation work, check `contracts/calculation-executor-trace.md`,
+   `packs/codex-hermes-sf6/resources/calculation-executor-playbook.md`, and
+   `packs/codex-hermes-sf6/guards/calculation-executor-boundary.md`.
+9. Convert useful Hermes output into reviewed repo artifacts only when the
    target issue scope allows it.
-9. If Codex fallback analysis is used, record why Hermes-first delegation was
+10. If Codex fallback analysis is used, record why Hermes-first delegation was
    not attempted or could not complete.
-10. Run the relevant validators and record results before commit.
+11. Run the relevant validators and record results before commit.
 
 ## Review Checklist
 
@@ -71,6 +74,8 @@ Do not use this playbook to:
 - Exact current facts remain grounded in current-fact authority surfaces.
 - Web, article, video, and external visual atlas inputs do not override
   `official_raw`.
+- Calculation executors are trace generators only and do not become SF6,
+  formula, or current-fact authority.
 - Hermes memory, sessions, local skills, Curator output, browser state, cron
   state, Kanban state, and checkpoints are non-canonical.
 - Stale PR #71 and PR #83 are closed historical debt, not active sources.

--- a/tests/fixtures/calculation-executor/blocked-missing-formula-policy.json
+++ b/tests/fixtures/calculation-executor/blocked-missing-formula-policy.json
@@ -1,0 +1,32 @@
+{
+  "trace_id": "blocked-missing-formula-policy-001",
+  "trace_schema_version": "sf6-calculation-trace/v1",
+  "calculation_intent": "accepted_formula_execution",
+  "question_scope": "Attempt to execute an SF6-like formula without accepted formula policy.",
+  "input_values": {
+    "damage": "1000",
+    "modifier": "80"
+  },
+  "input_authority_refs": [],
+  "input_status": "hypothetical",
+  "formula_policy_ref": null,
+  "formula_status": "hold",
+  "rounding_policy_ref": null,
+  "rounding_status": "not_applicable",
+  "operations": [
+    {
+      "step_id": "step-1",
+      "operation_kind": "percent_of",
+      "inputs": ["modifier", "damage"],
+      "output_name": "computed_damage"
+    }
+  ],
+  "created_by": "fixture",
+  "created_at": "2026-05-17T00:00:00Z",
+  "repo_revision": "fixture",
+  "expected": {
+    "status": "blocked_missing_formula_policy",
+    "output_values": {},
+    "public_answer_allowed": false
+  }
+}

--- a/tests/fixtures/calculation-executor/blocked-missing-rounding-policy.json
+++ b/tests/fixtures/calculation-executor/blocked-missing-rounding-policy.json
@@ -1,0 +1,33 @@
+{
+  "trace_id": "blocked-missing-rounding-policy-001",
+  "trace_schema_version": "sf6-calculation-trace/v1",
+  "calculation_intent": "accepted_formula_execution",
+  "question_scope": "Attempt to execute a rounding-sensitive calculation without accepted rounding policy.",
+  "input_values": {
+    "value": "100",
+    "divisor": "3"
+  },
+  "input_authority_refs": [],
+  "input_status": "accepted",
+  "formula_policy_ref": "fixture-formula-policy",
+  "formula_status": "accepted",
+  "rounding_policy_ref": null,
+  "rounding_status": "hold",
+  "rounding_required": true,
+  "operations": [
+    {
+      "step_id": "step-1",
+      "operation_kind": "divide",
+      "inputs": ["value", "divisor"],
+      "output_name": "quotient"
+    }
+  ],
+  "created_by": "fixture",
+  "created_at": "2026-05-17T00:00:00Z",
+  "repo_revision": "fixture",
+  "expected": {
+    "status": "blocked_missing_rounding_policy",
+    "output_values": {},
+    "public_answer_allowed": false
+  }
+}

--- a/tests/fixtures/calculation-executor/hypothetical-addition.json
+++ b/tests/fixtures/calculation-executor/hypothetical-addition.json
@@ -1,0 +1,34 @@
+{
+  "trace_id": "hypothetical-addition-001",
+  "trace_schema_version": "sf6-calculation-trace/v1",
+  "calculation_intent": "hypothetical_arithmetic_check",
+  "question_scope": "Check arithmetic only for supplied hypothetical values.",
+  "input_values": {
+    "a": "100",
+    "b": "25"
+  },
+  "input_authority_refs": [],
+  "input_status": "hypothetical",
+  "formula_policy_ref": null,
+  "formula_status": "hypothetical",
+  "rounding_policy_ref": null,
+  "rounding_status": "not_applicable",
+  "operations": [
+    {
+      "step_id": "step-1",
+      "operation_kind": "add",
+      "inputs": ["a", "b"],
+      "output_name": "sum"
+    }
+  ],
+  "created_by": "fixture",
+  "created_at": "2026-05-17T00:00:00Z",
+  "repo_revision": "fixture",
+  "expected": {
+    "status": "hypothetical_arithmetic_only",
+    "output_values": {
+      "sum": "125"
+    },
+    "public_answer_allowed": false
+  }
+}

--- a/tests/fixtures/calculation-executor/hypothetical-multi-step.json
+++ b/tests/fixtures/calculation-executor/hypothetical-multi-step.json
@@ -1,0 +1,43 @@
+{
+  "trace_id": "hypothetical-multi-step-001",
+  "trace_schema_version": "sf6-calculation-trace/v1",
+  "calculation_intent": "hypothetical_arithmetic_check",
+  "question_scope": "Check a two-step arithmetic chain without SF6 formula authority.",
+  "input_values": {
+    "base": "100",
+    "bonus": "50",
+    "multiplier": "2"
+  },
+  "input_authority_refs": [],
+  "input_status": "hypothetical",
+  "formula_policy_ref": null,
+  "formula_status": "hypothetical",
+  "rounding_policy_ref": null,
+  "rounding_status": "not_applicable",
+  "operations": [
+    {
+      "step_id": "step-1",
+      "operation_kind": "add",
+      "inputs": ["base", "bonus"],
+      "output_name": "subtotal"
+    },
+    {
+      "step_id": "step-2",
+      "operation_kind": "multiply",
+      "inputs": ["subtotal", "multiplier"],
+      "output_name": "total"
+    }
+  ],
+  "created_by": "fixture",
+  "created_at": "2026-05-17T00:00:00Z",
+  "repo_revision": "fixture",
+  "expected": {
+    "status": "hypothetical_arithmetic_only",
+    "output_values": {
+      "subtotal": "150",
+      "total": "300"
+    },
+    "operation_step_count": 2,
+    "public_answer_allowed": false
+  }
+}

--- a/tests/fixtures/calculation-executor/invalid-input.json
+++ b/tests/fixtures/calculation-executor/invalid-input.json
@@ -1,0 +1,32 @@
+{
+  "trace_id": "invalid-input-001",
+  "trace_schema_version": "sf6-calculation-trace/v1",
+  "calculation_intent": "hypothetical_arithmetic_check",
+  "question_scope": "Reject malformed decimal input deterministically.",
+  "input_values": {
+    "a": "not-a-number",
+    "b": "25"
+  },
+  "input_authority_refs": [],
+  "input_status": "hypothetical",
+  "formula_policy_ref": null,
+  "formula_status": "hypothetical",
+  "rounding_policy_ref": null,
+  "rounding_status": "not_applicable",
+  "operations": [
+    {
+      "step_id": "step-1",
+      "operation_kind": "add",
+      "inputs": ["a", "b"],
+      "output_name": "sum"
+    }
+  ],
+  "created_by": "fixture",
+  "created_at": "2026-05-17T00:00:00Z",
+  "repo_revision": "fixture",
+  "expected": {
+    "status": "invalid_input",
+    "output_values": {},
+    "public_answer_allowed": false
+  }
+}

--- a/tests/validation/run-all.ps1
+++ b/tests/validation/run-all.ps1
@@ -43,6 +43,7 @@ $validationScripts = @(
   'tests/validation/validate-agent-toolchain.ps1',
   'tests/validation/validate-answer-orchestration-contracts.ps1',
   'tests/validation/validate-answer-smoke-fixtures.ps1',
+  'tests/validation/validate-calculation-executor.ps1',
   'tests/validation/validate-normalization-aliases.ps1',
   'tests/validation/validate-normalization-runtime-assets.ps1',
   'tests/validation/validate-knowledge-schema.ps1',

--- a/tests/validation/validate-calculation-executor.ps1
+++ b/tests/validation/validate-calculation-executor.ps1
@@ -1,0 +1,194 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$scriptPath = Join-Path $repoRoot 'packages/calculation-executor/sf6_calculation_executor.py'
+$fixtureRoot = Join-Path $repoRoot 'tests/fixtures/calculation-executor'
+
+$allowedExecutorRoles = @('calculation_executor', 'trace_generator', 'arithmetic_consistency_checker')
+$allowedStatuses = @(
+  'not_run',
+  'trace_generated',
+  'hypothetical_arithmetic_only',
+  'accepted_formula_execution',
+  'blocked_missing_input_authority',
+  'blocked_missing_formula_policy',
+  'blocked_missing_rounding_policy',
+  'blocked_ambiguous_route',
+  'blocked_public_answer_boundary',
+  'invalid_input',
+  'executor_error',
+  'out_of_scope'
+)
+$blockedOrNonPublicStatuses = @(
+  'not_run',
+  'trace_generated',
+  'hypothetical_arithmetic_only',
+  'blocked_missing_input_authority',
+  'blocked_missing_formula_policy',
+  'blocked_missing_rounding_policy',
+  'blocked_ambiguous_route',
+  'blocked_public_answer_boundary',
+  'invalid_input',
+  'executor_error',
+  'out_of_scope'
+)
+
+function Add-Issue {
+  param(
+    [Parameter(Mandatory = $true)][ref]$Issues,
+    [Parameter(Mandatory = $true)][string]$Message
+  )
+  $Issues.Value += $Message
+}
+
+function Assert-Property {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  if (-not ($Object.PSObject.Properties.Name -contains $Name)) {
+    Add-Issue $Issues "$Context missing field: $Name"
+  }
+}
+
+$issues = @()
+
+if (-not (Test-Path -LiteralPath $scriptPath -PathType Leaf)) {
+  throw 'Missing calculation executor script'
+}
+if (-not (Test-Path -LiteralPath $fixtureRoot -PathType Container)) {
+  throw 'Missing calculation executor fixture directory'
+}
+
+$pythonCommand = Get-Command python -ErrorAction SilentlyContinue
+if (-not $pythonCommand) {
+  throw 'Python executable not found on PATH'
+}
+
+$fixtureFiles = @(Get-ChildItem -LiteralPath $fixtureRoot -File -Filter '*.json' | Sort-Object Name)
+if ($fixtureFiles.Count -eq 0) {
+  throw 'No calculation executor fixtures found'
+}
+
+foreach ($fixtureFile in $fixtureFiles) {
+  $relativePath = $fixtureFile.FullName.Substring($repoRoot.Length + 1).Replace('\', '/')
+  $fixture = Get-Content -LiteralPath $fixtureFile.FullName -Raw -Encoding UTF8 | ConvertFrom-Json
+  $outputText = & $pythonCommand.Source $scriptPath --input $fixtureFile.FullName
+  if ($LASTEXITCODE -ne 0) {
+    Add-Issue ([ref]$issues) "$relativePath executor exited with code $LASTEXITCODE"
+    continue
+  }
+
+  try {
+    $trace = $outputText | ConvertFrom-Json
+  }
+  catch {
+    Add-Issue ([ref]$issues) "$relativePath executor output is not JSON"
+    continue
+  }
+
+  foreach ($field in @(
+    'trace_id',
+    'trace_schema_version',
+    'executor_id',
+    'executor_role',
+    'executor_authority_status',
+    'calculation_intent',
+    'question_scope',
+    'input_values',
+    'input_authority_refs',
+    'input_status',
+    'formula_policy_ref',
+    'formula_status',
+    'rounding_policy_ref',
+    'rounding_status',
+    'operation_steps',
+    'output_values',
+    'status',
+    'public_answer_allowed',
+    'generated_reference_allowed',
+    'accepted_current_fact_authority',
+    'uncertainty_or_hold_reasons',
+    'created_by',
+    'created_at',
+    'repo_revision',
+    'limitations'
+  )) {
+    Assert-Property $trace $field $relativePath ([ref]$issues)
+  }
+
+  if ($trace.trace_schema_version -ne 'sf6-calculation-trace/v1') {
+    Add-Issue ([ref]$issues) "$relativePath output has unexpected trace_schema_version"
+  }
+  if ($trace.executor_role -notin $allowedExecutorRoles) {
+    Add-Issue ([ref]$issues) "$relativePath output has invalid executor_role: $($trace.executor_role)"
+  }
+  if ($trace.status -notin $allowedStatuses) {
+    Add-Issue ([ref]$issues) "$relativePath output has invalid status: $($trace.status)"
+  }
+  if ($trace.accepted_current_fact_authority -ne $false) {
+    Add-Issue ([ref]$issues) "$relativePath output must not be accepted current-fact authority"
+  }
+  if ($trace.generated_reference_allowed -ne $false) {
+    Add-Issue ([ref]$issues) "$relativePath output must not feed generated references"
+  }
+  if ($trace.status -in $blockedOrNonPublicStatuses -and $trace.public_answer_allowed -ne $false) {
+    Add-Issue ([ref]$issues) "$relativePath non-public status must not allow public answers"
+  }
+
+  foreach ($authorityFlag in @('not_sf6_authority', 'not_formula_authority', 'not_current_fact_authority')) {
+    if (@($trace.executor_authority_status) -notcontains $authorityFlag) {
+      Add-Issue ([ref]$issues) "$relativePath missing executor authority flag: $authorityFlag"
+    }
+  }
+
+  foreach ($step in @($trace.operation_steps)) {
+    foreach ($field in @('step_id', 'operation_kind', 'inputs_used', 'output', 'rounding_applied', 'policy_ref', 'notes')) {
+      Assert-Property $step $field "$relativePath operation step" ([ref]$issues)
+    }
+  }
+
+  $expected = $fixture.expected
+  if ($expected) {
+    if ($trace.status -ne $expected.status) {
+      Add-Issue ([ref]$issues) "$relativePath expected status $($expected.status), got $($trace.status)"
+    }
+    if ($trace.public_answer_allowed -ne $expected.public_answer_allowed) {
+      Add-Issue ([ref]$issues) "$relativePath public_answer_allowed mismatch"
+    }
+    if ($expected.PSObject.Properties.Name -contains 'operation_step_count') {
+      if (@($trace.operation_steps).Count -ne $expected.operation_step_count) {
+        Add-Issue ([ref]$issues) "$relativePath expected $($expected.operation_step_count) operation step(s), got $(@($trace.operation_steps).Count)"
+      }
+    }
+    if ($expected.output_values) {
+      foreach ($property in $expected.output_values.PSObject.Properties) {
+        $actualProperty = $trace.output_values.PSObject.Properties[$property.Name]
+        if (-not $actualProperty) {
+          Add-Issue ([ref]$issues) "$relativePath missing output value: $($property.Name)"
+          continue
+        }
+        if ($actualProperty.Value -ne $property.Value) {
+          Add-Issue ([ref]$issues) "$relativePath expected output $($property.Name)=$($property.Value), got $($actualProperty.Value)"
+        }
+      }
+    }
+  }
+
+  $rawFixtureText = Get-Content -LiteralPath $fixtureFile.FullName -Raw -Encoding UTF8
+  foreach ($forbidden in @('Hermes memory', 'raw transcript', 'credential', 'secret', 'token', 'official_raw override')) {
+    if ($rawFixtureText -match [regex]::Escape($forbidden)) {
+      Add-Issue ([ref]$issues) "$relativePath contains forbidden local-state or authority text: $forbidden"
+    }
+  }
+}
+
+if ($issues.Count -gt 0) {
+  throw ($issues -join '; ')
+}
+
+Write-Host 'Calculation executor OK'

--- a/tests/validation/validate-codex-hermes-pack.ps1
+++ b/tests/validation/validate-codex-hermes-pack.ps1
@@ -47,11 +47,13 @@ $requiredFiles = @(
   'packs/codex-hermes-sf6/resources/hermes-cli-capability-reference.md',
   'packs/codex-hermes-sf6/resources/sf6-video-analysis-protocol.md',
   'packs/codex-hermes-sf6/resources/external-frame-atlas-policy.md',
+  'packs/codex-hermes-sf6/resources/calculation-executor-playbook.md',
   'packs/codex-hermes-sf6/guards/hermes-local-state-boundary.md',
   'packs/codex-hermes-sf6/guards/current-fact-boundary.md',
   'packs/codex-hermes-sf6/guards/article-video-boundary.md',
   'packs/codex-hermes-sf6/guards/video-observation-boundary.md',
-  'packs/codex-hermes-sf6/guards/external-visual-asset-boundary.md'
+  'packs/codex-hermes-sf6/guards/external-visual-asset-boundary.md',
+  'packs/codex-hermes-sf6/guards/calculation-executor-boundary.md'
 )
 
 $issues = @()

--- a/tests/validation/validate-v2-contracts.ps1
+++ b/tests/validation/validate-v2-contracts.ps1
@@ -12,12 +12,14 @@ $requiredJsonSchemas = @(
   'contracts/answer-intent.schema.json',
   'contracts/evidence-card.schema.json',
   'contracts/answer-plan.schema.json',
+  'contracts/calculation-trace.schema.json',
   'contracts/normalization-aliases.schema.json',
   'contracts/agent-toolchain.schema.json'
 )
 
 $requiredDocs = @(
   'contracts/frame-current-runtime-assets.md',
+  'contracts/calculation-executor-trace.md',
   'contracts/video-observation.md',
   'contracts/evidence-gate.md',
   'contracts/web-research-policy.md'


### PR DESCRIPTION
## Summary

- Add a repo-owned deterministic calculation executor script under `packages/calculation-executor/`.
- Add `contracts/calculation-trace.schema.json` and fixture coverage for hypothetical arithmetic, blocked formula/rounding cases, and invalid input.
- Add `validate-calculation-executor.ps1` and wire it into `run-all.ps1`.
- Add Codex-Hermes playbook and guard docs so Hermes/Codex/provider Codex use the script as an executor only.

Closes #212.

## Hermes-first analysis

Hermes was used as the primary implementation-design analyst. Hermes recommended Python stdlib only, JSON stdin/file input, trace JSON output, fixture-backed validation, and no third-party authority skill.

Codex role: Hermes operator, boundary auditor, artifact converter, implementation executor, validator runner, PR executor.

Hermes output status: primary draft input only, not canonical evidence.

No Hermes raw transcript, memory, sessions, local skills, logs, caches, credentials, secrets, tokens, or local state are committed.

## Executor model

The executor uses Python stdlib `decimal.Decimal` and supports only formula-neutral arithmetic operations in this tranche:

- `add`
- `subtract`
- `multiply`
- `divide`
- `sum`
- `min`
- `max`
- `difference`
- `compare`
- `percent_of`

It emits `sf6-calculation-trace/v1` JSON and always keeps `accepted_current_fact_authority: false`.

## Not changed

- No third-party/wild math skill was installed or trusted as authority.
- No SF6 combo damage formulas, scaling tables, frame timing formulas, punish-window rules, meaty/oki rules, resource formulas, or rounding policy were accepted.
- No review-only source claim, video observation, current-fact candidate, combo fixture, or trace output was promoted.
- No public `sf6-agent` behavior changed.
- No `data/exports`, `data/roster`, `official_raw`, generated references, frame-current assets, normalization assets, `.dist`, or current facts changed.

## Validation

- `python packages/calculation-executor/sf6_calculation_executor.py --input tests/fixtures/calculation-executor/hypothetical-addition.json --pretty` PASS
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-calculation-executor.ps1` PASS
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-v2-contracts.ps1` PASS
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-codex-hermes-pack.ps1` PASS
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1` PASS
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1` PASS
- `git diff --check` PASS
- `git diff --check origin/main...HEAD` PASS
