### PR TITLE
[v2.6] Decide public adapter disposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ public adapter is in
 The Phase 2 plan for separating generated knowledge references from
 hand-written public adapter policy references is in
 [`docs/architecture/generated-reference-responsibility-plan.md`](./docs/architecture/generated-reference-responsibility-plan.md).
+The ADR selecting removal of the public adapter after runtime relocation is in
+[`docs/architecture/decisions/0003-retire-public-sf6-agent-adapter.md`](./docs/architecture/decisions/0003-retire-public-sf6-agent-adapter.md).
 
 ## Public answer adapter status
 
@@ -82,8 +84,8 @@ distribution surfaceとして扱います。
 - `data/exports/` と `data/roster/` から生成された `skills/sf6-agent/assets/frame-current/`
 
 `skills/sf6-agent/` は当面、新しい公開機能を足す場所ではありません。
-今後のscoped workで残存責務を棚卸ししたうえで、削除・移設・再有効化の
-どれにするかを決めます。
+ADR-0003 では、再利用するruntime payloadを先に移設したうえで、このpublic
+adapter surfaceを削除する方針を選択しています。
 
 `workflows/*`、`tests/validation/*`、`packages/*`、`contracts/*`、
 `packs/hermes-sf6/*` はpublic answer skillとして配布しません。

--- a/data/repository-surfaces.json
+++ b/data/repository-surfaces.json
@@ -230,7 +230,8 @@
       "policy_refs": [
         "AGENTS.md",
         "contracts/generated-surface.schema.json",
-        "docs/architecture/generated-reference-responsibility-plan.md"
+        "docs/architecture/generated-reference-responsibility-plan.md",
+        "docs/architecture/decisions/0003-retire-public-sf6-agent-adapter.md"
       ],
       "notes": "Generated derived output from curated knowledge. It is currently located under the deferred public adapter path, but it is separate from hand-written adapter policy references."
     },
@@ -261,7 +262,8 @@
       "policy_refs": [
         "AGENTS.md",
         "skills/sf6-agent/SKILL.md",
-        "docs/architecture/generated-reference-responsibility-plan.md"
+        "docs/architecture/generated-reference-responsibility-plan.md",
+        "docs/architecture/decisions/0003-retire-public-sf6-agent-adapter.md"
       ],
       "notes": "Hand-written adapter policy files define deferred public adapter behavior only. They are not generated stable concept payloads and are not canonical SF6 knowledge."
     },
@@ -294,7 +296,9 @@
       ],
       "policy_refs": [
         "AGENTS.md",
-        "contracts/frame-current-runtime-assets.md"
+        "contracts/frame-current-runtime-assets.md",
+        "docs/architecture/frame-current-runtime-separation-plan.md",
+        "docs/architecture/decisions/0003-retire-public-sf6-agent-adapter.md"
       ],
       "notes": "Derived from exact current-fact authority but currently located under deferred public adapter path."
     },
@@ -324,7 +328,8 @@
       ],
       "policy_refs": [
         "AGENTS.md",
-        "contracts/normalization-aliases.schema.json"
+        "contracts/normalization-aliases.schema.json",
+        "docs/architecture/decisions/0003-retire-public-sf6-agent-adapter.md"
       ],
       "notes": "Generated query-normalization support, not exact current-fact authority."
     },
@@ -356,6 +361,7 @@
       ],
       "policy_refs": [
         "docs/architecture/decisions/0002-private-hermes-first-operation.md",
+        "docs/architecture/decisions/0003-retire-public-sf6-agent-adapter.md",
         "docs/architecture/reviews/full-directory-refactor-audit-20260517.md"
       ],
       "notes": "Generated bundle for deferred public distribution. It may exist locally after validation but should not be tracked."
@@ -385,9 +391,10 @@
       ],
       "policy_refs": [
         "AGENTS.md",
-        "docs/architecture/decisions/0002-private-hermes-first-operation.md"
+        "docs/architecture/decisions/0002-private-hermes-first-operation.md",
+        "docs/architecture/decisions/0003-retire-public-sf6-agent-adapter.md"
       ],
-      "notes": "Existing public adapter surface. Active product focus is deferred while private Hermes-first operation is stabilized."
+      "notes": "Existing public adapter surface. ADR-0003 selects removal after reusable runtime payloads are relocated out of this adapter path."
     },
     {
       "id": "validation_scripts",

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -5,6 +5,7 @@ Architecture docs define the v2 source-of-truth model.
 - [v2-architecture.md](./v2-architecture.md)
 - [decisions/](./decisions/README.md)
 - [decisions/0002-private-hermes-first-operation.md](./decisions/0002-private-hermes-first-operation.md)
+- [decisions/0003-retire-public-sf6-agent-adapter.md](./decisions/0003-retire-public-sf6-agent-adapter.md)
 - [hermes-v2.1-roadmap.md](./hermes-v2.1-roadmap.md)
 - [hermes-growth-harness-map.md](./hermes-growth-harness-map.md)
 - [agent-toolchain-freshness.md](./agent-toolchain-freshness.md)

--- a/docs/architecture/decisions/0003-retire-public-sf6-agent-adapter.md
+++ b/docs/architecture/decisions/0003-retire-public-sf6-agent-adapter.md
@@ -1,0 +1,165 @@
+---
+id: adr-0003
+title: Retire Public sf6-agent Adapter After Runtime Surface Relocation
+status: accepted
+date: 2026-05-17
+decision_type: architecture_decision
+scope: public_adapter_disposition
+tracking_issue: "#246"
+
+selected_disposition: remove_after_runtime_relocation
+reactivate_public_distribution: false
+immediate_deletion: false
+
+depends_on:
+  - adr-0002
+  - frame-current-runtime-separation-plan
+  - generated-reference-responsibility-plan
+
+runtime_surfaces_to_relocate_first:
+  - generated_knowledge_references
+  - frame_current_runtime_assets
+  - normalization_runtime_assets
+
+surfaces_to_retire_later:
+  - sf6_agent_public_adapter
+  - sf6_agent_adapter_policy_references
+  - release_bundle_dist
+  - skill_installers_package
+
+markers:
+  - sf6.boundary.public_adapter_remove_after_runtime_relocation
+  - sf6.boundary.public_adapter_not_reactivated
+  - sf6.boundary.runtime_payloads_must_move_before_adapter_removal
+  - sf6.boundary.no_public_adapter_behavior_change_in_adr
+---
+
+# Retire Public sf6-agent Adapter After Runtime Surface Relocation
+
+## Decision
+
+The selected disposition for `skills/sf6-agent/` is **remove after runtime
+surface relocation**.
+
+This means:
+
+- Do not reactivate public `sf6-agent` distribution in v2.6.
+- Do not relocate the whole `skills/sf6-agent/` adapter as another public skill
+  package.
+- First move reusable generated runtime payloads out of the deferred adapter
+  path.
+- Then retire and remove the remaining public adapter, installer, and release
+  distribution surfaces through scoped PRs.
+
+In short, the decision is: remove after runtime surface relocation.
+
+This ADR is design-only. It does not delete files, move files, rebuild generated
+outputs, or change public `sf6-agent` behavior.
+
+## Context
+
+ADR-0002 set the current priority to private Hermes-first operation and marked
+public `skills/sf6-agent/` distribution as a deferred legacy surface with no
+known external public-skill users.
+
+Two Phase 2 mapping documents now separate the reusable runtime responsibilities
+from the public adapter path:
+
+- `docs/architecture/frame-current-runtime-separation-plan.md` maps
+  `frame_current_runtime_assets` and proposes `runtime/frame-current/`.
+- `docs/architecture/generated-reference-responsibility-plan.md` maps
+  `generated_knowledge_references` and `sf6_agent_adapter_policy_references`,
+  and proposes `runtime/generated-knowledge/`.
+
+The remaining question is whether the public adapter itself should be removed,
+relocated, or reactivated.
+
+## Options Considered
+
+### Option A: Reactivate
+
+Reactivate public `skills/sf6-agent/` distribution as an active product surface.
+
+Rejected for v2.6. The current repository focus is private Hermes-first
+knowledge growth and maintainer operation. Reactivating public distribution now
+would keep adapter behavior, runtime payloads, release bundle docs, installers,
+and maintainer workflows active at the same time.
+
+### Option B: Relocate Whole Adapter
+
+Move `skills/sf6-agent/` to another public adapter path while preserving the
+same product concept.
+
+Rejected for v2.6. Relocating the whole adapter preserves most of the same
+maintenance burden and does not match the current private-operation priority.
+Only reusable runtime payloads should be relocated.
+
+### Option C: Remove After Runtime Relocation
+
+Move reusable generated runtime payloads to repo-local runtime surfaces, keep
+temporary compatibility copies only when needed, then remove the remaining
+public adapter surface.
+
+Accepted. This keeps useful generated payloads while removing the public skill
+distribution layer that is not the active product focus.
+
+## Target State
+
+Long-term target:
+
+```text
+knowledge/curated/
+  -> runtime/generated-knowledge/
+
+data/exports/
+data/roster/
+  -> runtime/frame-current/
+
+data/aliases/
+  -> runtime/normalization/
+```
+
+`skills/sf6-agent/` should not remain the primary home for generated runtime
+payloads. If temporary compatibility copies are needed during migration, they
+must be documented as deferred legacy bridge outputs, not authority.
+
+`skills/sf6-agent/references/*-policy.md` is adapter behavior policy only. It
+is not canonical SF6 knowledge. If the adapter is removed, these files should be
+deleted or archived as historical design context, not promoted into
+`knowledge/curated/`.
+
+## Transition Order
+
+1. Add this ADR and validators. No files move in this step.
+2. Decide `.dist`, installer, and distribution docs handling.
+3. Classify `packages/*` as active repo-local, deferred distribution, legacy, or
+   shared infrastructure.
+4. Relocate generated runtime payloads:
+   - `runtime/frame-current/`
+   - `runtime/generated-knowledge/`
+   - `runtime/normalization/` if normalization runtime assets remain useful.
+5. Add bridge validators only if compatibility copies remain under
+   `skills/sf6-agent/`.
+6. Remove or archive the remaining `skills/sf6-agent/` adapter surface.
+
+## Consequences
+
+- Future PRs should not add public adapter features to `skills/sf6-agent/`.
+- Public distribution work requires a new ADR that explicitly reopens that
+  product direction.
+- Runtime payload migration can proceed without treating the public adapter as
+  the primary product surface.
+- Maintainer workflows remain under `workflows/`, `docs/architecture/`,
+  `contracts/`, `tests/validation/`, and repo-local Hermes support.
+
+## Non-Goals
+
+- This ADR does not delete `skills/sf6-agent/`.
+- This ADR does not move generated references, frame-current assets, or
+  normalization assets.
+- This ADR does not rebuild generated outputs.
+- This ADR does not change current facts, `official_raw`, `data/exports/`,
+  `data/roster/`, `knowledge/curated/`, or `.dist`.
+- This ADR does not change public `sf6-agent` behavior.
+- This ADR does not commit Hermes memory, sessions, local skills, raw
+  transcripts, logs, caches, credentials, or secrets.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -4,3 +4,4 @@ Architecture decision records capture accepted repository-level decisions that s
 
 - [0001-hermes-primary-orchestration.md](./0001-hermes-primary-orchestration.md)
 - [0002-private-hermes-first-operation.md](./0002-private-hermes-first-operation.md)
+- [0003-retire-public-sf6-agent-adapter.md](./0003-retire-public-sf6-agent-adapter.md)

--- a/docs/architecture/harness-and-distribution-roles.md
+++ b/docs/architecture/harness-and-distribution-roles.md
@@ -16,9 +16,8 @@ collection, review, validation, and promotion workflows are stabilized.
 
 It is not the active product surface during the private Hermes-first operation
 phase. There are no known external public-skill users, so this surface is not
-protected as an external compatibility contract. Later scoped work may remove
-or relocate it after mapping its remaining canonical and derived
-responsibilities.
+protected as an external compatibility contract. ADR-0003 selects removal after
+reusable runtime payloads are relocated out of the adapter path.
 
 While it remains in the repository, public distribution surfaces are limited
 to:
@@ -94,6 +93,7 @@ Wrappers must not become independent source-of-truth procedures. If a wrapper di
 
 The accepted v2.1 orchestration decision is [decisions/0001-hermes-primary-orchestration.md](./decisions/0001-hermes-primary-orchestration.md).
 The active private-operation priority is [decisions/0002-private-hermes-first-operation.md](./decisions/0002-private-hermes-first-operation.md).
+The public adapter disposition is [decisions/0003-retire-public-sf6-agent-adapter.md](./decisions/0003-retire-public-sf6-agent-adapter.md).
 
 ## Codex And Repo Development
 

--- a/tests/validation/run-all.ps1
+++ b/tests/validation/run-all.ps1
@@ -55,6 +55,7 @@ $readOnlyValidationScripts = @(
   'tests/validation/validate-powershell-compatibility-policy.ps1',
   'tests/validation/validate-frame-current-runtime-separation-plan.ps1',
   'tests/validation/validate-generated-reference-responsibility-plan.ps1',
+  'tests/validation/validate-public-adapter-disposition-adr.ps1',
   'tests/validation/validate-answer-orchestration-contracts.ps1',
   'tests/validation/validate-answer-smoke-fixtures.ps1',
   'tests/validation/validate-calculation-executor.ps1',

--- a/tests/validation/validate-public-adapter-disposition-adr.ps1
+++ b/tests/validation/validate-public-adapter-disposition-adr.ps1
@@ -1,0 +1,106 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$adrPath = 'docs/architecture/decisions/0003-retire-public-sf6-agent-adapter.md'
+$decisionsReadmePath = 'docs/architecture/decisions/README.md'
+$architectureReadmePath = 'docs/architecture/README.md'
+$readmePath = 'README.md'
+$harnessPath = 'docs/architecture/harness-and-distribution-roles.md'
+$registryPath = 'data/repository-surfaces.json'
+
+function Read-Text {
+  param([Parameter(Mandatory = $true)][string]$RelativePath)
+  return Get-Content -LiteralPath (Join-Path $repoRoot $RelativePath) -Raw -Encoding UTF8
+}
+
+function Assert-Contains {
+  param(
+    [Parameter(Mandatory = $true)][string]$Text,
+    [Parameter(Mandatory = $true)][string]$Needle,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  if (-not $Text.Contains($Needle)) {
+    $Issues.Value += "$Context must mention: $Needle"
+  }
+}
+
+$issues = @()
+
+foreach ($relativePath in @(
+  $adrPath,
+  $decisionsReadmePath,
+  $architectureReadmePath,
+  $readmePath,
+  $harnessPath,
+  $registryPath
+)) {
+  if (-not (Test-Path -LiteralPath (Join-Path $repoRoot $relativePath) -PathType Leaf)) {
+    $issues += "Missing public adapter disposition file: $relativePath"
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot $adrPath) -PathType Leaf) {
+  $adr = Read-Text $adrPath
+  foreach ($needle in @(
+    'id: adr-0003',
+    'status: accepted',
+    'tracking_issue: "#246"',
+    'selected_disposition: remove_after_runtime_relocation',
+    'reactivate_public_distribution: false',
+    'immediate_deletion: false',
+    'sf6.boundary.public_adapter_remove_after_runtime_relocation',
+    'sf6.boundary.public_adapter_not_reactivated',
+    'skills/sf6-agent/',
+    'remove after runtime surface relocation',
+    'runtime/frame-current/',
+    'runtime/generated-knowledge/',
+    'runtime/normalization/',
+    'frame-current-runtime-separation-plan.md',
+    'generated-reference-responsibility-plan.md',
+    'Do not reactivate public `sf6-agent` distribution',
+    'This ADR is design-only',
+    'does not delete files',
+    'does not change public `sf6-agent` behavior'
+  )) {
+    Assert-Contains $adr $needle $adrPath ([ref]$issues)
+  }
+}
+
+foreach ($doc in @($decisionsReadmePath, $architectureReadmePath, $readmePath, $harnessPath)) {
+  if (Test-Path -LiteralPath (Join-Path $repoRoot $doc) -PathType Leaf) {
+    $text = Read-Text $doc
+    if ($doc -in @($decisionsReadmePath, $architectureReadmePath, $harnessPath)) {
+      Assert-Contains $text '0003-retire-public-sf6-agent-adapter.md' $doc ([ref]$issues)
+    } else {
+      Assert-Contains $text $adrPath $doc ([ref]$issues)
+    }
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot $registryPath) -PathType Leaf) {
+  $registry = Get-Content -LiteralPath (Join-Path $repoRoot $registryPath) -Raw -Encoding UTF8 | ConvertFrom-Json
+  $adapter = @($registry.surfaces | Where-Object { $_.id -eq 'sf6_agent_public_adapter' })
+  if ($adapter.Count -ne 1) {
+    $issues += "$registryPath must contain exactly one sf6_agent_public_adapter surface"
+  } else {
+    $surface = $adapter[0]
+    if ($surface.public_distribution_status -ne 'deferred') {
+      $issues += 'sf6_agent_public_adapter must remain deferred until implementation removes it'
+    }
+    if (@($surface.policy_refs) -notcontains $adrPath) {
+      $issues += "sf6_agent_public_adapter must reference $adrPath"
+    }
+    if (-not ([string]$surface.notes).Contains('ADR-0003 selects removal after reusable runtime payloads are relocated')) {
+      $issues += 'sf6_agent_public_adapter notes must record the ADR-0003 removal-after-relocation decision'
+    }
+  }
+}
+
+if ($issues.Count -gt 0) {
+  throw ($issues -join "`n")
+}
+
+Write-Host 'Public adapter disposition ADR OK'


### PR DESCRIPTION
## Summary

- Add ADR-0003 selecting `remove_after_runtime_relocation` for `skills/sf6-agent/`.
- Record that public `sf6-agent` distribution is not reactivated in v2.6 and should be removed after reusable runtime payloads are relocated.
- Update discovery docs and repository surface registry policy refs for affected deferred/runtime surfaces.
- Add a focused validator for the ADR and wire it into the read-only validation lane.

Closes #246.

## Validation

- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-public-adapter-disposition-adr.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-repository-surfaces.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 -Lane read-only`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1`
- `git diff --check`
- `git diff --check origin/main...HEAD`

## Intentionally not done

- Did not delete or move `skills/sf6-agent/`.
- Did not move or regenerate generated references, frame-current assets, or normalization assets.
- Did not change current facts, `official_raw`, `data/exports`, `data/roster`, `knowledge/curated`, or `.dist`.
- Did not change public `sf6-agent` behavior.
