### PR TITLE
[v2.6] Add Agent Skill APM dependency policy

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,9 +25,33 @@
       "matchStrings": [
         "renovate-version:\\s*(?<currentValue>\\S+)\\s+#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)"
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "Update pinned external Agent Skill dependencies managed by the maintainer APM manifest.",
+      "managerFilePatterns": [
+        "/^tools\\/agent-skills\\/apm\\.yml$/"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>git-tags|git-refs)\\s+depName=(?<depName>\\S+)\\s*\\n\\s*-\\s*\\S+#(?<currentValue>[^\\s@]+)"
+      ]
     }
   ],
   "packageRules": [
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchFileNames": [
+        "tools/agent-skills/apm.yml"
+      ],
+      "groupName": "Agent Skill APM dependencies",
+      "labels": [
+        "dependencies",
+        "toolchain",
+        "agent-skills"
+      ]
+    },
     {
       "matchManagers": [
         "nix"

--- a/docs/architecture/agent-skill-dependency-policy.md
+++ b/docs/architecture/agent-skill-dependency-policy.md
@@ -1,0 +1,130 @@
+# Agent Skill Dependency Policy
+
+この文書は、private `sf6ingest` Hermes maintainer profile で使う外部
+Agent Skill 依存を GitHub-reviewable に管理するための方針です。
+
+対象は maintainer operation だけです。外部 Agent Skill は SF6 公式値、
+式、丸め規則、current facts、public answer authority を提供しません。
+外部 Agent Skill は executor / operator instruction dependency であり、
+repo authority は `AGENTS.md`、`workflows/`、`contracts/`、validator、
+reviewed repo artifact に残します。
+
+## Decision
+
+v2.6 では APM を依存 manifest / lockfile の標準候補として採用します。
+
+ただし、public `sf6-agent` distribution は ADR-0002 により deferred の
+ままです。APM は public skill distribution を再開するためではなく、
+private maintainer profile の外部 skill 依存を review するために使います。
+
+管理場所:
+
+- manifest: `tools/agent-skills/apm.yml`
+- lockfile: `tools/agent-skills/apm.lock.yaml`
+
+`apm.lock.yaml` は、外部依存を初めて追加して `apm install` を実行した
+時点で commit します。依存が空の間は lockfile は不要です。
+
+## Manifest Rules
+
+`tools/agent-skills/apm.yml` は maintainer-only manifest です。
+
+依存を追加する場合は、以下を必須にします。
+
+- GitHub / Git host dependency は reviewed tag または immutable SHA に pin
+  する。
+- In English validator terms: every external Agent Skill dependency must use a
+  reviewed tag or immutable SHA.
+- Floating `main`、default branch、moving branch は原則禁止。使う場合は
+  temporary exception として issue / PR に理由と review deadline を書く。
+- multi-skill repository は必要な skill subset だけを選ぶ。広い bundle を
+  丸ごと入れない。
+- Renovate が拾える metadata comment を依存行の直前に置く。
+- private local path、absolute path、secrets、tokens、profile state、
+  local Hermes state を manifest に入れない。
+- dependency の採用理由、source review、security/trust review、expected
+  maintainer task を PR に書く。
+
+Dependency example:
+
+```yaml
+dependencies:
+  apm:
+    # renovate: datasource=git-tags depName=K-Dense-AI/scientific-agent-skills
+    - K-Dense-AI/scientific-agent-skills/scientific-skills/sympy#v2.38.0
+```
+
+The example uses a virtual subdirectory plus a pinned tag. APM records selected
+skill subsets in `apm.yml` / `apm.lock.yaml` when `--skill` is used, so broad
+skill collections must preserve the selected subset in reviewed files.
+
+## Lockfile Rules
+
+When dependencies exist:
+
+- Commit `tools/agent-skills/apm.lock.yaml`.
+- Do not hand-edit the lockfile.
+- Review resolved commit SHA, content hash, deployed file list, and any security
+  scan findings.
+- Use frozen / audit style checks before treating a dependency update as ready.
+- Do not commit deployed local Hermes profile state, local installed skill
+  directories, memories, sessions, logs, caches, raw transcripts, `.env`, or
+  `auth.json`.
+
+If APM output paths would collide with public `skills/sf6-agent/`, generated
+adapter references, `.dist`, or runtime assets, hold the PR until the output
+boundary is redesigned.
+
+## Renovate Rules
+
+Renovate tracks `tools/agent-skills/apm.yml` with a regex custom manager.
+
+The custom manager uses the metadata comment immediately before a dependency
+line and supports `git-tags` / `git-refs` style datasources. For normal
+dependencies, prefer `git-tags` so Renovate proposes reviewed release/tag
+updates.
+
+Renovate PRs for Agent Skill dependencies are dependency PRs, not automatic
+authority promotions. A maintainer must still review:
+
+- upstream skill diff
+- pinned ref / resolved commit
+- selected skill subset
+- APM lockfile changes
+- security/audit output
+- whether the skill remains executor-only for SF6 work
+
+## Math Skill Boundary
+
+Math-related skills such as SymPy / SageMath operator instructions are managed
+through this same dependency mechanism if adopted.
+
+They may help produce calculation traces or prompts for a selected CAS /
+symbolic math backend. They must not become repo-owned SF6 formula authority.
+SF6-specific calculation behavior belongs in maintainer instructions for the
+selected backend, not in accepted repo facts.
+
+## Not Managed Here
+
+Do not use this manifest for:
+
+- Hermes memory
+- session search state
+- external Memory Provider state
+- Curator output
+- profile exports
+- local installed skill directories
+- gateway / bot config
+- MCP server defaults
+- public `sf6-agent` distribution
+
+Gateway, MCP, external Memory Providers, and broad third-party skill bundles
+remain deferred unless a later issue adds a reviewed adoption policy.
+
+## References
+
+- https://microsoft.github.io/apm/consumer/manage-dependencies/
+- https://microsoft.github.io/apm/reference/cli/install/
+- https://docs.renovatebot.com/modules/manager/regex/
+- https://docs.renovatebot.com/modules/datasource/git-tags/
+- https://docs.renovatebot.com/modules/datasource/git-refs/

--- a/docs/architecture/harness-and-distribution-roles.md
+++ b/docs/architecture/harness-and-distribution-roles.md
@@ -99,6 +99,12 @@ APM or Agent Skills public distribution is deferred by ADR-0002.
 
 APM may also support repo-local maintainer setup manifests after cloning this repository.
 
+External Agent Skill dependencies for private `sf6ingest` operation are
+managed by `docs/architecture/agent-skill-dependency-policy.md` and
+`tools/agent-skills/apm.yml`. They are maintainer executor / operator
+instruction dependencies only; they do not provide SF6 official values,
+formulas, rounding rules, current facts, or public answer authority.
+
 Do not create a public repo-maintainer skill package at this stage. Repo
 maintainer workflows require a clone of this repository and should remain
 repo-local unless a later architecture decision says otherwise.

--- a/docs/architecture/hermes-maintainer-profile-policy.md
+++ b/docs/architecture/hermes-maintainer-profile-policy.md
@@ -141,6 +141,11 @@ requirements. See:
 - https://hermes-agent.nousresearch.com/docs/user-guide/configuration/
 - https://hermes-agent.nousresearch.com/docs/user-guide/security
 
+After #231, external Agent Skill dependencies are managed by
+`docs/architecture/agent-skill-dependency-policy.md` and
+`tools/agent-skills/apm.yml`. The manifest is maintainer-only and does not
+reactivate public `sf6-agent` distribution.
+
 ## Profile Distribution Boundary
 
 Profile Distribution may be useful later for sharing the shape of a private

--- a/tests/validation/validate-agent-toolchain.ps1
+++ b/tests/validation/validate-agent-toolchain.ps1
@@ -105,12 +105,14 @@ $issues = @()
 $requiredFiles = @(
   '.github/renovate.json',
   'docs/architecture/agent-toolchain-freshness.md',
+  'docs/architecture/agent-skill-dependency-policy.md',
   'docs/architecture/hermes-maintainer-profile-policy.md',
   'flake.lock',
   'flake.nix',
   $schemaPath,
   'data/toolchain/README.md',
   $manifestPath,
+  'tools/agent-skills/apm.yml',
   'workflows/check-agent-toolchain-freshness.md'
 )
 $allowedRootProperties = @(
@@ -276,9 +278,75 @@ if (Test-Path -LiteralPath (Join-Path $repoRoot '.github/renovate.json') -PathTy
       $issues += ".github/renovate.json missing Nix/Hermes update text: $needle"
     }
   }
+  foreach ($needle in @(
+    'tools/agent-skills/apm.yml',
+    'agent skill apm dependencies',
+    'git-tags',
+    'git-refs'
+  )) {
+    if ($renovateText -notmatch [regex]::Escape($needle)) {
+      $issues += ".github/renovate.json missing Agent Skill dependency update text: $needle"
+    }
+  }
   foreach ($forbidden in @('secret', 'token', 'credential', '.env')) {
     if ($renovateText -match [regex]::Escape($forbidden)) {
       $issues += ".github/renovate.json contains forbidden secret-like text: $forbidden"
+    }
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot 'tools/agent-skills/apm.yml') -PathType Leaf) {
+  $apmText = Read-Text 'tools/agent-skills/apm.yml'
+  foreach ($needle in @(
+    'name: sf6-maintainer-agent-skills',
+    'targets:',
+    '- agent-skills',
+    'dependencies:',
+    'apm: []',
+    'devDependencies:'
+  )) {
+    if ($apmText -notmatch [regex]::Escape($needle)) {
+      $issues += "tools/agent-skills/apm.yml missing required text: $needle"
+    }
+  }
+  foreach ($forbidden in @(
+    '~/.hermes',
+    'HERMES_HOME',
+    '.env',
+    'auth.json',
+    'credential',
+    'secret',
+    'token',
+    'memories/',
+    'sessions/',
+    'state.db',
+    'logs/',
+    'cache',
+    '/home/',
+    'C:\'
+  )) {
+    if ($apmText -match [regex]::Escape($forbidden)) {
+      $issues += "tools/agent-skills/apm.yml contains forbidden local-state or secret-like text: $forbidden"
+    }
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot 'docs/architecture/agent-skill-dependency-policy.md') -PathType Leaf) {
+  $agentSkillPolicy = Read-Text 'docs/architecture/agent-skill-dependency-policy.md'
+  foreach ($needle in @(
+    'tools/agent-skills/apm.yml',
+    'tools/agent-skills/apm.lock.yaml',
+    'executor / operator instruction dependency',
+    'reviewed tag or immutable SHA',
+    'Renovate',
+    'git-tags',
+    'git-refs',
+    'SymPy',
+    'SageMath',
+    'must not become repo-owned SF6 formula authority'
+  )) {
+    if ($agentSkillPolicy -notmatch [regex]::Escape($needle)) {
+      $issues += "docs/architecture/agent-skill-dependency-policy.md missing policy text: $needle"
     }
   }
 }

--- a/tools/agent-skills/apm.yml
+++ b/tools/agent-skills/apm.yml
@@ -1,0 +1,9 @@
+name: sf6-maintainer-agent-skills
+version: 0.0.0
+description: Maintainer-only external Agent Skill dependency manifest for private sf6ingest operation.
+targets:
+  - agent-skills
+dependencies:
+  apm: []
+devDependencies:
+  apm: []


### PR DESCRIPTION
Closes #231.

## Summary
- Add `docs/architecture/agent-skill-dependency-policy.md` in Japanese-first maintainer prose.
- Add maintainer-only `tools/agent-skills/apm.yml` as the external Agent Skill dependency manifest. It starts with empty dependency sets; `apm.lock.yaml` is required once dependencies are added.
- Add Renovate regex custom manager support for pinned Agent Skill refs in `tools/agent-skills/apm.yml` using `git-tags` / `git-refs` metadata comments.
- Link the policy from Hermes maintainer profile and harness/distribution boundary docs.
- Extend `validate-agent-toolchain.ps1` to require the new policy, manifest, and Renovate guardrails.

## Boundary
- Does not install external / wild Agent Skills yet.
- Does not add a SymPy or SageMath skill dependency yet; it defines the pinned dependency mechanism they must use if adopted.
- Does not commit APM lockfile because the manifest has no dependencies yet.
- Does not commit Hermes memory, sessions, local profile state, local installed skill state, logs, caches, credentials, raw transcripts, or deployed local skill output.
- Does not reactivate public `sf6-agent` distribution.

## Validation
- `pwsh -NoProfile -File tests/validation/validate-agent-toolchain.ps1`
- `pwsh -NoProfile -File tests/validation/validate-doc-links.ps1`
- `pwsh -NoProfile -File tests/validation/run-all.ps1 -Lane read-only`
- `pwsh -NoProfile -File tests/validation/run-all.ps1`
- `git diff --check`
- `git diff --check origin/main...HEAD`