### PR TITLE
[v2.6] Document repository surface registry lanes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ Validator-facing boundary markers:
 - `skills/sf6-agent/references/generated-*` is derived
 - `skills/sf6-agent/assets/frame-current/` is derived
 
+Machine-readable surface classifications live in
+[`data/repository-surfaces.json`](./data/repository-surfaces.json). Maintainer
+guidance for using the registry with validation lanes is in
+[`docs/architecture/repository-surface-registry-policy.md`](./docs/architecture/repository-surface-registry-policy.md).
+
 ## Public answer adapter status
 
 `skills/sf6-agent/` は既存の単一public answer adapter surfaceです。
@@ -187,6 +192,10 @@ pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 -Lane
 | `legacy-distribution` | deferred public distribution bundle / `.dist` を検証する。 |
 | `all` | CI相当。derived build と legacy distribution を含む従来互換のfull suite。 |
 
+Validation lane と repository surface role の対応は
+[`docs/architecture/repository-surface-registry-policy.md`](./docs/architecture/repository-surface-registry-policy.md)
+を参照してください。
+
 広いPRやmerge前確認では、従来どおりfull suiteを実行します。
 
 ```powershell
@@ -210,6 +219,7 @@ Generated referencesやframe-current assetsを変更するPRでは、derived out
 - [docs/architecture/v2-architecture.md](./docs/architecture/v2-architecture.md): v2のsource-of-truth構造
 - [docs/architecture/language-policy.md](./docs/architecture/language-policy.md): 日本語first運用と英語互換構造
 - [docs/architecture/harness-and-distribution-roles.md](./docs/architecture/harness-and-distribution-roles.md): public adapter、repo-local workflow、Hermes harness、配布境界
+- [docs/architecture/repository-surface-registry-policy.md](./docs/architecture/repository-surface-registry-policy.md): repository surface registry と validation lane の使い方
 - [docs/architecture/japanese-maintainer-docs-policy.md](./docs/architecture/japanese-maintainer-docs-policy.md): 日本語メンテナー向けdoc方針
 - [workflows/README.md](./workflows/README.md): canonical maintainer proceduresの索引
 - [docs/testing/README.md](./docs/testing/README.md): smoke runsとvalidation docs

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -41,3 +41,4 @@ When `source_refs.path` points to a migrated legacy file, `source_revision` iden
 
 - `repository-surface.schema.json`: machine-readable index contract for canonical, derived, deferred legacy, repo-local support, historical, and non-canonical repository surfaces.
 - `data/repository-surfaces.json`: seed registry of existing reviewed boundaries. The registry indexes current policy; it does not replace `AGENTS.md`, ADRs, workflows, or validators as policy sources yet.
+- `docs/architecture/repository-surface-registry-policy.md`: maintainer-facing guide for using registry surface roles with validation lanes and generated / deferred legacy surface boundaries.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -20,4 +20,5 @@ Architecture docs define the v2 source-of-truth model.
 - [video-observation-v2.2-plan.md](./video-observation-v2.2-plan.md)
 - [language-policy.md](./language-policy.md)
 - [harness-and-distribution-roles.md](./harness-and-distribution-roles.md)
+- [repository-surface-registry-policy.md](./repository-surface-registry-policy.md)
 - [japanese-maintainer-docs-policy.md](./japanese-maintainer-docs-policy.md)

--- a/docs/architecture/repository-surface-registry-policy.md
+++ b/docs/architecture/repository-surface-registry-policy.md
@@ -1,0 +1,125 @@
+---
+title: Repository Surface Registry Policy
+status: accepted
+last_reviewed: 2026-05-17
+tracking_issue: "#238"
+---
+
+# Repository Surface Registry Policy
+
+この文書は、`data/repository-surfaces.json` を maintainer がどう読むかを定義する。
+
+`data/repository-surfaces.json` は `repository-surfaces/v1` の registry であり、
+repo 内の主要 surface を `surface_role`、`path_state`、生成元、配布状態、通常回答
+authority などで索引する。これは `AGENTS.md`、ADR、workflow、contract、validator を
+置き換える正本ではない。既存の reviewed boundary を参照しやすくするための
+machine-readable index である。
+
+## 使い方
+
+maintainer は、path の責務や validation lane を判断するときに次を見る。
+
+1. `AGENTS.md` と関連 ADR / workflow を読む。
+2. `data/repository-surfaces.json` で該当 path の surface ID と role を確認する。
+3. `validation_expectation` と validation lane を選ぶ。
+4. 変更後に該当 validator を実行する。
+
+registry の claim は、それだけで現在の file state の証明にはならない。tracked file
+の有無は `git ls-files`、変更状態は `git status`、境界違反は validator で確認する。
+
+## 主要フィールド
+
+| Field | 意味 |
+|---|---|
+| `id` | surface を参照するための安定 ID。issue、PR、docs では path だけでなく ID も使う。 |
+| `path_globs` | surface に属する path pattern。validator は tracked file との整合を確認する。 |
+| `path_state` | `tracked_present`、`generated_untracked`、`documented_absent` のどれか。 |
+| `surface_role` | `canonical`、`derived`、`deferred_legacy`、`repo_local_support`、`historical`、`non_canonical` のどれか。 |
+| `source_of_truth` | surface の根拠になる source。generated surface は `self` を使わない。 |
+| `generated` | 生成物かどうか。`true` の surface は `generator` と `source_paths` を持つ。 |
+| `allowed_to_edit_directly` | maintainer が手で編集してよい surface かどうか。 |
+| `public_distribution_status` | public distribution との関係。deferred public adapter は `deferred` を使う。 |
+| `normal_public_answer_authority` | 通常回答の根拠として使えるかどうか。 |
+| `validation_expectation` | 期待される validator / boundary check。 |
+
+## Surface Role
+
+| Role | 読み方 | 変更時の基本姿勢 |
+|---|---|---|
+| `canonical` | repo 内の正本。例: `knowledge/`、`data/exports/`、`contracts/`、`workflows/`。 | 直接編集できるかは `allowed_to_edit_directly` と workflow に従う。 |
+| `derived` | generator と source paths から作られる生成物。 | source または generator を直し、必要な lane で再生成する。手で正本化しない。 |
+| `deferred_legacy` | 既存 public distribution / adapter 由来だが、現在の active product focus ではない surface。 | 新機能を足さない。残す、移す、消す判断は scoped ADR / issue で行う。 |
+| `repo_local_support` | maintainer workflow、validator、package、Hermes pack など repo-local 運用支援。 | public answer skill behavior と混ぜない。procedure authority は canonical workflow へ寄せる。 |
+| `historical` | smoke report や過去実行証跡。 | execution evidence として扱い、 gameplay authority や current fact authority にしない。 |
+| `non_canonical` | raw snapshot、normalized intermediate、manual-review sidecar など通常回答の正本ではないもの。 | normal public answer authority にしない。必要なら review / retention policy を明示する。 |
+
+## Validation Lane との対応
+
+`tests/validation/run-all.ps1` は次の lane を持つ。
+
+| Lane | 使うとき | 関係する registry role / surface |
+|---|---|---|
+| `read-only` | docs、contracts、workflows、registry、fixture、境界 marker など、生成物を作らずに確認する通常 lane。 | `canonical`、`repo_local_support`、`historical`、`non_canonical` の boundary check。 |
+| `derived-build` | generated references、frame-current assets、normalization assets を再生成して確認するとき。 | `derived` かつ `generated: true` の tracked runtime / reference surface。 |
+| `legacy-distribution` | `.dist` や deferred public distribution bundle / installer 境界を確認するとき。 | `deferred_legacy` と deferred distribution output。 |
+| `all` | merge 前や CI 相当の full suite。 | read-only、derived-build、legacy-distribution をまとめて確認する。 |
+
+狭い docs / policy PR ではまず `read-only` を使う。generated surface や `.dist` を
+触っていないのに `derived-build` や `legacy-distribution` を選ぶ必要はない。
+
+## Generated Surface IDs
+
+次の surface は registry 上で generated / derived として扱う。
+
+| ID | Path | Generator | Source |
+|---|---|---|---|
+| `generated_knowledge_references` | `skills/sf6-agent/references/generated-*` | `packages/knowledge-generation/build-sf6-agent-knowledge.ps1` | `knowledge/curated` |
+| `frame_current_runtime_assets` | `skills/sf6-agent/assets/frame-current/*` | `packages/skill-packaging/build-frame-current-runtime-assets.ps1` | `data/exports`, `data/roster` |
+| `normalization_runtime_assets` | `skills/sf6-agent/assets/normalization/*` | `packages/skill-packaging/build-normalization-runtime-assets.ps1` | `data/aliases` |
+| `release_bundle_dist` | `.dist/sf6-agent-bundle.zip` | `packages/skill-packaging/build-release-bundle.ps1` | `skills/sf6-agent`, `packages/skill-packaging` |
+
+`generated_knowledge_references`、`frame_current_runtime_assets`、`normalization_runtime_assets`
+は tracked generated outputs である。変更する場合は source / generator / generated
+output の差分を review する。
+
+`release_bundle_dist` は `generated_untracked` であり、local validation で作られても
+tracked artifact にしない。
+
+## Deferred Legacy Surface IDs
+
+次の surface は private Hermes-first operation の active product focus ではない。
+
+| ID | 意味 |
+|---|---|
+| `sf6_agent_public_adapter` | 既存 public answer adapter。現在は deferred legacy distribution surface。 |
+| `skill_installers_package` | deferred public skill installer tooling。 |
+| `release_bundle_dist` | deferred public distribution bundle output。 |
+
+これらを変更する PR は、通常の private workflow 改善と混ぜない。public adapter を
+remove / relocate / reactivate するかは、後続の scoped ADR / issue で決める。
+
+## Non-canonical Boundary IDs
+
+次の surface は通常回答の根拠ではない。
+
+| ID | 境界 |
+|---|---|
+| `raw_snapshots` | reproducibility / ingest review の入力。normal public answer evidence ではない。 |
+| `normalized_intermediate_state` | intermediate state。現在は `documented_absent`。 |
+| `manual_review_sidecars` | withheld rows や review holds。runtime current fact payload に入れない。 |
+
+これらを accepted answer authority に昇格しない。必要な情報は review / curated /
+exported current-fact surface へ、明示的な workflow と validator を通して移す。
+
+## Maintainer Rule
+
+新しい directory、生成物、distribution output、local support package を追加するときは、
+次を同じ PR で確認する。
+
+- `data/repository-surfaces.json` に既存 role で表せるか。
+- 表せない場合は `contracts/repository-surface.schema.json` の変更が必要か。
+- `tests/validation/validate-repository-surfaces.ps1` に required ID や boundary check が必要か。
+- README / architecture / workflow のどこから maintainer がその surface を発見できるか。
+
+registry は refactor の許可証ではない。破壊的変更は歓迎だが、surface の role、source、
+distribution status、validator expectation を先に見える化してから実施する。

--- a/tests/validation/validate-repository-surfaces.ps1
+++ b/tests/validation/validate-repository-surfaces.ps1
@@ -4,10 +4,18 @@ $ErrorActionPreference = 'Stop'
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 $schemaPath = 'contracts/repository-surface.schema.json'
 $registryPath = 'data/repository-surfaces.json'
+$policyDocPath = 'docs/architecture/repository-surface-registry-policy.md'
+$readmePath = 'README.md'
+$contractsReadmePath = 'contracts/README.md'
 
 function Read-Json {
   param([Parameter(Mandatory = $true)][string]$RelativePath)
   return Get-Content -LiteralPath (Join-Path $repoRoot $RelativePath) -Raw -Encoding UTF8 | ConvertFrom-Json
+}
+
+function Read-Text {
+  param([Parameter(Mandatory = $true)][string]$RelativePath)
+  return Get-Content -LiteralPath (Join-Path $repoRoot $RelativePath) -Raw -Encoding UTF8
 }
 
 function Test-Property {
@@ -48,6 +56,19 @@ function Get-TrackedMatches {
   })
 }
 
+function Assert-TextContains {
+  param(
+    [Parameter(Mandatory = $true)][string]$Text,
+    [Parameter(Mandatory = $true)][string]$Needle,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  if (-not $Text.Contains($Needle)) {
+    $Issues.Value += "$Context must mention: $Needle"
+  }
+}
+
 $issues = @()
 $requiredSurfaceIds = @(
   'knowledge',
@@ -75,7 +96,7 @@ $requiredSurfaceIds = @(
   'manual_review_sidecars'
 )
 
-foreach ($relativePath in @($schemaPath, $registryPath)) {
+foreach ($relativePath in @($schemaPath, $registryPath, $policyDocPath, $readmePath, $contractsReadmePath)) {
   if (-not (Test-Path -LiteralPath (Join-Path $repoRoot $relativePath) -PathType Leaf)) {
     $issues += "Missing repository surface file: $relativePath"
   }
@@ -203,6 +224,62 @@ if (Test-Path -LiteralPath (Join-Path $repoRoot $registryPath) -PathType Leaf) {
     if (-not $seenIds.ContainsKey($requiredId)) {
       $issues += "$registryPath missing required seed surface: $requiredId"
     }
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot $policyDocPath) -PathType Leaf) {
+  $policyDoc = Read-Text $policyDocPath
+  foreach ($requiredText in @(
+    'data/repository-surfaces.json',
+    'repository-surfaces/v1',
+    'surface_role',
+    'path_state',
+    'validation_expectation',
+    'read-only',
+    'derived-build',
+    'legacy-distribution',
+    'all',
+    'canonical',
+    'derived',
+    'deferred_legacy',
+    'repo_local_support',
+    'historical',
+    'non_canonical',
+    'generated_knowledge_references',
+    'frame_current_runtime_assets',
+    'normalization_runtime_assets',
+    'release_bundle_dist',
+    'sf6_agent_public_adapter',
+    'skill_installers_package',
+    'raw_snapshots',
+    'normalized_intermediate_state',
+    'manual_review_sidecars'
+  )) {
+    Assert-TextContains $policyDoc $requiredText $policyDocPath ([ref]$issues)
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot $readmePath) -PathType Leaf) {
+  $readme = Read-Text $readmePath
+  foreach ($requiredText in @(
+    'data/repository-surfaces.json',
+    'docs/architecture/repository-surface-registry-policy.md',
+    'read-only',
+    'derived-build',
+    'legacy-distribution'
+  )) {
+    Assert-TextContains $readme $requiredText $readmePath ([ref]$issues)
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot $contractsReadmePath) -PathType Leaf) {
+  $contractsReadme = Read-Text $contractsReadmePath
+  foreach ($requiredText in @(
+    'repository-surface.schema.json',
+    'data/repository-surfaces.json',
+    'docs/architecture/repository-surface-registry-policy.md'
+  )) {
+    Assert-TextContains $contractsReadme $requiredText $contractsReadmePath ([ref]$issues)
   }
 }
 


### PR DESCRIPTION
## Summary

- Add a Japanese-first repository surface registry policy doc explaining how to read `data/repository-surfaces.json`.
- Link the registry doc from `README.md`, `contracts/README.md`, and the architecture index.
- Extend `validate-repository-surfaces.ps1` so registry docs must mention the key lanes, roles, and surface IDs.

Closes #238.

## Validation

- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-repository-surfaces.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 -Lane read-only`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1`
- `git diff --check`
- `git diff --check origin/main...HEAD`

## Notes

- No surface reclassification.
- No public `sf6-agent` behavior changes.
- No intentional generated reference, frame-current, normalization, or `.dist` artifact commits.
- No Hermes local state, raw transcript, memory, sessions, logs, cache, or credentials committed.
