### PR TITLE
[v2.6] Add calculation executor percent smoke

### DIFF
--- a/docs/testing/smoke-runs/calculation-executor-percent-smoke-20260517.md
+++ b/docs/testing/smoke-runs/calculation-executor-percent-smoke-20260517.md
@@ -1,0 +1,76 @@
+# Calculation Executor Percent Smoke - 2026-05-17
+
+## Summary
+
+This smoke run verifies that the deterministic calculation executor can handle
+SF6-shaped percentage arithmetic without becoming SF6 authority.
+
+The calculation is intentionally hypothetical:
+
+- base value: `80`
+- modifier: `85%`
+- computed output: `68`
+
+This smoke run does not define or accept any SF6 combo scaling formula,
+rounding rule, damage formula, current system mechanic, or public answer
+behavior.
+
+## Command
+
+```bash
+python packages/calculation-executor/sf6_calculation_executor.py \
+  --input tests/fixtures/calculation-executor/hypothetical-percent-consistency.json \
+  --pretty
+```
+
+## Trace Summary
+
+| Field | Value |
+|---|---|
+| `trace_id` | `hypothetical-percent-consistency-001` |
+| `trace_schema_version` | `sf6-calculation-trace/v1` |
+| `executor_id` | `sf6_calculation_executor.py@v1` |
+| `executor_role` | `calculation_executor` |
+| `calculation_intent` | `hypothetical_arithmetic_check` |
+| `input_status` | `hypothetical` |
+| `formula_status` | `hypothetical` |
+| `rounding_status` | `not_applicable` |
+| `operation_kind` | `percent_of` |
+| `output_values.composed_percent` | `68` |
+| `status` | `hypothetical_arithmetic_only` |
+| `public_answer_allowed` | `false` |
+| `generated_reference_allowed` | `false` |
+| `accepted_current_fact_authority` | `false` |
+
+## Boundary Audit
+
+- The executor output is arithmetic trace evidence only.
+- The trace is not SF6 authority.
+- The trace is not formula authority.
+- The trace is not current-fact authority.
+- The fixture has no `input_authority_refs` because the values are
+  hypothetical.
+- The trace does not cite `data/exports/`, `data/roster`, `official_raw`,
+  generated references, video observations, review-only candidates, or combo
+  fixtures as current-fact authority.
+- The trace must not support public current-fact answers.
+
+## What Was Not Done
+
+- No third-party math skill was installed.
+- No SF6 formula was accepted.
+- No combo damage, scaling table, minimum guarantee, frame timing, punish
+  window, meaty/oki, resource, or rounding policy was added.
+- No public `sf6-agent` behavior changed.
+- No generated references, frame-current assets, normalization assets,
+  `data/exports`, `data/roster`, `official_raw`, `.dist`, or current facts were
+  changed.
+- No Hermes memory, sessions, raw transcripts, logs, caches, credentials,
+  secrets, tokens, or hidden tool state were committed.
+
+## Validation
+
+- `python packages/calculation-executor/sf6_calculation_executor.py --input tests/fixtures/calculation-executor/hypothetical-percent-consistency.json --pretty`
+  - PASS
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-calculation-executor.ps1`
+  - PASS

--- a/tests/fixtures/calculation-executor/hypothetical-percent-consistency.json
+++ b/tests/fixtures/calculation-executor/hypothetical-percent-consistency.json
@@ -1,0 +1,36 @@
+{
+  "trace_id": "hypothetical-percent-consistency-001",
+  "trace_schema_version": "sf6-calculation-trace/v1",
+  "calculation_intent": "hypothetical_arithmetic_check",
+  "question_scope": "Check whether hypothetical 85% of hypothetical 80 is arithmetically consistent with 68.",
+  "input_values": {
+    "base_percent": "80",
+    "modifier_percent": "85"
+  },
+  "input_authority_refs": [],
+  "input_status": "hypothetical",
+  "formula_policy_ref": null,
+  "formula_status": "hypothetical",
+  "rounding_policy_ref": null,
+  "rounding_status": "not_applicable",
+  "operations": [
+    {
+      "step_id": "step-1",
+      "operation_kind": "percent_of",
+      "inputs": ["modifier_percent", "base_percent"],
+      "output_name": "composed_percent",
+      "notes": "Generic arithmetic only: 85 percent of 80 equals 68."
+    }
+  ],
+  "created_by": "fixture",
+  "created_at": "2026-05-17T00:00:00Z",
+  "repo_revision": "fixture",
+  "expected": {
+    "status": "hypothetical_arithmetic_only",
+    "output_values": {
+      "composed_percent": "68"
+    },
+    "operation_step_count": 1,
+    "public_answer_allowed": false
+  }
+}


### PR DESCRIPTION
## Summary

- Add a calculation-executor fixture for hypothetical percentage composition: 85% of 80 = 68.
- Add a docs-only smoke report recording the executor command, trace summary, and non-authority boundary.

Closes #214.

## Boundary

This is hypothetical arithmetic only. It does not define or accept any SF6 combo scaling formula, damage formula, rounding rule, minimum guarantee, current system mechanic, or public answer behavior.

The resulting trace status is `hypothetical_arithmetic_only` and keeps:

- `public_answer_allowed: false`
- `generated_reference_allowed: false`
- `accepted_current_fact_authority: false`

## Not changed

- No third-party math skill was installed.
- No SF6 formula was accepted.
- No review-only source claim, video observation, current-fact candidate, combo fixture, or trace output was promoted.
- No public `sf6-agent` behavior changed.
- No `data/exports`, `data/roster`, `official_raw`, generated references, frame-current assets, normalization assets, `.dist`, or current facts changed.
- No Hermes memory, sessions, raw transcripts, logs, caches, credentials, secrets, tokens, or hidden tool state were committed.

## Validation

- `python packages/calculation-executor/sf6_calculation_executor.py --input tests/fixtures/calculation-executor/hypothetical-percent-consistency.json --pretty` PASS
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-calculation-executor.ps1` PASS
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1` PASS
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1` PASS
- `git diff --check` PASS
- `git diff --check origin/main...HEAD` PASS
