### PR TITLE
[v2.6] Add repository surface registry seed

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -36,3 +36,8 @@ When `source_refs.path` points to a migrated legacy file, `source_revision` iden
 
 - `agent-toolchain.schema.json`: maintainer agent toolchain policy contract for reviewed capabilities and freshness expectations.
 - `data/toolchain/`: canonical maintainer-toolchain policy data, not SF6 gameplay knowledge or exact current-fact authority.
+
+## Repository Surface Registry
+
+- `repository-surface.schema.json`: machine-readable index contract for canonical, derived, deferred legacy, repo-local support, historical, and non-canonical repository surfaces.
+- `data/repository-surfaces.json`: seed registry of existing reviewed boundaries. The registry indexes current policy; it does not replace `AGENTS.md`, ADRs, workflows, or validators as policy sources yet.

--- a/contracts/repository-surface.schema.json
+++ b/contracts/repository-surface.schema.json
@@ -1,0 +1,169 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sf6-knowledge-agent-kit.local/repository-surface.schema.json",
+  "title": "Repository Surface Registry",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "last_reviewed",
+    "registry_status",
+    "policy_refs",
+    "surfaces"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "repository-surfaces/v1"
+    },
+    "last_reviewed": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+    "registry_status": {
+      "type": "string",
+      "const": "seed_index_of_existing_reviewed_boundaries"
+    },
+    "policy_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "surfaces": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "title",
+          "path_globs",
+          "path_state",
+          "surface_role",
+          "authority_scope",
+          "source_of_truth",
+          "generated",
+          "generator",
+          "source_paths",
+          "allowed_to_edit_directly",
+          "public_distribution_status",
+          "normal_public_answer_authority",
+          "validation_expectation",
+          "policy_refs",
+          "notes"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9_]*$"
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "path_globs": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "uniqueItems": true
+          },
+          "path_state": {
+            "type": "string",
+            "enum": [
+              "tracked_present",
+              "generated_untracked",
+              "documented_absent"
+            ]
+          },
+          "surface_role": {
+            "type": "string",
+            "enum": [
+              "canonical",
+              "derived",
+              "deferred_legacy",
+              "repo_local_support",
+              "historical",
+              "non_canonical"
+            ]
+          },
+          "authority_scope": {
+            "type": "string",
+            "minLength": 1
+          },
+          "source_of_truth": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "uniqueItems": true
+          },
+          "generated": {
+            "type": "boolean"
+          },
+          "generator": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "source_paths": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "uniqueItems": true
+          },
+          "allowed_to_edit_directly": {
+            "type": "boolean"
+          },
+          "public_distribution_status": {
+            "type": "string",
+            "enum": [
+              "not_distribution",
+              "private_repo_local",
+              "deferred",
+              "mixed_private_and_deferred",
+              "public_active"
+            ]
+          },
+          "normal_public_answer_authority": {
+            "type": "boolean"
+          },
+          "validation_expectation": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "uniqueItems": true
+          },
+          "policy_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "uniqueItems": true
+          },
+          "notes": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/data/repository-surfaces.json
+++ b/data/repository-surfaces.json
@@ -1,0 +1,673 @@
+{
+  "schema_version": "repository-surfaces/v1",
+  "last_reviewed": "2026-05-17",
+  "registry_status": "seed_index_of_existing_reviewed_boundaries",
+  "policy_refs": [
+    "AGENTS.md",
+    "docs/architecture/decisions/0002-private-hermes-first-operation.md",
+    "docs/architecture/harness-and-distribution-roles.md",
+    "docs/architecture/reviews/full-directory-refactor-audit-20260517.md"
+  ],
+  "surfaces": [
+    {
+      "id": "knowledge",
+      "title": "Knowledge Root",
+      "path_globs": [
+        "knowledge/*"
+      ],
+      "path_state": "tracked_present",
+      "surface_role": "canonical",
+      "authority_scope": "repo knowledge source root with mixed answer authority by sub-surface",
+      "source_of_truth": [
+        "self"
+      ],
+      "generated": false,
+      "generator": null,
+      "source_paths": [],
+      "allowed_to_edit_directly": true,
+      "public_distribution_status": "not_distribution",
+      "normal_public_answer_authority": false,
+      "validation_expectation": [
+        "knowledge_schema_valid",
+        "source_metadata_preserved"
+      ],
+      "policy_refs": [
+        "AGENTS.md"
+      ],
+      "notes": "Canonical knowledge root. Public answer authority depends on sub-surface; exact current facts remain outside curated prose."
+    },
+    {
+      "id": "knowledge_curated",
+      "title": "Curated Knowledge",
+      "path_globs": [
+        "knowledge/curated/*"
+      ],
+      "path_state": "tracked_present",
+      "surface_role": "canonical",
+      "authority_scope": "curated stable knowledge without exact current move values",
+      "source_of_truth": [
+        "self"
+      ],
+      "generated": false,
+      "generator": null,
+      "source_paths": [],
+      "allowed_to_edit_directly": true,
+      "public_distribution_status": "not_distribution",
+      "normal_public_answer_authority": true,
+      "validation_expectation": [
+        "knowledge_schema_valid",
+        "no_exact_current_values"
+      ],
+      "policy_refs": [
+        "AGENTS.md",
+        "contracts/evidence-gate.md"
+      ],
+      "notes": "Curated prose is canonical for stable concepts, not for exact current frame data."
+    },
+    {
+      "id": "data_exports",
+      "title": "Current Fact Exports",
+      "path_globs": [
+        "data/exports/*/snapshot_manifest.json",
+        "data/exports/*/official_raw.json",
+        "data/exports/*/derived_metrics.json",
+        "data/exports/*/supercombo_enrichment.json"
+      ],
+      "path_state": "tracked_present",
+      "surface_role": "canonical",
+      "authority_scope": "exact current fact authority",
+      "source_of_truth": [
+        "self"
+      ],
+      "generated": false,
+      "generator": null,
+      "source_paths": [],
+      "allowed_to_edit_directly": false,
+      "public_distribution_status": "not_distribution",
+      "normal_public_answer_authority": true,
+      "validation_expectation": [
+        "ingest_artifacts_valid",
+        "raw_snapshot_manifest_consistent"
+      ],
+      "policy_refs": [
+        "AGENTS.md",
+        "ingest/frame_data/README.md"
+      ],
+      "notes": "Published current facts are canonical; manual-review sidecars remain non-canonical."
+    },
+    {
+      "id": "data_roster",
+      "title": "Current Character Roster",
+      "path_globs": [
+        "data/roster/*"
+      ],
+      "path_state": "tracked_present",
+      "surface_role": "canonical",
+      "authority_scope": "current roster authority",
+      "source_of_truth": [
+        "self"
+      ],
+      "generated": false,
+      "generator": null,
+      "source_paths": [],
+      "allowed_to_edit_directly": true,
+      "public_distribution_status": "not_distribution",
+      "normal_public_answer_authority": true,
+      "validation_expectation": [
+        "roster_source_valid"
+      ],
+      "policy_refs": [
+        "AGENTS.md"
+      ],
+      "notes": "Roster data grounds current character coverage and generated runtime assets."
+    },
+    {
+      "id": "contracts",
+      "title": "Contracts",
+      "path_globs": [
+        "contracts/*"
+      ],
+      "path_state": "tracked_present",
+      "surface_role": "canonical",
+      "authority_scope": "schemas and artifact contracts",
+      "source_of_truth": [
+        "self"
+      ],
+      "generated": false,
+      "generator": null,
+      "source_paths": [],
+      "allowed_to_edit_directly": true,
+      "public_distribution_status": "not_distribution",
+      "normal_public_answer_authority": false,
+      "validation_expectation": [
+        "contract_schema_discoverable",
+        "validator_contract_layer_present"
+      ],
+      "policy_refs": [
+        "AGENTS.md",
+        "contracts/README.md"
+      ],
+      "notes": "Canonical schema and contract surface, not SF6 gameplay answer evidence by itself."
+    },
+    {
+      "id": "workflows",
+      "title": "Maintainer Workflows",
+      "path_globs": [
+        "workflows/*"
+      ],
+      "path_state": "tracked_present",
+      "surface_role": "canonical",
+      "authority_scope": "maintainer procedure authority",
+      "source_of_truth": [
+        "self"
+      ],
+      "generated": false,
+      "generator": null,
+      "source_paths": [],
+      "allowed_to_edit_directly": true,
+      "public_distribution_status": "private_repo_local",
+      "normal_public_answer_authority": false,
+      "validation_expectation": [
+        "doc_links_valid"
+      ],
+      "policy_refs": [
+        "AGENTS.md",
+        "workflows/codex-to-hermes-delegation.md"
+      ],
+      "notes": "Canonical maintainer procedures for private Hermes-first operation."
+    },
+    {
+      "id": "evals",
+      "title": "Answer Quality Evals",
+      "path_globs": [
+        "evals/*"
+      ],
+      "path_state": "tracked_present",
+      "surface_role": "canonical",
+      "authority_scope": "answer quality cases and rubrics",
+      "source_of_truth": [
+        "self"
+      ],
+      "generated": false,
+      "generator": null,
+      "source_paths": [],
+      "allowed_to_edit_directly": true,
+      "public_distribution_status": "not_distribution",
+      "normal_public_answer_authority": false,
+      "validation_expectation": [
+        "evals_valid"
+      ],
+      "policy_refs": [
+        "AGENTS.md"
+      ],
+      "notes": "Canonical for answer-quality expectations, not direct current-fact evidence."
+    },
+    {
+      "id": "generated_knowledge_references",
+      "title": "Generated Skill Knowledge References",
+      "path_globs": [
+        "skills/sf6-agent/references/generated-*"
+      ],
+      "path_state": "tracked_present",
+      "surface_role": "derived",
+      "authority_scope": "generated adapter references from curated knowledge",
+      "source_of_truth": [
+        "knowledge/curated"
+      ],
+      "generated": true,
+      "generator": "packages/knowledge-generation/build-sf6-agent-knowledge.ps1",
+      "source_paths": [
+        "knowledge/curated"
+      ],
+      "allowed_to_edit_directly": false,
+      "public_distribution_status": "deferred",
+      "normal_public_answer_authority": false,
+      "validation_expectation": [
+        "generated_marker_present",
+        "source_paths_present",
+        "generated_knowledge_valid"
+      ],
+      "policy_refs": [
+        "AGENTS.md",
+        "contracts/generated-surface.schema.json"
+      ],
+      "notes": "Generated derived output for the deferred public adapter surface."
+    },
+    {
+      "id": "frame_current_runtime_assets",
+      "title": "Frame Current Runtime Assets",
+      "path_globs": [
+        "skills/sf6-agent/assets/frame-current/*"
+      ],
+      "path_state": "tracked_present",
+      "surface_role": "derived",
+      "authority_scope": "derived exact current-fact runtime payload",
+      "source_of_truth": [
+        "data/exports",
+        "data/roster"
+      ],
+      "generated": true,
+      "generator": "packages/skill-packaging/build-frame-current-runtime-assets.ps1",
+      "source_paths": [
+        "data/exports",
+        "data/roster/current-character-roster.json"
+      ],
+      "allowed_to_edit_directly": false,
+      "public_distribution_status": "mixed_private_and_deferred",
+      "normal_public_answer_authority": true,
+      "validation_expectation": [
+        "frame_current_assets_valid",
+        "generated_marker_present",
+        "csv_sidecars_excluded"
+      ],
+      "policy_refs": [
+        "AGENTS.md",
+        "contracts/frame-current-runtime-assets.md"
+      ],
+      "notes": "Derived from exact current-fact authority but currently located under deferred public adapter path."
+    },
+    {
+      "id": "normalization_runtime_assets",
+      "title": "Normalization Runtime Assets",
+      "path_globs": [
+        "skills/sf6-agent/assets/normalization/*"
+      ],
+      "path_state": "tracked_present",
+      "surface_role": "derived",
+      "authority_scope": "query normalization runtime payload",
+      "source_of_truth": [
+        "data/aliases"
+      ],
+      "generated": true,
+      "generator": "packages/skill-packaging/build-normalization-runtime-assets.ps1",
+      "source_paths": [
+        "data/aliases"
+      ],
+      "allowed_to_edit_directly": false,
+      "public_distribution_status": "mixed_private_and_deferred",
+      "normal_public_answer_authority": false,
+      "validation_expectation": [
+        "normalization_runtime_assets_valid",
+        "not_current_fact_authority"
+      ],
+      "policy_refs": [
+        "AGENTS.md",
+        "contracts/normalization-aliases.schema.json"
+      ],
+      "notes": "Generated query-normalization support, not exact current-fact authority."
+    },
+    {
+      "id": "release_bundle_dist",
+      "title": "Release Bundle Output",
+      "path_globs": [
+        ".dist/sf6-agent-bundle.zip"
+      ],
+      "path_state": "generated_untracked",
+      "surface_role": "derived",
+      "authority_scope": "generated release bundle output",
+      "source_of_truth": [
+        "skills/sf6-agent",
+        "packages/skill-packaging"
+      ],
+      "generated": true,
+      "generator": "packages/skill-packaging/build-release-bundle.ps1",
+      "source_paths": [
+        "skills/sf6-agent",
+        "packages/skill-packaging"
+      ],
+      "allowed_to_edit_directly": false,
+      "public_distribution_status": "deferred",
+      "normal_public_answer_authority": false,
+      "validation_expectation": [
+        "distribution_valid_when_built",
+        "not_tracked"
+      ],
+      "policy_refs": [
+        "docs/architecture/decisions/0002-private-hermes-first-operation.md",
+        "docs/architecture/reviews/full-directory-refactor-audit-20260517.md"
+      ],
+      "notes": "Generated bundle for deferred public distribution. It may exist locally after validation but should not be tracked."
+    },
+    {
+      "id": "sf6_agent_public_adapter",
+      "title": "SF6 Agent Public Adapter",
+      "path_globs": [
+        "skills/sf6-agent/*"
+      ],
+      "path_state": "tracked_present",
+      "surface_role": "deferred_legacy",
+      "authority_scope": "adapter behavior for deferred public skill distribution",
+      "source_of_truth": [
+        "skills/sf6-agent/SKILL.md",
+        "AGENTS.md"
+      ],
+      "generated": false,
+      "generator": null,
+      "source_paths": [],
+      "allowed_to_edit_directly": true,
+      "public_distribution_status": "deferred",
+      "normal_public_answer_authority": false,
+      "validation_expectation": [
+        "legacy_cleanup_boundary_preserved",
+        "current_fact_boundaries_preserved"
+      ],
+      "policy_refs": [
+        "AGENTS.md",
+        "docs/architecture/decisions/0002-private-hermes-first-operation.md"
+      ],
+      "notes": "Existing public adapter surface. Active product focus is deferred while private Hermes-first operation is stabilized."
+    },
+    {
+      "id": "validation_scripts",
+      "title": "Validation Scripts",
+      "path_globs": [
+        "tests/validation/*"
+      ],
+      "path_state": "tracked_present",
+      "surface_role": "repo_local_support",
+      "authority_scope": "executable repository contract layer",
+      "source_of_truth": [
+        "contracts",
+        "AGENTS.md"
+      ],
+      "generated": false,
+      "generator": null,
+      "source_paths": [],
+      "allowed_to_edit_directly": true,
+      "public_distribution_status": "private_repo_local",
+      "normal_public_answer_authority": false,
+      "validation_expectation": [
+        "run_all_includes_expected_validators"
+      ],
+      "policy_refs": [
+        "AGENTS.md",
+        "contracts/README.md"
+      ],
+      "notes": "Repo-local executable checks for contracts, generated surfaces, and boundary rules."
+    },
+    {
+      "id": "knowledge_generation_package",
+      "title": "Knowledge Generation Package",
+      "path_globs": [
+        "packages/knowledge-generation/*"
+      ],
+      "path_state": "tracked_present",
+      "surface_role": "repo_local_support",
+      "authority_scope": "generated knowledge reference builder",
+      "source_of_truth": [
+        "knowledge/curated"
+      ],
+      "generated": false,
+      "generator": null,
+      "source_paths": [],
+      "allowed_to_edit_directly": true,
+      "public_distribution_status": "mixed_private_and_deferred",
+      "normal_public_answer_authority": false,
+      "validation_expectation": [
+        "generated_knowledge_reproducible"
+      ],
+      "policy_refs": [
+        "packages/README.md",
+        "docs/architecture/decisions/0002-private-hermes-first-operation.md"
+      ],
+      "notes": "Builder for derived knowledge references under the deferred public adapter path."
+    },
+    {
+      "id": "skill_packaging_package",
+      "title": "Skill Packaging Package",
+      "path_globs": [
+        "packages/skill-packaging/*"
+      ],
+      "path_state": "tracked_present",
+      "surface_role": "repo_local_support",
+      "authority_scope": "runtime asset and release bundle builders",
+      "source_of_truth": [
+        "data/exports",
+        "data/roster",
+        "data/aliases",
+        "skills/sf6-agent"
+      ],
+      "generated": false,
+      "generator": null,
+      "source_paths": [],
+      "allowed_to_edit_directly": true,
+      "public_distribution_status": "mixed_private_and_deferred",
+      "normal_public_answer_authority": false,
+      "validation_expectation": [
+        "runtime_assets_reproducible",
+        "distribution_valid_when_built"
+      ],
+      "policy_refs": [
+        "packages/README.md",
+        "docs/architecture/reviews/full-directory-refactor-audit-20260517.md"
+      ],
+      "notes": "Currently mixes private runtime asset builders with deferred public distribution bundle tooling."
+    },
+    {
+      "id": "skill_installers_package",
+      "title": "Skill Installer Package",
+      "path_globs": [
+        "packages/skill-installers/*"
+      ],
+      "path_state": "tracked_present",
+      "surface_role": "deferred_legacy",
+      "authority_scope": "deferred public skill installer tooling",
+      "source_of_truth": [
+        "packages/skill-installers"
+      ],
+      "generated": false,
+      "generator": null,
+      "source_paths": [],
+      "allowed_to_edit_directly": true,
+      "public_distribution_status": "deferred",
+      "normal_public_answer_authority": false,
+      "validation_expectation": [
+        "legacy_distribution_boundary_preserved"
+      ],
+      "policy_refs": [
+        "docs/architecture/decisions/0002-private-hermes-first-operation.md",
+        "docs/architecture/reviews/full-directory-refactor-audit-20260517.md"
+      ],
+      "notes": "Installer tooling belongs to deferred public distribution and should not drive private operation design."
+    },
+    {
+      "id": "skill_validator_package",
+      "title": "Skill Validator Package",
+      "path_globs": [
+        "packages/skill-validator/*"
+      ],
+      "path_state": "tracked_present",
+      "surface_role": "repo_local_support",
+      "authority_scope": "skill validation support placeholder",
+      "source_of_truth": [
+        "packages/skill-validator"
+      ],
+      "generated": false,
+      "generator": null,
+      "source_paths": [],
+      "allowed_to_edit_directly": true,
+      "public_distribution_status": "mixed_private_and_deferred",
+      "normal_public_answer_authority": false,
+      "validation_expectation": [
+        "package_boundary_documented"
+      ],
+      "policy_refs": [
+        "packages/README.md",
+        "docs/architecture/decisions/0002-private-hermes-first-operation.md"
+      ],
+      "notes": "Placeholder/support surface whose future depends on deferred public adapter decisions."
+    },
+    {
+      "id": "calculation_executor_package",
+      "title": "Calculation Executor Package",
+      "path_globs": [
+        "packages/calculation-executor/*"
+      ],
+      "path_state": "tracked_present",
+      "surface_role": "repo_local_support",
+      "authority_scope": "arithmetic trace executor only",
+      "source_of_truth": [
+        "contracts/calculation-executor-trace.md",
+        "contracts/calculation-trace.schema.json"
+      ],
+      "generated": false,
+      "generator": null,
+      "source_paths": [],
+      "allowed_to_edit_directly": true,
+      "public_distribution_status": "private_repo_local",
+      "normal_public_answer_authority": false,
+      "validation_expectation": [
+        "calculation_executor_valid",
+        "not_formula_authority"
+      ],
+      "policy_refs": [
+        "contracts/calculation-executor-trace.md"
+      ],
+      "notes": "Executor for calculation traces. It is not SF6 formula, input, or current-fact authority."
+    },
+    {
+      "id": "hermes_sf6_pack",
+      "title": "Hermes SF6 Pack",
+      "path_globs": [
+        "packs/hermes-sf6/*"
+      ],
+      "path_state": "tracked_present",
+      "surface_role": "repo_local_support",
+      "authority_scope": "repo-local Hermes orchestration support",
+      "source_of_truth": [
+        "workflows",
+        "docs/architecture"
+      ],
+      "generated": false,
+      "generator": null,
+      "source_paths": [],
+      "allowed_to_edit_directly": true,
+      "public_distribution_status": "private_repo_local",
+      "normal_public_answer_authority": false,
+      "validation_expectation": [
+        "hermes_pack_valid",
+        "noncanonical_memory_boundary_preserved"
+      ],
+      "policy_refs": [
+        "AGENTS.md",
+        "docs/architecture/harness-and-distribution-roles.md"
+      ],
+      "notes": "Repo-local orchestration support. Hermes memory, sessions, and profile state remain non-canonical."
+    },
+    {
+      "id": "codex_hermes_sf6_pack",
+      "title": "Codex-Hermes SF6 Pack",
+      "path_globs": [
+        "packs/codex-hermes-sf6/*"
+      ],
+      "path_state": "tracked_present",
+      "surface_role": "repo_local_support",
+      "authority_scope": "Codex-operated Hermes-first support",
+      "source_of_truth": [
+        "workflows/codex-to-hermes-delegation.md",
+        "docs/architecture/codex-hermes-bridge-policy.md"
+      ],
+      "generated": false,
+      "generator": null,
+      "source_paths": [],
+      "allowed_to_edit_directly": true,
+      "public_distribution_status": "private_repo_local",
+      "normal_public_answer_authority": false,
+      "validation_expectation": [
+        "codex_hermes_pack_valid",
+        "fallback_reason_boundary_preserved"
+      ],
+      "policy_refs": [
+        "AGENTS.md",
+        "workflows/codex-to-hermes-delegation.md"
+      ],
+      "notes": "Support pack for Hermes-first delegation. Canonical procedure remains in workflows and architecture docs."
+    },
+    {
+      "id": "raw_snapshots",
+      "title": "Raw Source Snapshots",
+      "path_globs": [
+        "data/raw/*"
+      ],
+      "path_state": "tracked_present",
+      "surface_role": "non_canonical",
+      "authority_scope": "raw reproducibility input, not normal public answer evidence",
+      "source_of_truth": [
+        "external_source_snapshots"
+      ],
+      "generated": false,
+      "generator": null,
+      "source_paths": [],
+      "allowed_to_edit_directly": false,
+      "public_distribution_status": "not_distribution",
+      "normal_public_answer_authority": false,
+      "validation_expectation": [
+        "raw_snapshot_minimality_valid",
+        "not_normal_public_answer_authority"
+      ],
+      "policy_refs": [
+        "AGENTS.md",
+        "ingest/frame_data/README.md"
+      ],
+      "notes": "Raw snapshots support reproducibility and ingestion review. They are not final evidence for normal public answers."
+    },
+    {
+      "id": "normalized_intermediate_state",
+      "title": "Normalized Intermediate State",
+      "path_globs": [
+        "data/normalized/*"
+      ],
+      "path_state": "documented_absent",
+      "surface_role": "non_canonical",
+      "authority_scope": "normalized intermediate state, not final evidence",
+      "source_of_truth": [
+        "ingest/frame_data"
+      ],
+      "generated": false,
+      "generator": null,
+      "source_paths": [],
+      "allowed_to_edit_directly": false,
+      "public_distribution_status": "not_distribution",
+      "normal_public_answer_authority": false,
+      "validation_expectation": [
+        "not_tracked_currently",
+        "not_normal_public_answer_authority"
+      ],
+      "policy_refs": [
+        "AGENTS.md",
+        "ingest/frame_data/README.md"
+      ],
+      "notes": "Documented boundary with no currently tracked files. If introduced, it must remain non-canonical unless a later policy changes that."
+    },
+    {
+      "id": "manual_review_sidecars",
+      "title": "Manual Review Sidecars",
+      "path_globs": [
+        "data/exports/*/*_manual_review.*"
+      ],
+      "path_state": "tracked_present",
+      "surface_role": "non_canonical",
+      "authority_scope": "manual-review holds and withheld rows",
+      "source_of_truth": [
+        "ingest/frame_data",
+        "data/exports"
+      ],
+      "generated": false,
+      "generator": null,
+      "source_paths": [],
+      "allowed_to_edit_directly": false,
+      "public_distribution_status": "not_distribution",
+      "normal_public_answer_authority": false,
+      "validation_expectation": [
+        "manual_review_not_runtime",
+        "not_normal_public_answer_authority"
+      ],
+      "policy_refs": [
+        "AGENTS.md",
+        "ingest/frame_data/README.md",
+        "contracts/frame-current-runtime-assets.md"
+      ],
+      "notes": "Manual-review sidecars record withheld or unresolved rows and must not feed normal public answer authority."
+    }
+  ]
+}

--- a/tests/validation/run-all.ps1
+++ b/tests/validation/run-all.ps1
@@ -41,6 +41,7 @@ $validationScripts = @(
   'tests/validation/validate-codex-hermes-delegation-fixtures.ps1',
   'tests/validation/validate-v2-contracts.ps1',
   'tests/validation/validate-agent-toolchain.ps1',
+  'tests/validation/validate-repository-surfaces.ps1',
   'tests/validation/validate-answer-orchestration-contracts.ps1',
   'tests/validation/validate-answer-smoke-fixtures.ps1',
   'tests/validation/validate-calculation-executor.ps1',

--- a/tests/validation/validate-repository-surfaces.ps1
+++ b/tests/validation/validate-repository-surfaces.ps1
@@ -1,0 +1,213 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$schemaPath = 'contracts/repository-surface.schema.json'
+$registryPath = 'data/repository-surfaces.json'
+
+function Read-Json {
+  param([Parameter(Mandatory = $true)][string]$RelativePath)
+  return Get-Content -LiteralPath (Join-Path $repoRoot $RelativePath) -Raw -Encoding UTF8 | ConvertFrom-Json
+}
+
+function Test-Property {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name
+  )
+  return $null -ne $Object.PSObject.Properties[$Name]
+}
+
+function Assert-Property {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+  if (-not (Test-Property $Object $Name)) {
+    $Issues.Value += "$Context missing property: $Name"
+  }
+}
+
+function Get-TrackedMatches {
+  param(
+    [Parameter(Mandatory = $true)][string[]]$TrackedPaths,
+    [Parameter(Mandatory = $true)][string]$Glob
+  )
+
+  $normalizedGlob = $Glob.Replace('\', '/')
+  if ($normalizedGlob.EndsWith('/')) {
+    $normalizedGlob = "$normalizedGlob*"
+  }
+
+  return @($TrackedPaths | Where-Object {
+    $_ -eq $normalizedGlob -or
+    $_ -like $normalizedGlob -or
+    $_ -like "$normalizedGlob/*"
+  })
+}
+
+$issues = @()
+$requiredSurfaceIds = @(
+  'knowledge',
+  'knowledge_curated',
+  'data_exports',
+  'data_roster',
+  'contracts',
+  'workflows',
+  'evals',
+  'generated_knowledge_references',
+  'frame_current_runtime_assets',
+  'normalization_runtime_assets',
+  'release_bundle_dist',
+  'sf6_agent_public_adapter',
+  'validation_scripts',
+  'knowledge_generation_package',
+  'skill_packaging_package',
+  'skill_installers_package',
+  'skill_validator_package',
+  'calculation_executor_package',
+  'hermes_sf6_pack',
+  'codex_hermes_sf6_pack',
+  'raw_snapshots',
+  'normalized_intermediate_state',
+  'manual_review_sidecars'
+)
+
+foreach ($relativePath in @($schemaPath, $registryPath)) {
+  if (-not (Test-Path -LiteralPath (Join-Path $repoRoot $relativePath) -PathType Leaf)) {
+    $issues += "Missing repository surface file: $relativePath"
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot $schemaPath) -PathType Leaf) {
+  $schema = Read-Json $schemaPath
+  foreach ($field in @('$schema', '$id', 'title')) {
+    Assert-Property $schema $field $schemaPath ([ref]$issues)
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot $registryPath) -PathType Leaf) {
+  $registry = Read-Json $registryPath
+  foreach ($field in @('schema_version', 'last_reviewed', 'registry_status', 'policy_refs', 'surfaces')) {
+    Assert-Property $registry $field $registryPath ([ref]$issues)
+  }
+
+  if ((Test-Property $registry 'schema_version') -and $registry.schema_version -ne 'repository-surfaces/v1') {
+    $issues += "$registryPath must use schema_version repository-surfaces/v1"
+  }
+  if ((Test-Property $registry 'registry_status') -and $registry.registry_status -ne 'seed_index_of_existing_reviewed_boundaries') {
+    $issues += "$registryPath must remain a seed index of existing reviewed boundaries"
+  }
+
+  $trackedPaths = @()
+  $pathTrackingAvailable = $false
+  if (Get-Command git -ErrorAction SilentlyContinue) {
+    $trackedPaths = @(& git -C $repoRoot ls-files)
+    if ($LASTEXITCODE -ne 0) {
+      throw 'Unable to list tracked repository files'
+    }
+    $pathTrackingAvailable = $true
+  } else {
+    Write-Host 'WARNING: git is unavailable; skipping repository surface tracked-path checks'
+  }
+
+  $surfaces = @($registry.surfaces)
+  $seenIds = @{}
+  foreach ($surface in $surfaces) {
+    $id = if (Test-Property $surface 'id') { [string]$surface.id } else { '<missing-id>' }
+    foreach ($field in @(
+      'id',
+      'title',
+      'path_globs',
+      'path_state',
+      'surface_role',
+      'authority_scope',
+      'source_of_truth',
+      'generated',
+      'generator',
+      'source_paths',
+      'allowed_to_edit_directly',
+      'public_distribution_status',
+      'normal_public_answer_authority',
+      'validation_expectation',
+      'policy_refs',
+      'notes'
+    )) {
+      Assert-Property $surface $field "$registryPath surface $id" ([ref]$issues)
+    }
+
+    if ($seenIds.ContainsKey($id)) {
+      $issues += "$registryPath duplicate surface id: $id"
+    } else {
+      $seenIds[$id] = $true
+    }
+
+    $pathMatches = @()
+    foreach ($glob in @($surface.path_globs)) {
+      $matches = @()
+      if ($pathTrackingAvailable) {
+        $matches = @(Get-TrackedMatches $trackedPaths ([string]$glob))
+      }
+      $pathMatches += $matches
+      if ($pathTrackingAvailable) {
+        if ($surface.path_state -eq 'tracked_present' -and $matches.Count -eq 0) {
+          $issues += "$registryPath surface $id path_glob has no tracked match: $glob"
+        }
+        if ($surface.path_state -eq 'documented_absent' -and $matches.Count -gt 0) {
+          $issues += "$registryPath surface $id is documented_absent but has tracked matches for: $glob"
+        }
+        if ($surface.path_state -eq 'generated_untracked' -and $matches.Count -gt 0) {
+          $issues += "$registryPath surface $id is generated_untracked but tracked files match: $glob"
+        }
+      }
+    }
+
+    if ($surface.generated -eq $true) {
+      if ($null -eq $surface.generator -or [string]::IsNullOrWhiteSpace([string]$surface.generator)) {
+        $issues += "$registryPath generated surface $id must declare generator"
+      }
+      if (@($surface.source_paths).Count -eq 0) {
+        $issues += "$registryPath generated surface $id must declare source_paths"
+      }
+      if (@($surface.source_of_truth) -contains 'self') {
+        $issues += "$registryPath generated surface $id must not use source_of_truth self"
+      }
+      if ($surface.allowed_to_edit_directly -ne $false) {
+        $issues += "$registryPath generated surface $id must not allow direct edits"
+      }
+    }
+
+    if ($surface.surface_role -eq 'canonical' -and $surface.generated -ne $false) {
+      $issues += "$registryPath canonical surface $id must not be generated"
+    }
+    if ($surface.surface_role -eq 'derived' -and $surface.generated -ne $true) {
+      $issues += "$registryPath derived surface $id must be generated"
+    }
+    if ($surface.surface_role -eq 'non_canonical' -and $surface.normal_public_answer_authority -ne $false) {
+      $issues += "$registryPath non-canonical surface $id must not be normal public answer authority"
+    }
+    if ($id -eq 'sf6_agent_public_adapter' -and $surface.public_distribution_status -ne 'deferred') {
+      $issues += "$registryPath must represent skills/sf6-agent as deferred"
+    }
+    if ($id -eq 'release_bundle_dist' -and $surface.path_state -ne 'generated_untracked') {
+      $issues += "$registryPath must represent .dist release bundle as generated_untracked"
+    }
+    if ($id -eq 'normalized_intermediate_state' -and $surface.path_state -ne 'documented_absent') {
+      $issues += "$registryPath must represent data/normalized as documented_absent until tracked files exist"
+    }
+  }
+
+  foreach ($requiredId in $requiredSurfaceIds) {
+    if (-not $seenIds.ContainsKey($requiredId)) {
+      $issues += "$registryPath missing required seed surface: $requiredId"
+    }
+  }
+}
+
+if ($issues.Count -gt 0) {
+  throw ($issues -join "`n")
+}
+
+Write-Host 'Repository surfaces OK'

--- a/tests/validation/validate-v2-contracts.ps1
+++ b/tests/validation/validate-v2-contracts.ps1
@@ -14,7 +14,8 @@ $requiredJsonSchemas = @(
   'contracts/answer-plan.schema.json',
   'contracts/calculation-trace.schema.json',
   'contracts/normalization-aliases.schema.json',
-  'contracts/agent-toolchain.schema.json'
+  'contracts/agent-toolchain.schema.json',
+  'contracts/repository-surface.schema.json'
 )
 
 $requiredDocs = @(


### PR DESCRIPTION
Closes #222.

## Summary

- Add `contracts/repository-surface.schema.json` for a machine-readable repository surface registry.
- Add `data/repository-surfaces.json` as a seed index of existing reviewed boundaries, not a new policy source.
- Seed canonical, derived, deferred legacy, repo-local support, and non-canonical surfaces called out by AGENTS, ADR-0002, and the full directory audit.
- Add `tests/validation/validate-repository-surfaces.ps1` and wire it into `run-all.ps1`.
- Document the registry in `contracts/README.md` and include the schema in `validate-v2-contracts.ps1`.

## Boundary Notes

- This PR does not relocate, delete, or reactivate `skills/sf6-agent/`.
- It does not split validation lanes yet.
- It does not change current facts, `official_raw`, raw snapshots, generated references, frame-current assets, normalization assets, `.dist`, or public adapter behavior.
- `data/normalized/` is represented as `documented_absent` because it is a documented non-canonical boundary but has no tracked files today.
- `.dist/sf6-agent-bundle.zip` is represented as `generated_untracked`.
- Hermes output was used only as primary draft input for scope shaping; raw Hermes transcript/local state was not committed.

## Validation

- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-repository-surfaces.ps1` OK
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-repository-surfaces.ps1` OK, with git-unavailable warning and tracked-path checks skipped
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-v2-contracts.ps1` OK
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1` OK
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1` OK
- `git diff --check` OK
- `git diff --check origin/main...HEAD` OK
