### PR TITLE
[v2.6] Add Hermes status and negative learning guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,26 @@
 - Current operation prioritizes personal/private Codex-operated Hermes-first workflows; `skills/sf6-agent/` is deferred until later scoped work decides whether to remove, relocate, or reactivate it.
 - See `docs/architecture/hermes-v2.1-roadmap.md`, `docs/architecture/codex-hermes-bridge-policy.md`, and `workflows/codex-to-hermes-delegation.md`.
 
+## Project Status Protocol
+
+- Before answering project status, resuming previous work, editing files, or updating progress docs, verify the current baseline.
+- Identify the current date, cwd, repository root, and git root.
+- Read this `AGENTS.md` and any relevant subdirectory or workflow context before applying remembered instructions.
+- Run `git status --short --branch` and inspect the relevant issue, PR, roadmap, and on-disk docs for the task.
+- Treat Hermes memory, session search, local skills, Curator output, Kanban state, checkpoints, and previous chat summaries as secondary hints only.
+- If memory/session recall conflicts with current git, disk, issue, PR, or validator evidence, prefer the current evidence and state the contradiction.
+- Label important status claims when useful as `verified_from_git`, `verified_from_disk`, `from_issue_or_pr`, `from_memory_or_session`, `inferred`, or `unknown`.
+- Do not modify files, update progress docs, or claim validation if the baseline has unresolved contradictions.
+- Do not report tests, validators, PR state, merge state, or issue closure as complete unless verified from current command output, GitHub state, or checked-in artifacts.
+
+## Negative Learning Guard
+
+- Treat missing packages, path problems, auth failures, network failures, sandbox limitations, migration artifacts, stale generated files, and tool-version mismatches as provisional failures.
+- Do not write permanent Hermes skills, memory, workflow rules, or repo policy saying a tool or workflow "does not work" unless the user confirms it is a stable constraint or a later verification proves it.
+- After environment, dependency, profile, auth, or toolchain changes, retry previously failed tools before preserving an avoidance rule.
+- When creating or updating local skills, distinguish permanent API/spec limits, repo policy, temporary environment failures, and one-off transient errors.
+- Promote only durable procedural lessons through the reviewed repo path. Do not promote raw failure logs, local Hermes state, or temporary workarounds as canonical behavior.
+
 ## Workflow Rules
 
 - Maintainer procedures belong under `workflows/`.

--- a/docs/architecture/hermes-skill-self-improvement-policy.md
+++ b/docs/architecture/hermes-skill-self-improvement-policy.md
@@ -51,6 +51,43 @@ If a local skill needs an example, use a procedural placeholder or a reviewed
 repo artifact reference. Do not embed SF6 current facts or private maintainer
 state as reusable skill content.
 
+## Negative Learning Guard
+
+Hermes may learn from failed attempts, but temporary failure must not become a
+permanent repo rule or local skill constraint without verification.
+
+Treat these failures as provisional by default:
+
+- missing packages or tools
+- path, shell, or platform differences
+- auth or credential availability
+- network, rate-limit, or service availability
+- sandbox or permissions limits
+- migration artifacts
+- stale generated files
+- version mismatches in local tools or profile setup
+
+Do not create or patch a local skill that says a tool, workflow, source, or
+validator should be avoided permanently unless one of these is true:
+
+- the user confirms it is a stable project constraint
+- a current repo policy or upstream specification says it is unsupported
+- a later verification after environment/toolchain repair still reproduces the
+  failure
+
+When recording a lesson from failure, separate:
+
+- permanent API or specification limits
+- reviewed repo policy
+- local environment setup requirements
+- temporary environment failures
+- one-off transient errors
+
+Prefer "verify again after setup changes" over "avoid forever". If a failed
+path becomes useful after a toolchain, profile, auth, or dependency change,
+update or remove the old local skill guidance instead of preserving the stale
+avoidance rule.
+
 ## Promotion Path
 
 Local procedural learning becomes repo behavior only through this path:


### PR DESCRIPTION
Closes #227.

## Summary

- Add a repo-wide Project Status Protocol to `AGENTS.md` so status, resume, edit, and progress claims must be verified against current git, disk, issue/PR, and validator evidence.
- Add a repo-wide Negative Learning Guard to prevent transient package/path/auth/network/sandbox/version failures from becoming permanent Hermes memory, skill, workflow, or policy constraints.
- Extend `docs/architecture/hermes-skill-self-improvement-policy.md` with detailed negative-learning rules for local Hermes skill creation and patching.

## Boundary

- Hermes memory, session search, local skills, Curator output, Kanban state, checkpoints, and previous chat summaries remain secondary hints only.
- No Hermes memory, sessions, local profile state, raw transcripts, logs, caches, credentials, generated assets, current facts, or public `sf6-agent` behavior changed.

## Validation

- `pwsh -NoProfile -File tests/validation/validate-doc-links.ps1` OK
- `pwsh -NoProfile -File tests/validation/validate-architecture-markers.ps1` OK
- `pwsh -NoProfile -File tests/validation/run-all.ps1 -Lane read-only` OK
- `git diff --check` OK
- `git diff --check origin/main...HEAD` OK

## Notes

- #197 was updated separately to record the recommended execution order.
- Stale draft PR #198 was closed as superseded by #220 / #221 so it cannot accidentally close parent roadmap #197.
