### PR TITLE
[v2.6] Define sf6ingest safe profile policy

### DIFF
--- a/docs/architecture/hermes-maintainer-profile-policy.md
+++ b/docs/architecture/hermes-maintainer-profile-policy.md
@@ -68,6 +68,118 @@ hermes skills inspect hermes-agent
 Do not copy local skill list output, enabled/disabled state, local skill paths,
 or profile-specific skill configuration into canonical policy data.
 
+## Safe Config Policy
+
+This section defines the repo-managed safe config expectation for the local
+`sf6ingest` Hermes profile. It is not an exported profile config and must not
+be copied from a maintainer machine.
+
+Recommended:
+
+- `terminal.backend: docker` for untrusted repositories, broad source ingest,
+  experimental refactors, or any task that may execute unfamiliar code.
+- `approvals.mode: smart` for normal trusted repo-local maintainer work.
+- `approvals.mode: manual` for credential-adjacent work, destructive file
+  operations, gateway/bot operation, or high-risk external source handling.
+- `skills.guard_agent_created: true` to scan agent-created or agent-mutated
+  skills before they become reusable local procedure.
+- `security.redact_secrets: true` so tool output and logs get a redaction
+  safety net before they are displayed or stored.
+- `security.tirith_fail_open: false` when Tirith is enabled, so a failed guard
+  stops instead of silently allowing the action.
+- `security.allow_private_urls: false` unless a task explicitly requires a
+  reviewed private/local URL.
+- `security.website_blocklist.enabled: true` with private/admin/local domains
+  blocked for URL-capable web and browser tools.
+- `compression.enabled: true` with `auxiliary.compression` using the main
+  model/provider, or another summarizer whose context window is verified to be
+  at least as large as the main model.
+- `agent.tool_use_enforcement: auto` unless a later profile review shows a
+  model-specific reason to change it.
+- Empty or minimal `terminal.env_passthrough` and `terminal.docker_forward_env`.
+  Forward only the credential needed for the active task, and remove it after
+  the task when possible.
+
+Allowed with explicit review:
+
+- `terminal.backend: local` for trusted repo work on a maintainer-owned
+  checkout. This is convenient but not a sandbox; commands run with the
+  maintainer user's filesystem access.
+- `terminal.docker_mount_cwd_to_workspace: true` for deliberate repo editing
+  inside Docker, after confirming the mounted path is the intended checkout.
+- `terminal.docker_forward_env` entries such as `GITHUB_TOKEN` only when the
+  active task requires them. Anything forwarded is visible to commands inside
+  the container.
+- `skills.external_dirs` only for reviewed maintainer dependency directories
+  defined by #231 or a later policy. Do not point it at the whole repo
+  `skills/` directory as the default.
+
+Deferred:
+
+- Gateway, messaging bot, cron, Kanban, MCP, external Memory Providers, and
+  cloud memory integrations are not enabled by default for `sf6ingest`.
+- APM / Agent Skill dependency installation is deferred to #231. Until then,
+  do not install broad third-party skill collections as repo-managed profile
+  state.
+
+Forbidden:
+
+- `approvals.mode: off` for normal repo work.
+- Committing actual `config.yaml`, `.env`, `auth.json`, profile exports,
+  memory, sessions, state DB, logs, caches, browser state, cron state, local
+  managed skills, or raw transcripts.
+- Forwarding broad host environment or credential sets into Docker or cloud
+  sandboxes.
+- Treating a local safe-config check as proof of canonical repo state.
+
+The official Hermes configuration docs state that the local backend has no
+isolation and runs with the user's filesystem access, while Docker provides a
+containerized backend. They also document `skills.guard_agent_created`,
+`security.redact_secrets`, Tirith, URL blocklists, and compression context
+requirements. See:
+
+- https://hermes-agent.nousresearch.com/docs/user-guide/configuration/
+- https://hermes-agent.nousresearch.com/docs/user-guide/security
+
+## Profile Distribution Boundary
+
+Profile Distribution may be useful later for sharing the shape of a private
+maintainer profile, but it is not active public `sf6-agent` distribution.
+
+May be Git-managed if reviewed and scrubbed:
+
+- `SOUL.md`
+- safe `config.yaml` templates with no secrets, tokens, local paths, or
+  machine-specific provider state
+- reviewed `skills/` or APM-managed skill dependency manifests
+- `cron/` templates only if cron operation is later enabled
+- `mcp.json` templates only if MCP operation is later enabled
+- `distribution.yaml`
+- README / setup docs
+- `.env.EXAMPLE`
+
+Must remain local user-owned data and must not be committed:
+
+- `memories/`
+- `sessions/`
+- `state.db`, `state.db-shm`, `state.db-wal`
+- `.env`
+- `auth.json`
+- `logs/`
+- `workspace/`
+- `plans/`
+- `home/`
+- `*_cache/`
+- `local/`
+- raw transcripts, browser state, cron state, profile-specific managed skills,
+  local command output, and credentials
+
+Hermes Profile Distribution hard-excludes sensitive user-owned paths such as
+`auth.json`, `.env`, `memories/`, `sessions/`, `state.db*`, `logs/`,
+`workspace/`, `plans/`, `home/`, `*_cache/`, and `local/`. This repo mirrors
+that boundary and treats local memory/session/provider state as non-canonical.
+See https://hermes-agent.nousresearch.com/docs/user-guide/profile-distributions
+
 ## Version Pin And Freshness Review
 
 Hermes CLI version management uses the repo Nix flake as the primary

--- a/workflows/hermes-ingest-profile-setup.md
+++ b/workflows/hermes-ingest-profile-setup.md
@@ -44,15 +44,49 @@ Use repo-external profile state:
 export HERMES_HOME="$HOME/.hermes/profiles/sf6ingest"
 ```
 
-Configure Hermes so it can discover the repo's public adapter skills without turning Hermes state into repo state. When using external skill discovery, prefer the repo `skills/` directory:
+Configure `sf6ingest` from the safe config policy in
+`docs/architecture/hermes-maintainer-profile-policy.md`. The profile state stays
+outside the repo; this repository records expectations, not the machine's
+actual `config.yaml`.
+
+Recommended starting posture:
 
 ```yaml
+terminal:
+  backend: docker
+  env_passthrough: []
+  docker_forward_env: []
+
+approvals:
+  mode: smart
+
 skills:
-  external_dirs:
-    - /absolute/path/to/SF6-skills/skills
+  guard_agent_created: true
+  external_dirs: []
+
+security:
+  redact_secrets: true
+  tirith_fail_open: false
+  allow_private_urls: false
+
+compression:
+  enabled: true
+
+agent:
+  tool_use_enforcement: auto
 ```
 
-Do not configure `workflows/` as a skill directory. Workflows are canonical maintainer procedures, not public adapter skills.
+`terminal.backend: local` is allowed for trusted repo-local work, but it is not
+a sandbox. Use Docker for untrusted code, broad source ingest, experimental
+refactors, or credential-adjacent tasks.
+
+Do not point `skills.external_dirs` at the repo `skills/` directory by default.
+`skills/sf6-agent/` is a deferred public adapter surface, not the active private
+Hermes maintainer skill package. External skill directories must come from a
+reviewed dependency policy such as #231 or a later architecture decision.
+
+Do not configure `workflows/` as a skill directory. Workflows are canonical
+maintainer procedures, not Hermes installed skills.
 
 ## Verification
 
@@ -75,6 +109,17 @@ hermes profile list
 hermes profile show sf6ingest
 hermes chat -Q --max-turns 1 -q "Reply with one sentence confirming this profile can run non-interactively."
 ```
+
+Also verify the safe config posture locally without committing the output:
+
+```bash
+hermes config check
+hermes config
+```
+
+Review the printed local config for the recommended keys above. If a command,
+section, or config key differs across Hermes versions, record the mismatch as a
+local review note only. Do not paste local profile output into repo artifacts.
 
 Prefer the repo Nix flake and Renovate Nix flake PRs for Hermes CLI version
 freshness. Use `hermes --version` output only as a fallback local freshness


### PR DESCRIPTION
Closes #228.

## Summary
- Add `sf6ingest` safe config policy to `docs/architecture/hermes-maintainer-profile-policy.md`.
- Define recommended, allowed, deferred, and forbidden settings for terminal backend, approvals, skill guard, secret redaction, Tirith, URL/private access, compression, tool-use enforcement, and env forwarding.
- Add Profile Distribution boundary for Git-managed templates vs local user-owned state.
- Update `workflows/hermes-ingest-profile-setup.md` to stop recommending repo `skills/` as `skills.external_dirs` and to use an empty external dirs default pending #231.

## Boundary
- Does not commit actual Hermes profile config, memories, sessions, logs, caches, credentials, raw transcripts, or local managed skills.
- Does not enable gateway, MCP, cron, external memory providers, APM install, or public `sf6-agent` behavior.
- `skills/sf6-agent/` remains deferred public adapter surface.

## Validation
- `pwsh -NoProfile -File tests/validation/validate-doc-links.ps1`
- `pwsh -NoProfile -File tests/validation/validate-architecture-markers.ps1`
- `pwsh -NoProfile -File tests/validation/run-all.ps1 -Lane read-only`
- `pwsh -NoProfile -File tests/validation/run-all.ps1`
- `git diff --check`
- `git diff --check origin/main...HEAD`