### PR TITLE
[v2.6] Document PowerShell compatibility policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,11 @@ Validation lane と repository surface role の対応は
 [`docs/architecture/repository-surface-registry-policy.md`](./docs/architecture/repository-surface-registry-policy.md)
 を参照してください。
 
+Maintainer validation は `pwsh` を supported command とします。
+Windows PowerShell / `powershell.exe` fallback と git visibility warning の扱いは
+[`docs/architecture/powershell-compatibility-policy.md`](./docs/architecture/powershell-compatibility-policy.md)
+を参照してください。
+
 広いPRやmerge前確認では、従来どおりfull suiteを実行します。
 
 ```powershell
@@ -220,6 +225,7 @@ Generated referencesやframe-current assetsを変更するPRでは、derived out
 - [docs/architecture/language-policy.md](./docs/architecture/language-policy.md): 日本語first運用と英語互換構造
 - [docs/architecture/harness-and-distribution-roles.md](./docs/architecture/harness-and-distribution-roles.md): public adapter、repo-local workflow、Hermes harness、配布境界
 - [docs/architecture/repository-surface-registry-policy.md](./docs/architecture/repository-surface-registry-policy.md): repository surface registry と validation lane の使い方
+- [docs/architecture/powershell-compatibility-policy.md](./docs/architecture/powershell-compatibility-policy.md): `pwsh` と Windows PowerShell fallback の互換 policy
 - [docs/architecture/japanese-maintainer-docs-policy.md](./docs/architecture/japanese-maintainer-docs-policy.md): 日本語メンテナー向けdoc方針
 - [workflows/README.md](./workflows/README.md): canonical maintainer proceduresの索引
 - [docs/testing/README.md](./docs/testing/README.md): smoke runsとvalidation docs

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -21,4 +21,5 @@ Architecture docs define the v2 source-of-truth model.
 - [language-policy.md](./language-policy.md)
 - [harness-and-distribution-roles.md](./harness-and-distribution-roles.md)
 - [repository-surface-registry-policy.md](./repository-surface-registry-policy.md)
+- [powershell-compatibility-policy.md](./powershell-compatibility-policy.md)
 - [japanese-maintainer-docs-policy.md](./japanese-maintainer-docs-policy.md)

--- a/docs/architecture/hermes-growth-harness-map.md
+++ b/docs/architecture/hermes-growth-harness-map.md
@@ -87,6 +87,8 @@ When Windows PowerShell cannot see Git during generated-surface checks, the
 handoff should report that warning and separately verify from a git-visible
 environment that generated references, `.dist`, frame-current assets, and
 normalization runtime assets have no residual diff.
+See `docs/architecture/powershell-compatibility-policy.md` for the canonical
+`pwsh` / Windows PowerShell fallback policy.
 
 ## Deferred Harness Surfaces
 

--- a/docs/architecture/powershell-compatibility-policy.md
+++ b/docs/architecture/powershell-compatibility-policy.md
@@ -1,0 +1,103 @@
+---
+title: PowerShell Compatibility Policy
+status: accepted
+last_reviewed: 2026-05-17
+tracking_issue: "#240"
+---
+
+# PowerShell Compatibility Policy
+
+この文書は、repo-local maintainer validation で使う PowerShell 実行環境を定義する。
+
+## 結論
+
+`pwsh` を supported maintainer validation command とする。
+
+Windows PowerShell, usually exposed as `powershell.exe`, is treated as a
+fallback / legacy-compatible runner. It may be useful for Windows-only legacy
+installer checks, but it is not the preferred maintainer validation path for
+v2.6 private Hermes-first work.
+
+## 根拠
+
+この repo の maintainer toolchain は `mise.toml` で PowerShell Core を
+`powershell-core` として管理し、expected command を `pwsh` としている。
+GitHub Actions も v2 validation を `pwsh` shell で実行する。
+
+既存 docs には古い `powershell` / `powershell.exe` examples が残っている。
+それらは deferred public distribution installer docs や Windows fallback
+確認のためには残してよい。ただし、通常の repo validation、PR validation、
+Hermes / Codex maintainer workflow では `pwsh` を使う。
+
+## Supported Command Shape
+
+通常の validation はこの形で実行する。
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 -Lane read-only
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1
+```
+
+focused validator も同じ command shape を使う。
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1
+```
+
+`-NoProfile` は user profile state の影響を避けるために使う。`-ExecutionPolicy Bypass`
+は Windows execution policy で local script validation が止まる環境を避けるために
+付ける。これは repo policy や security boundary を緩めるものではなく、repo 内の
+reviewed script を明示的に実行するための invocation shape である。
+
+## Known Difference: Git Visibility
+
+Windows PowerShell で `run-all.ps1` や generated-surface validators を実行すると、
+`git` が見えない環境がある。この場合、validator は git-based cleanliness check を
+skip または warning として扱うことがある。
+
+その warning を validation success と同一視しない。Windows PowerShell が `git` を
+見られなかった場合は、WSL、Git Bash、`pwsh`、または別の git-visible shell で
+次を確認する。
+
+```bash
+git status --porcelain
+git diff --check
+git diff --check origin/main...HEAD
+```
+
+generated surface を触る PR では、少なくとも次の derived / generated paths に
+残差分がないことも確認する。
+
+```bash
+git status --porcelain -- \
+  skills/sf6-agent/references/generated-knowledge-index.md \
+  skills/sf6-agent/references/generated-concepts.md \
+  skills/sf6-agent/assets/frame-current \
+  skills/sf6-agent/assets/normalization \
+  .dist
+```
+
+## When Windows PowerShell Is Acceptable
+
+Windows PowerShell は次の用途に限定して扱う。
+
+- deferred public distribution installer docs の legacy example。
+- Windows-only user environment での compatibility smoke。
+- `powershell.exe` 自体の fallback behavior を検証する scoped issue。
+
+ただし、その結果を CI-equivalent validation として扱うには、`pwsh` または
+git-visible shell での確認を併記する。
+
+## Documentation Rule
+
+新しい maintainer docs、workflow docs、PR body examples、smoke report templates では
+`pwsh` を使う。`powershell` / `powershell.exe` を書く場合は、Windows fallback、
+legacy distribution installer、または explicit compatibility smoke であることを
+文脈に書く。
+
+## Non-goals
+
+- Windows PowerShell support を削除しない。
+- deferred public distribution installer docs を一括 rewrite しない。
+- `run-all.ps1` の runtime behavior をこの policy だけで変更しない。
+- local PATH、profile、registry、credential、Hermes profile state を canonical にしない。

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -13,6 +13,10 @@ Run the full local verification sequence with:
 pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1
 ```
 
+Maintainer validation uses `pwsh` as the supported command. Windows
+PowerShell / `powershell.exe` fallback and git visibility warnings are covered
+by [docs/architecture/powershell-compatibility-policy.md](../architecture/powershell-compatibility-policy.md).
+
 GitHub Actions uses the same entrypoint in `.github/workflows/v2-validation.yml` for pull requests targeting `main` and pushes to `main`.
 
 `run-all.ps1` supports validation lanes:
@@ -37,19 +41,19 @@ After each generation step, the suite fails if tracked derived outputs changed. 
 
 Manual validator set:
 
-- `powershell -ExecutionPolicy Bypass -File tests/validation/validate-v2-surfaces.ps1`
-- `powershell -ExecutionPolicy Bypass -File tests/validation/validate-v2-contracts.ps1`
-- `powershell -ExecutionPolicy Bypass -File tests/validation/validate-knowledge-schema.ps1`
-- `powershell -ExecutionPolicy Bypass -File tests/validation/validate-ingest-artifacts.ps1`
-- `powershell -ExecutionPolicy Bypass -File tests/validation/validate-video-artifacts.ps1`
-- `powershell -ExecutionPolicy Bypass -File tests/validation/validate-combo-damage-fixtures.ps1`
-- `powershell -ExecutionPolicy Bypass -File tests/validation/validate-evals.ps1`
-- `powershell -ExecutionPolicy Bypass -File tests/validation/validate-roster-source.ps1`
-- `powershell -ExecutionPolicy Bypass -File tests/validation/validate-frame-current-assets.ps1`
-- `powershell -ExecutionPolicy Bypass -File tests/validation/validate-generated-knowledge.ps1`
-- `powershell -ExecutionPolicy Bypass -File tests/validation/validate-current-fact-boundaries.ps1`
-- `powershell -ExecutionPolicy Bypass -File tests/validation/validate-distribution.ps1`
-- `powershell -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1`
-- `powershell -ExecutionPolicy Bypass -File tests/validation/validate-legacy-cleanup.ps1`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-v2-surfaces.ps1`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-v2-contracts.ps1`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-knowledge-schema.ps1`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-ingest-artifacts.ps1`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-video-artifacts.ps1`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-combo-damage-fixtures.ps1`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-evals.ps1`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-roster-source.ps1`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-frame-current-assets.ps1`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-generated-knowledge.ps1`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-current-fact-boundaries.ps1`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-distribution.ps1`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-legacy-cleanup.ps1`
 
 Old prose-locking validators were removed. New validators should check contracts and source boundaries, not subjective strategic correctness.

--- a/tests/validation/run-all.ps1
+++ b/tests/validation/run-all.ps1
@@ -52,6 +52,7 @@ $readOnlyValidationScripts = @(
   'tests/validation/validate-v2-contracts.ps1',
   'tests/validation/validate-agent-toolchain.ps1',
   'tests/validation/validate-repository-surfaces.ps1',
+  'tests/validation/validate-powershell-compatibility-policy.ps1',
   'tests/validation/validate-answer-orchestration-contracts.ps1',
   'tests/validation/validate-answer-smoke-fixtures.ps1',
   'tests/validation/validate-calculation-executor.ps1',

--- a/tests/validation/validate-powershell-compatibility-policy.ps1
+++ b/tests/validation/validate-powershell-compatibility-policy.ps1
@@ -1,0 +1,107 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$policyPath = 'docs/architecture/powershell-compatibility-policy.md'
+
+function Read-Text {
+  param([Parameter(Mandatory = $true)][string]$RelativePath)
+  return Get-Content -LiteralPath (Join-Path $repoRoot $RelativePath) -Raw -Encoding UTF8
+}
+
+function Assert-PathExists {
+  param(
+    [Parameter(Mandatory = $true)][string]$RelativePath,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  if (-not (Test-Path -LiteralPath (Join-Path $repoRoot $RelativePath) -PathType Leaf)) {
+    $Issues.Value += "Missing required PowerShell compatibility policy file: $RelativePath"
+  }
+}
+
+function Assert-Contains {
+  param(
+    [Parameter(Mandatory = $true)][string]$Text,
+    [Parameter(Mandatory = $true)][string]$Needle,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  if (-not $Text.Contains($Needle)) {
+    $Issues.Value += "$Context must mention: $Needle"
+  }
+}
+
+$issues = @()
+
+$requiredDocs = @(
+  $policyPath,
+  'README.md',
+  'docs/architecture/README.md',
+  'docs/testing/README.md',
+  'workflows/manage-maintainer-toolchain.md',
+  'workflows/github-management.md',
+  'workflows/maintainer-agent-session.md',
+  'workflows/check-agent-toolchain-freshness.md'
+)
+
+foreach ($relativePath in $requiredDocs) {
+  Assert-PathExists $relativePath ([ref]$issues)
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot $policyPath) -PathType Leaf) {
+  $policy = Read-Text $policyPath
+  foreach ($requiredText in @(
+    'pwsh',
+    'powershell.exe',
+    'Windows PowerShell',
+    'PowerShell Core',
+    'supported maintainer validation command',
+    'fallback / legacy-compatible runner',
+    'Git Visibility',
+    'git status --porcelain',
+    'git diff --check',
+    'origin/main...HEAD',
+    'skills/sf6-agent/references/generated-knowledge-index.md',
+    'skills/sf6-agent/assets/frame-current',
+    'skills/sf6-agent/assets/normalization',
+    '.dist',
+    '-NoProfile',
+    '-ExecutionPolicy Bypass'
+  )) {
+    Assert-Contains $policy $requiredText $policyPath ([ref]$issues)
+  }
+}
+
+foreach ($relativePath in @(
+  'README.md',
+  'docs/testing/README.md',
+  'workflows/manage-maintainer-toolchain.md',
+  'workflows/github-management.md',
+  'workflows/maintainer-agent-session.md',
+  'workflows/check-agent-toolchain-freshness.md'
+)) {
+  if (Test-Path -LiteralPath (Join-Path $repoRoot $relativePath) -PathType Leaf) {
+    $text = Read-Text $relativePath
+    Assert-Contains $text 'docs/architecture/powershell-compatibility-policy.md' $relativePath ([ref]$issues)
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot 'docs/architecture/README.md') -PathType Leaf) {
+  $architectureReadme = Read-Text 'docs/architecture/README.md'
+  Assert-Contains $architectureReadme 'powershell-compatibility-policy.md' 'docs/architecture/README.md' ([ref]$issues)
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot 'docs/testing/README.md') -PathType Leaf) {
+  $testingReadme = Read-Text 'docs/testing/README.md'
+  if ($testingReadme.Contains('`powershell -ExecutionPolicy Bypass -File tests/validation/')) {
+    $issues += 'docs/testing/README.md maintainer validator examples must use pwsh, not bare powershell'
+  }
+}
+
+if ($issues.Count -gt 0) {
+  throw ($issues -join "`n")
+}
+
+Write-Host 'PowerShell compatibility policy OK'

--- a/workflows/check-agent-toolchain-freshness.md
+++ b/workflows/check-agent-toolchain-freshness.md
@@ -102,12 +102,15 @@ output remains non-canonical.
 After editing toolchain policy data, run:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-agent-toolchain.ps1
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-v2-contracts.ps1
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-agent-toolchain.ps1
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-v2-contracts.ps1
 ```
 
 Before opening a PR, also run the full validation suite:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1
 ```
+
+See `docs/architecture/powershell-compatibility-policy.md` for Windows
+PowerShell / `powershell.exe` fallback guidance.

--- a/workflows/github-management.md
+++ b/workflows/github-management.md
@@ -179,6 +179,9 @@ git status --porcelain -- \
   skills/sf6-agent/assets/frame-current
 ```
 
+See `docs/architecture/powershell-compatibility-policy.md` for the repo
+policy on `pwsh`, Windows PowerShell fallback, and git visibility warnings.
+
 Do not ignore failing checks. If a failure is legacy-obsolete or out of scope, document that clearly in the PR and create a follow-up issue when needed.
 
 ## PR Body Requirements

--- a/workflows/maintainer-agent-session.md
+++ b/workflows/maintainer-agent-session.md
@@ -95,6 +95,9 @@ that these generated or derived surfaces have no residual diff:
 - `skills/sf6-agent/assets/frame-current/`
 - `skills/sf6-agent/assets/normalization/`
 
+See `docs/architecture/powershell-compatibility-policy.md` for the canonical
+`pwsh` / Windows PowerShell fallback policy.
+
 Completion is determined by validation results, not agent confidence.
 
 ## End-Of-Session Handoff

--- a/workflows/manage-maintainer-toolchain.md
+++ b/workflows/manage-maintainer-toolchain.md
@@ -51,6 +51,11 @@ Prefer the repo Nix flake for Hermes CLI pinning and Renovate updates. Keep
 Hermes profile state outside the repository and promote only reviewed repo
 artifacts into this repository.
 
+PowerShell compatibility policy is documented in
+`docs/architecture/powershell-compatibility-policy.md`. Maintainer validation
+uses `pwsh`; Windows PowerShell / `powershell.exe` is fallback or legacy
+compatibility only.
+
 ## Local Setup
 
 From WSL2 or another Linux environment with this repo already checked out:


### PR DESCRIPTION
## Summary

- Add a Japanese-first PowerShell compatibility policy for maintainer validation.
- Define `pwsh` as the supported validation command and Windows PowerShell / `powershell.exe` as fallback or legacy-compatible.
- Add a focused validator and wire it into the read-only validation lane.
- Link the policy from README, testing docs, architecture index, and maintainer workflows.

Closes #240.

## Validation

- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-powershell-compatibility-policy.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 -Lane read-only`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1`
- `git diff --check`
- `git diff --check origin/main...HEAD`

## Notes

- No validator runtime behavior changes beyond doc discoverability checks.
- No generated references, frame-current assets, normalization assets, or `.dist` artifacts committed.
- No public `sf6-agent` behavior changes.
- No Hermes local state, raw transcript, memory, sessions, logs, cache, credentials, or profile state committed.
