### PR TITLE
[v2.6] Define Hermes Curator worktree checkpoint policy

### DIFF
--- a/docs/architecture/harness-and-distribution-roles.md
+++ b/docs/architecture/harness-and-distribution-roles.md
@@ -64,6 +64,11 @@ non-canonical context under `docs/architecture/hermes-memory-policy.md`.
 External Memory Providers are not enabled by default for v2.6 private
 `sf6ingest` operation.
 
+Curator, worktree, and checkpoint lifecycle is governed by
+`docs/architecture/hermes-curator-worktree-checkpoint-policy.md`. Curator
+output, checkpoint store, Kanban state, and worktree-local Hermes state are not
+canonical repo artifacts.
+
 Final outputs must be repo artifacts, such as:
 
 - `knowledge/sources/*`

--- a/docs/architecture/hermes-curator-worktree-checkpoint-policy.md
+++ b/docs/architecture/hermes-curator-worktree-checkpoint-policy.md
@@ -1,0 +1,150 @@
+# Hermes Curator / Worktree / Checkpoint Policy
+
+この文書は、private `sf6ingest` Hermes maintainer profile で使う Curator、
+git worktree、checkpoints / `/rollback` の運用ライフサイクルを定義します。
+
+対象は maintainer-local operation だけです。Curator output、local skills、
+checkpoint store、Kanban state、session exports、logs、caches、profile state
+は repo authority ではありません。
+
+## Decision
+
+v2.6 では以下を既定方針にします。
+
+- Curator は local skill hygiene のために使ってよい。ただし初回と通常運用
+  の前に `hermes curator run --dry-run` を確認する。
+- 重要な hand-authored / workflow-critical skill は real Curator run の前に
+  `hermes curator pin <skill>` で保護する。
+- Real Curator run の前に `hermes curator backup --reason "<reason>"` を
+  取り、必要なら `hermes curator rollback` または
+  `hermes curator restore <skill>` で戻す。
+- substantial Hermes editing は専用 git worktree または `hermes -w` を使う。
+- Checkpoints は Hermes tool-driven edits の local safety feature として
+  有効にしてよい。Git commit、validator、PR review の代替にはしない。
+- Gateway、cron、Kanban は v2.6 既定では有効化しない。
+
+## Curator Lifecycle
+
+Curator may be used only for local `sf6ingest` skill hygiene.
+
+Before a real Curator run:
+
+1. Verify repo baseline with `git status --short --branch`.
+2. Confirm `HERMES_HOME` is outside the repository.
+3. Run `hermes curator status`.
+4. Run `hermes curator run --dry-run`.
+5. Review the proposed changes locally.
+6. Pin important skills with `hermes curator pin <skill>`.
+7. Take a manual backup with `hermes curator backup --reason "<reason>"`.
+
+During or after a real Curator run:
+
+- Do not let Curator mutate checked-in repo surfaces.
+- Review `~/.hermes/logs/curator/.../REPORT.md` locally.
+- If a change is wrong, use `hermes curator rollback` or
+  `hermes curator restore <skill>`.
+- If a lesson is durable, promote a summary through issue / PR / reviewed repo
+  artifact. Do not commit the raw Curator report.
+
+Curator promotion path:
+
+```text
+local Curator finding
+  -> maintainer summary
+  -> GitHub issue or PR note
+  -> reviewed repo artifact under AGENTS.md / workflows / docs / tests
+  -> validator coverage when the rule must be enforced
+```
+
+## Worktree Lifecycle
+
+Use a dedicated git worktree, or Hermes automatic worktree mode with
+`hermes -w`, when any of the following is true:
+
+- multiple agents may work in parallel
+- the change is a broad refactor or multi-directory edit
+- the task is experimental and may be discarded
+- generated surfaces or packaging outputs may be rebuilt
+- the task may run destructive commands or large automated edits
+- the work may conflict with active maintainer edits in the main checkout
+
+Small docs-only edits in a clean checkout may stay in the main checkout, but
+the maintainer must still verify `git status --short --branch` before editing.
+
+Worktree rules:
+
+- Use one branch/worktree per substantial Hermes experiment.
+- Keep branch names issue-scoped.
+- Commit reviewed milestones with Git; checkpoints are only between-commit
+  safety nets.
+- Remove worktrees only after deciding whether to keep or discard the work.
+- Do not force-remove a worktree with unreviewed changes.
+- Do not commit `.worktrees/` contents or Hermes-generated local state.
+
+## Checkpoint Lifecycle
+
+Checkpoints may be enabled for Hermes sessions that edit files, run generated
+surface builds, or perform substantial tool-driven changes.
+
+Checkpoint state lives under `~/.hermes/checkpoints/` and must remain local.
+It is not a repo artifact.
+
+Use checkpoints this way:
+
+1. Enable checkpoints for the local Hermes session or profile when the task may
+   edit files.
+2. Keep normal Git commits as the reviewed history.
+3. Use `/rollback diff <N>` before restoring.
+4. Use `/rollback <N>` for agent-driven mistakes that should be undone in the
+   working tree.
+5. Re-run `git status --short --branch` and relevant validators after a
+   rollback.
+6. Periodically inspect and prune local checkpoint storage with Hermes
+   checkpoint commands.
+
+Do not use checkpoints to:
+
+- hide or skip Git review
+- replace PR review
+- restore across unrelated tasks without inspecting the diff
+- preserve raw media, datasets, credentials, or generated caches in repo
+  artifacts
+- claim validation passed after rollback without re-running validators
+
+## Deferred Operations
+
+Gateway, cron, durable Kanban, and background multi-agent workers remain
+deferred by default for v2.6 `sf6ingest` operation.
+
+If later enabled, they need a separate policy covering:
+
+- profile isolation
+- authorization and allowed users
+- worktree isolation
+- checkpoint behavior
+- local state cleanup
+- failure recovery
+- no raw transcript / local state commit
+
+## Not Committed
+
+Do not commit:
+
+- `~/.hermes/skills/` local managed skill directories
+- `~/.hermes/skills/.archive/`
+- `~/.hermes/skills/.curator_backups/`
+- `~/.hermes/logs/curator/`
+- Curator `run.json` or raw `REPORT.md`
+- `~/.hermes/checkpoints/`
+- Kanban state
+- checkpoint store
+- session exports
+- logs, caches, browser state, cron state
+- `.env`, `auth.json`, credentials, tokens, secrets
+- raw Hermes transcripts or local command output
+
+## References
+
+- https://hermes-agent.nousresearch.com/docs/user-guide/features/curator
+- https://hermes-agent.nousresearch.com/docs/user-guide/git-worktrees
+- https://hermes-agent.nousresearch.com/docs/user-guide/checkpoints-and-rollback

--- a/docs/architecture/hermes-maintainer-profile-policy.md
+++ b/docs/architecture/hermes-maintainer-profile-policy.md
@@ -127,6 +127,12 @@ Memory and session-search policy is defined in
 `session_search` are local non-canonical context only. External Memory
 Providers are deferred by default for v2.6.
 
+Curator, worktree, and checkpoint policy is defined in
+`docs/architecture/hermes-curator-worktree-checkpoint-policy.md`. Curator must
+start with dry-run / pin / backup review, substantial Hermes editing should use
+dedicated worktrees or `hermes -w`, and checkpoints remain local rollback
+safety state.
+
 Forbidden:
 
 - `approvals.mode: off` for normal repo work.

--- a/tests/validation/validate-agent-toolchain.ps1
+++ b/tests/validation/validate-agent-toolchain.ps1
@@ -106,6 +106,7 @@ $requiredFiles = @(
   '.github/renovate.json',
   'docs/architecture/agent-toolchain-freshness.md',
   'docs/architecture/agent-skill-dependency-policy.md',
+  'docs/architecture/hermes-curator-worktree-checkpoint-policy.md',
   'docs/architecture/hermes-memory-policy.md',
   'docs/architecture/hermes-maintainer-profile-policy.md',
   'flake.lock',
@@ -371,6 +372,31 @@ if (Test-Path -LiteralPath (Join-Path $repoRoot 'docs/architecture/hermes-memory
   )) {
     if ($memoryPolicy -notmatch [regex]::Escape($needle)) {
       $issues += "docs/architecture/hermes-memory-policy.md missing policy text: $needle"
+    }
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot 'docs/architecture/hermes-curator-worktree-checkpoint-policy.md') -PathType Leaf) {
+  $lifecyclePolicy = Read-Text 'docs/architecture/hermes-curator-worktree-checkpoint-policy.md'
+  foreach ($needle in @(
+    'Curator / Worktree / Checkpoint Policy',
+    'hermes curator run --dry-run',
+    'hermes curator pin <skill>',
+    'hermes curator backup --reason',
+    'hermes curator rollback',
+    'hermes curator restore <skill>',
+    'hermes -w',
+    'dedicated git worktree',
+    '/rollback diff <N>',
+    '~/.hermes/checkpoints/',
+    'Git commit、validator、PR review の代替にはしない',
+    'Gateway、cron、Kanban は v2.6 既定では有効化しない',
+    'Do not commit:',
+    '~/.hermes/logs/curator/',
+    'checkpoint store'
+  )) {
+    if ($lifecyclePolicy -notmatch [regex]::Escape($needle)) {
+      $issues += "docs/architecture/hermes-curator-worktree-checkpoint-policy.md missing policy text: $needle"
     }
   }
 }

--- a/workflows/hermes-ingest-profile-setup.md
+++ b/workflows/hermes-ingest-profile-setup.md
@@ -85,6 +85,13 @@ Built-in Hermes memory and `session_search` may be enabled locally for
 remain disabled by default unless a later reviewed issue adopts one. See
 `docs/architecture/hermes-memory-policy.md`.
 
+For substantial Hermes-assisted edits, use a dedicated git worktree or
+`hermes -w`, and enable checkpoints as a local rollback safety feature. Run
+Curator only through the lifecycle in
+`docs/architecture/hermes-curator-worktree-checkpoint-policy.md`: dry-run,
+pin important skills, backup, review, restore/rollback if needed, and promote
+only summarized lessons through reviewed repo artifacts.
+
 Do not point `skills.external_dirs` at the repo `skills/` directory by default.
 `skills/sf6-agent/` is a deferred public adapter surface, not the active private
 Hermes maintainer skill package. External skill directories must come from a


### PR DESCRIPTION
Closes #230.

## Summary
- Add `docs/architecture/hermes-curator-worktree-checkpoint-policy.md`.
- Define Curator dry-run / pin / backup / rollback / restore lifecycle for local `sf6ingest` skill hygiene.
- Define when substantial Hermes work should use dedicated git worktrees or `hermes -w`.
- Define checkpoints as local safety state for tool-driven edits, not a substitute for Git commits, validators, or PR review.
- Link the lifecycle policy from Hermes maintainer profile, harness/distribution roles, and `sf6ingest` setup workflow.
- Extend `validate-agent-toolchain.ps1` to require the lifecycle guardrails.

## Boundary
- Does not run Curator, create checkpoints, create worktrees, or inspect local Hermes state.
- Does not commit Curator output, local skill directories, checkpoint store, Kanban state, sessions, logs, caches, credentials, raw transcripts, or profile state.
- Does not enable gateway, cron, Kanban, or live Hermes in CI.
- Does not change public `sf6-agent` behavior.

## Validation
- `pwsh -NoProfile -File tests/validation/validate-agent-toolchain.ps1`
- `pwsh -NoProfile -File tests/validation/validate-doc-links.ps1`
- `pwsh -NoProfile -File tests/validation/run-all.ps1 -Lane read-only`
- `pwsh -NoProfile -File tests/validation/run-all.ps1`
- `git diff --check`
- `git diff --check origin/main...HEAD`