### PR TITLE
[v2.6] Split validation suite into lanes

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,23 @@ maintainer profileがある環境のrepo-local growth engineであり、root
 変更後は、少なくとも次を確認します。
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 -Lane read-only
+```
+
+`run-all.ps1` は validation lane を持ちます。引数なしは従来互換の
+`all` lane です。
+
+| Lane | 用途 |
+|---|---|
+| `read-only` | 通常の docs / contracts / workflows / registry / artifact 境界検証。generated output と `.dist` を作らない。 |
+| `derived-build` | generated references、frame-current assets、normalization assets を再生成して残差分を確認する。 |
+| `legacy-distribution` | deferred public distribution bundle / `.dist` を検証する。 |
+| `all` | CI相当。derived build と legacy distribution を含む従来互換のfull suite。 |
+
+広いPRやmerge前確認では、従来どおりfull suiteを実行します。
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1
 ```
 
 追加でよく使う確認:

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -10,17 +10,27 @@ Manual adapter behavior checks:
 Run the full local verification sequence with:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -File tests/validation/run-all.ps1
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1
 ```
 
 GitHub Actions uses the same entrypoint in `.github/workflows/v2-validation.yml` for pull requests targeting `main` and pushes to `main`.
 
-The sequence intentionally builds derived payloads before validation:
+`run-all.ps1` supports validation lanes:
+
+| Lane | Command | Purpose |
+|---|---|---|
+| `read-only` | `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 -Lane read-only` | Validate tracked repo artifacts, schemas, fixtures, docs, and boundaries without building generated outputs or `.dist`. |
+| `derived-build` | `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 -Lane derived-build` | Rebuild generated knowledge refs, frame-current assets, and normalization assets, then validate the derived surfaces. |
+| `legacy-distribution` | `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 -Lane legacy-distribution` | Build and validate the deferred public distribution bundle under `.dist`. |
+| `all` | `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1` | CI-compatible full suite. This is the default when `-Lane` is omitted. |
+
+The `all` lane intentionally builds derived payloads and the deferred distribution bundle before validation. The `derived-build` lane uses the first three commands only, while `legacy-distribution` uses the release-bundle command:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -File packages/knowledge-generation/build-sf6-agent-knowledge.ps1
-powershell -ExecutionPolicy Bypass -File packages/skill-packaging/build-frame-current-runtime-assets.ps1
-powershell -ExecutionPolicy Bypass -File packages/skill-packaging/build-release-bundle.ps1
+pwsh -NoProfile -ExecutionPolicy Bypass -File packages/knowledge-generation/build-sf6-agent-knowledge.ps1
+pwsh -NoProfile -ExecutionPolicy Bypass -File packages/skill-packaging/build-frame-current-runtime-assets.ps1
+pwsh -NoProfile -ExecutionPolicy Bypass -File packages/skill-packaging/build-normalization-runtime-assets.ps1
+pwsh -NoProfile -ExecutionPolicy Bypass -File packages/skill-packaging/build-release-bundle.ps1
 ```
 
 After each generation step, the suite fails if tracked derived outputs changed. Regenerated `skills/sf6-agent/references/generated-*` or `skills/sf6-agent/assets/frame-current/` files must be reviewed and committed before validation or release packaging is treated as reliable.

--- a/tests/validation/run-all.ps1
+++ b/tests/validation/run-all.ps1
@@ -1,3 +1,8 @@
+param(
+  [ValidateSet('read-only', 'derived-build', 'legacy-distribution', 'all')]
+  [string]$Lane = 'all'
+)
+
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
@@ -26,14 +31,19 @@ function Assert-NoDerivedOutputStatus {
   }
 }
 
-$preflightScripts = @(
+$derivedBuildPreflightScripts = @(
   'packages/knowledge-generation/build-sf6-agent-knowledge.ps1',
   'packages/skill-packaging/build-frame-current-runtime-assets.ps1',
-  'packages/skill-packaging/build-normalization-runtime-assets.ps1',
+  'packages/skill-packaging/build-normalization-runtime-assets.ps1'
+)
+
+$legacyDistributionPreflightScripts = @(
   'packages/skill-packaging/build-release-bundle.ps1'
 )
 
-$validationScripts = @(
+$allPreflightScripts = $derivedBuildPreflightScripts + $legacyDistributionPreflightScripts
+
+$readOnlyValidationScripts = @(
   'tests/validation/validate-v2-surfaces.ps1',
   'tests/validation/validate-architecture-markers.ps1',
   'tests/validation/validate-hermes-pack.ps1',
@@ -62,12 +72,59 @@ $validationScripts = @(
   'tests/validation/validate-frame-current-assets.ps1',
   'tests/validation/validate-generated-knowledge.ps1',
   'tests/validation/validate-current-fact-boundaries.ps1',
+  'tests/validation/validate-doc-links.ps1',
+  'tests/validation/validate-legacy-cleanup.ps1'
+)
+
+$derivedBuildValidationScripts = @(
+  'tests/validation/validate-generated-knowledge.ps1',
+  'tests/validation/validate-frame-current-assets.ps1',
+  'tests/validation/validate-normalization-runtime-assets.ps1',
+  'tests/validation/validate-normalization-aliases.ps1',
+  'tests/validation/validate-current-fact-boundaries.ps1',
+  'tests/validation/validate-repository-surfaces.ps1'
+)
+
+$legacyDistributionValidationScripts = @(
+  'tests/validation/validate-distribution.ps1',
+  'tests/validation/validate-legacy-cleanup.ps1'
+)
+
+$allValidationScripts = @(
+  $readOnlyValidationScripts | Where-Object {
+    $_ -notin @(
+      'tests/validation/validate-doc-links.ps1',
+      'tests/validation/validate-legacy-cleanup.ps1'
+    )
+  }
+) + @(
   'tests/validation/validate-distribution.ps1',
   'tests/validation/validate-doc-links.ps1',
   'tests/validation/validate-legacy-cleanup.ps1'
 )
 
-foreach ($relativePath in $preflightScripts + $validationScripts) {
+switch ($Lane) {
+  'read-only' {
+    $preflightScripts = @()
+    $validationScripts = $readOnlyValidationScripts
+  }
+  'derived-build' {
+    $preflightScripts = $derivedBuildPreflightScripts
+    $validationScripts = $derivedBuildValidationScripts
+  }
+  'legacy-distribution' {
+    $preflightScripts = $legacyDistributionPreflightScripts
+    $validationScripts = $legacyDistributionValidationScripts
+  }
+  'all' {
+    $preflightScripts = $allPreflightScripts
+    $validationScripts = $allValidationScripts
+  }
+}
+
+Write-Host "Running validation lane: $Lane"
+
+foreach ($relativePath in @($preflightScripts + $validationScripts | Select-Object -Unique)) {
   $scriptPath = Join-Path $repoRoot $relativePath
   if (-not (Test-Path -LiteralPath $scriptPath -PathType Leaf)) {
     throw "Missing validation script: $relativePath"
@@ -85,4 +142,4 @@ foreach ($relativePath in $validationScripts) {
   & (Join-Path $repoRoot $relativePath)
 }
 
-Write-Host 'V2 validation suite OK'
+Write-Host "V2 validation suite OK ($Lane lane)"

--- a/workflows/codex-to-hermes-delegation.md
+++ b/workflows/codex-to-hermes-delegation.md
@@ -185,8 +185,14 @@ Before committing work that used Hermes output:
 5. Confirm provider Codex did not become the final analyst or decision
    authority.
 6. Confirm Hermes memory, session, and local skill state are not committed.
-7. Run relevant validators for the changed surfaces.
-8. Run `tests/validation/run-all.ps1` when practical.
+7. Run relevant validators for the changed surfaces. For normal Hermes-first
+   docs, contracts, workflow, registry, or boundary-only changes, prefer
+   `tests/validation/run-all.ps1 -Lane read-only`.
+8. Run `tests/validation/run-all.ps1` when practical for merge readiness.
+   Use `-Lane derived-build` only when generated references, frame-current
+   assets, or normalization assets are intentionally in scope. Use
+   `-Lane legacy-distribution` only when deferred public distribution bundle or
+   installer surfaces are intentionally in scope.
 9. Run `git diff --check`.
 10. Verify generated or derived surfaces have no residual diff unless
    intentionally in scope.

--- a/workflows/github-management.md
+++ b/workflows/github-management.md
@@ -133,10 +133,34 @@ git pull --ff-only
 
 ## Validation Before PR Or Merge
 
-Before opening or merging PRs, run the relevant local checks. For broad repo changes, use the full v2 validation suite:
+Before opening or merging PRs, run the relevant local checks. For normal
+private Hermes-first docs, contracts, workflow, registry, or boundary-only
+changes, start with the read-only lane:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 -Lane read-only
+```
+
+Use the generated-surface lane when a PR intentionally touches generated
+references, frame-current assets, or normalization assets:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 -Lane derived-build
+```
+
+Use the legacy distribution lane only when a PR touches deferred public
+distribution bundle or installer surfaces:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 -Lane legacy-distribution
+```
+
+For broad repo changes and merge readiness, use the full v2 validation suite.
+Omitting `-Lane` is equivalent to `-Lane all` and preserves the CI-compatible
+legacy behavior:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1
 ```
 
 Also check:

--- a/workflows/maintainer-agent-session.md
+++ b/workflows/maintainer-agent-session.md
@@ -55,10 +55,23 @@ scope, non-goals, and acceptance are clear enough to test.
 
 Before opening a PR, run focused validators for the changed surfaces.
 
-When practical, also run the full validation suite:
+For normal private Hermes-first docs, contracts, workflow, registry, or
+boundary-only changes, run the read-only lane:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 -Lane read-only
+```
+
+Use `-Lane derived-build` when generated references, frame-current assets, or
+normalization assets are intentionally in scope. Use `-Lane
+legacy-distribution` only when deferred public distribution bundle or installer
+surfaces are intentionally in scope.
+
+When practical, also run the full validation suite. Omitting `-Lane` is
+equivalent to `-Lane all`:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1
 ```
 
 Always check whitespace and patch formatting:

--- a/workflows/manage-maintainer-toolchain.md
+++ b/workflows/manage-maintainer-toolchain.md
@@ -122,3 +122,5 @@ Before opening any repo PR, also run:
 ```powershell
 pwsh -NoProfile -File tests/validation/run-all.ps1
 ```
+
+For narrow toolchain docs or policy-only changes, `tests/validation/run-all.ps1 -Lane read-only` is the lighter first pass. Keep the no-argument `all` lane for merge readiness and CI-equivalent validation.


### PR DESCRIPTION
Closes #224.

## Summary

- Add `-Lane` support to `tests/validation/run-all.ps1`.
- Keep the default no-argument behavior as `all`, preserving the existing CI-compatible full suite.
- Add lanes:
  - `read-only`: repo artifact/schema/docs/boundary validation without generated preflight or `.dist` build.
  - `derived-build`: generated knowledge refs, frame-current assets, and normalization assets preflight plus focused validators.
  - `legacy-distribution`: deferred public distribution bundle build plus distribution/legacy cleanup validators.
  - `all`: current full suite behavior.
- Update README/testing/workflow docs with recommended lane usage for private Hermes-first work.

## Boundary Notes

- Does not move, delete, or reactivate `skills/sf6-agent/`.
- Does not change current facts, `official_raw`, raw snapshots, generated references, frame-current assets, normalization assets, `.dist`, or public adapter behavior.
- `.dist` remains a generated/untracked deferred legacy distribution output.
- Hermes was used only for narrow implementation-shape review; raw Hermes transcript/local state was not committed.

## Validation

Sequential lane validation:

- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 -Lane read-only` OK
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 -Lane derived-build` OK
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 -Lane legacy-distribution` OK
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1` OK

Additional checks:

- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1` OK
- `git diff --check` OK
- `git diff --check origin/main...HEAD` OK
- generated refs / frame-current / normalization / `.dist` residual diff check OK
