### PR TITLE
[v2.6] Add generic schema validation runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ installers, and distribution docs is in
 [`docs/architecture/decisions/0004-retire-deferred-distribution-surfaces.md`](./docs/architecture/decisions/0004-retire-deferred-distribution-surfaces.md).
 Package directory classifications are in
 [`docs/architecture/package-surface-classification.md`](./docs/architecture/package-surface-classification.md).
+Generic JSON Schema validation runner guidance is in
+[`docs/architecture/schema-validation-runner.md`](./docs/architecture/schema-validation-runner.md).
 
 ## Public answer adapter status
 

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -6,6 +6,12 @@ Contracts distinguish canonical surfaces from derived surfaces and use generic s
 
 Some contracts describe Markdown front matter or agent-readable artifacts that are enforced by dedicated validators rather than by a generic JSON Schema runtime. Validators under `tests/validation/` are the executable contract layer for the current repo.
 
+`tests/validation/validate-json-schema-manifest.ps1` is the manifest-driven
+generic JSON Schema runner for structural validation. Its coverage list lives in
+`tests/validation/schema-validation-manifest.json`. Dedicated validators remain
+the authority for semantic boundaries, cross-file consistency, generated-output
+reproducibility, current-fact rules, and Markdown front matter contracts.
+
 `tests/validation/validate-ingest-artifacts.ps1` is the executable contract layer for artifact-level review-only metadata under `knowledge/evidence/claims/*.claims.md`.
 
 `tests/validation/validate-current-fact-boundaries.ps1` is the executable contract layer for review-only current-fact candidate metadata under `knowledge/review/current-fact-candidates/`.
@@ -42,3 +48,9 @@ When `source_refs.path` points to a migrated legacy file, `source_revision` iden
 - `repository-surface.schema.json`: machine-readable index contract for canonical, derived, deferred legacy, repo-local support, historical, and non-canonical repository surfaces.
 - `data/repository-surfaces.json`: seed registry of existing reviewed boundaries. The registry indexes current policy; it does not replace `AGENTS.md`, ADRs, workflows, or validators as policy sources yet.
 - `docs/architecture/repository-surface-registry-policy.md`: maintainer-facing guide for using registry surface roles with validation lanes and generated / deferred legacy surface boundaries.
+
+## Generic Schema Validation
+
+- `tests/validation/schema-validation-manifest.json`: maps JSON Schemas to tracked JSON artifacts for generic structural validation.
+- `tests/validation/validate-json-schema-manifest.ps1`: validates manifest entries using local PowerShell `Test-Json`.
+- `docs/architecture/schema-validation-runner.md`: maintainer-facing boundary for what belongs in the generic runner versus dedicated validators.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -24,6 +24,7 @@ Architecture docs define the v2 source-of-truth model.
 - [harness-and-distribution-roles.md](./harness-and-distribution-roles.md)
 - [repository-surface-registry-policy.md](./repository-surface-registry-policy.md)
 - [package-surface-classification.md](./package-surface-classification.md)
+- [schema-validation-runner.md](./schema-validation-runner.md)
 - [generated-reference-responsibility-plan.md](./generated-reference-responsibility-plan.md)
 - [frame-current-runtime-separation-plan.md](./frame-current-runtime-separation-plan.md)
 - [powershell-compatibility-policy.md](./powershell-compatibility-policy.md)

--- a/docs/architecture/schema-validation-runner.md
+++ b/docs/architecture/schema-validation-runner.md
@@ -1,0 +1,60 @@
+---
+title: Generic Schema Validation Runner
+status: accepted
+last_reviewed: 2026-05-18
+tracking_issue: "#252"
+---
+
+# Generic Schema Validation Runner
+
+この文書は、JSON Schema backed artifacts を共通 runner で検証する
+Phase 3 方針を定義する。
+
+## Decision
+
+JSON Schema と JSON artifact の対応は
+`tests/validation/schema-validation-manifest.json` に集約する。
+
+`tests/validation/validate-json-schema-manifest.ps1` は manifest を読み、
+各 schema と artifact を PowerShell `Test-Json` で検証する。
+
+この runner は structural schema validation 専用であり、既存の semantic
+validators を置き換えない。
+
+## Initial Coverage
+
+初期 coverage は、network access や external dependency なしで安定して検証できる
+JSON artifact に限定する。
+
+| Schema | Documents |
+|---|---|
+| `contracts/repository-surface.schema.json` | `data/repository-surfaces.json` |
+| `contracts/agent-toolchain.schema.json` | `data/toolchain/maintainer-agent-toolchain.json` |
+| `contracts/normalization-aliases.schema.json` | `data/aliases/ja-query-fixtures.json` |
+| `contracts/external-frame-atlas-source-evaluation.schema.json` | `data/external-frame-atlas/evaluation/source-evaluation-matrix.json` |
+| `contracts/external-frame-atlas-source.schema.json` | `tests/fixtures/external-frame-atlas/*.json` |
+
+Schemas with external relative `$ref` files, markdown front matter contracts,
+or command-generated traces stay under dedicated validators until a later PR
+adds safe bundling or extraction support.
+
+## Boundary
+
+- Generic schema runner checks shape, required fields, enums, constants,
+  additional properties, and other JSON Schema structural constraints supported
+  by the local PowerShell runtime.
+- Dedicated validators continue to check semantic boundaries, cross-file
+  consistency, generated-output reproducibility, current-fact rules, copyright
+  boundaries, and repo policy wording.
+- Adding a schema/document pair requires updating the manifest and keeping any
+  necessary semantic validator in place.
+
+## Non-Goals
+
+- Do not replace semantic validators in this issue.
+- Do not validate markdown front matter through this runner in this issue.
+- Do not change artifact schemas, current facts, generated runtime assets,
+  `official_raw`, public `sf6-agent` behavior, or package executable behavior.
+- Do not add external schema validation dependencies.
+- Do not commit Hermes local state, raw transcripts, memory, sessions, logs,
+  caches, credentials, or secrets.

--- a/tests/validation/run-all.ps1
+++ b/tests/validation/run-all.ps1
@@ -50,6 +50,7 @@ $readOnlyValidationScripts = @(
   'tests/validation/validate-codex-hermes-pack.ps1',
   'tests/validation/validate-codex-hermes-delegation-fixtures.ps1',
   'tests/validation/validate-v2-contracts.ps1',
+  'tests/validation/validate-json-schema-manifest.ps1',
   'tests/validation/validate-agent-toolchain.ps1',
   'tests/validation/validate-repository-surfaces.ps1',
   'tests/validation/validate-package-surface-classification.ps1',

--- a/tests/validation/schema-validation-manifest.json
+++ b/tests/validation/schema-validation-manifest.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": "schema-validation-manifest/v1",
+  "last_reviewed": "2026-05-18",
+  "tracking_issue": "#252",
+  "runner": "tests/validation/validate-json-schema-manifest.ps1",
+  "validation_scope": "json_schema_structural_validation_only",
+  "semantic_validators_remain_authority": true,
+  "entries": [
+    {
+      "id": "repository_surfaces",
+      "schema_path": "contracts/repository-surface.schema.json",
+      "document_globs": [
+        "data/repository-surfaces.json"
+      ],
+      "notes": "Structural registry shape only; validate-repository-surfaces.ps1 remains semantic authority."
+    },
+    {
+      "id": "maintainer_agent_toolchain",
+      "schema_path": "contracts/agent-toolchain.schema.json",
+      "document_globs": [
+        "data/toolchain/maintainer-agent-toolchain.json"
+      ],
+      "notes": "Structural toolchain manifest shape only; validate-agent-toolchain.ps1 remains semantic authority."
+    },
+    {
+      "id": "normalization_aliases",
+      "schema_path": "contracts/normalization-aliases.schema.json",
+      "document_globs": [
+        "data/aliases/ja-query-fixtures.json"
+      ],
+      "notes": "Structural alias shape only; normalization validators remain semantic authority."
+    },
+    {
+      "id": "external_frame_atlas_source_evaluation",
+      "schema_path": "contracts/external-frame-atlas-source-evaluation.schema.json",
+      "document_globs": [
+        "data/external-frame-atlas/evaluation/source-evaluation-matrix.json"
+      ],
+      "notes": "Structural source evaluation shape only; external atlas evaluation validator remains semantic authority."
+    },
+    {
+      "id": "external_frame_atlas_source_fixtures",
+      "schema_path": "contracts/external-frame-atlas-source.schema.json",
+      "document_globs": [
+        "tests/fixtures/external-frame-atlas/*.json"
+      ],
+      "notes": "Structural external source fixture shape only; external atlas fixture validator remains semantic authority."
+    }
+  ]
+}

--- a/tests/validation/validate-json-schema-manifest.ps1
+++ b/tests/validation/validate-json-schema-manifest.ps1
@@ -1,0 +1,170 @@
+param(
+  [string]$ManifestPath = 'tests/validation/schema-validation-manifest.json'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+
+function Read-Json {
+  param([Parameter(Mandatory = $true)][string]$RelativePath)
+  return Get-Content -LiteralPath (Join-Path $repoRoot $RelativePath) -Raw -Encoding UTF8 | ConvertFrom-Json
+}
+
+function Read-Text {
+  param([Parameter(Mandatory = $true)][string]$RelativePath)
+  return Get-Content -LiteralPath (Join-Path $repoRoot $RelativePath) -Raw -Encoding UTF8
+}
+
+function Test-Property {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name
+  )
+  return $null -ne $Object.PSObject.Properties[$Name]
+}
+
+function Get-TrackedPaths {
+  if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    throw 'git is required for manifest glob expansion'
+  }
+
+  $paths = @(& git -C $repoRoot ls-files)
+  if ($LASTEXITCODE -ne 0) {
+    throw 'Unable to list tracked repository files'
+  }
+
+  return @($paths | ForEach-Object { [string]$_ })
+}
+
+function Get-TrackedMatches {
+  param(
+    [Parameter(Mandatory = $true)][string[]]$TrackedPaths,
+    [Parameter(Mandatory = $true)][string]$Glob
+  )
+
+  $normalizedGlob = $Glob.Replace('\', '/')
+  return @($TrackedPaths | Where-Object {
+    $_ -eq $normalizedGlob -or $_ -like $normalizedGlob
+  })
+}
+
+function Add-Issue {
+  param(
+    [Parameter(Mandatory = $true)][ref]$Issues,
+    [Parameter(Mandatory = $true)][string]$Message
+  )
+  $Issues.Value += $Message
+}
+
+$issues = @()
+$manifestRelativePath = $ManifestPath.Replace('\', '/')
+
+if (-not (Test-Path -LiteralPath (Join-Path $repoRoot $manifestRelativePath) -PathType Leaf)) {
+  throw "Missing schema validation manifest: $manifestRelativePath"
+}
+
+$manifest = Read-Json $manifestRelativePath
+
+foreach ($field in @(
+  'schema_version',
+  'last_reviewed',
+  'tracking_issue',
+  'runner',
+  'validation_scope',
+  'semantic_validators_remain_authority',
+  'entries'
+)) {
+  if (-not (Test-Property $manifest $field)) {
+    Add-Issue ([ref]$issues) "$manifestRelativePath missing field: $field"
+  }
+}
+
+if ((Test-Property $manifest 'schema_version') -and $manifest.schema_version -ne 'schema-validation-manifest/v1') {
+  Add-Issue ([ref]$issues) "$manifestRelativePath must use schema_version schema-validation-manifest/v1"
+}
+if ((Test-Property $manifest 'runner') -and $manifest.runner -ne 'tests/validation/validate-json-schema-manifest.ps1') {
+  Add-Issue ([ref]$issues) "$manifestRelativePath must point to tests/validation/validate-json-schema-manifest.ps1"
+}
+if ((Test-Property $manifest 'validation_scope') -and $manifest.validation_scope -ne 'json_schema_structural_validation_only') {
+  Add-Issue ([ref]$issues) "$manifestRelativePath must keep validation_scope json_schema_structural_validation_only"
+}
+if ((Test-Property $manifest 'semantic_validators_remain_authority') -and $manifest.semantic_validators_remain_authority -ne $true) {
+  Add-Issue ([ref]$issues) "$manifestRelativePath must keep semantic_validators_remain_authority true"
+}
+
+$trackedPaths = Get-TrackedPaths
+$seenIds = @{}
+
+foreach ($entry in @($manifest.entries)) {
+  $id = if (Test-Property $entry 'id') { [string]$entry.id } else { '<missing-id>' }
+  foreach ($field in @('id', 'schema_path', 'document_globs', 'notes')) {
+    if (-not (Test-Property $entry $field)) {
+      Add-Issue ([ref]$issues) "$manifestRelativePath entry $id missing field: $field"
+    }
+  }
+
+  if ($seenIds.ContainsKey($id)) {
+    Add-Issue ([ref]$issues) "$manifestRelativePath duplicate entry id: $id"
+  } else {
+    $seenIds[$id] = $true
+  }
+
+  if (-not (Test-Property $entry 'schema_path')) {
+    continue
+  }
+
+  $schemaRelativePath = ([string]$entry.schema_path).Replace('\', '/')
+  $schemaPath = Join-Path $repoRoot $schemaRelativePath
+  if (-not (Test-Path -LiteralPath $schemaPath -PathType Leaf)) {
+    Add-Issue ([ref]$issues) "$id schema_path does not exist: $schemaRelativePath"
+    continue
+  }
+
+  $schemaText = Read-Text $schemaRelativePath
+  $schema = $null
+  try {
+    $schema = $schemaText | ConvertFrom-Json
+  } catch {
+    Add-Issue ([ref]$issues) "$schemaRelativePath is not valid JSON: $($_.Exception.Message)"
+    continue
+  }
+
+  foreach ($field in @('$schema', '$id', 'title')) {
+    if (-not (Test-Property $schema $field)) {
+      Add-Issue ([ref]$issues) "$schemaRelativePath missing schema field: $field"
+    }
+  }
+
+  if (-not (Test-Property $entry 'document_globs')) {
+    continue
+  }
+
+  $documentMatches = @()
+  foreach ($glob in @($entry.document_globs)) {
+    $matches = @(Get-TrackedMatches $trackedPaths ([string]$glob))
+    if ($matches.Count -eq 0) {
+      Add-Issue ([ref]$issues) "$id document_glob has no tracked matches: $glob"
+    }
+    $documentMatches += $matches
+  }
+
+  foreach ($documentRelativePath in @($documentMatches | Sort-Object -Unique)) {
+    $documentPath = Join-Path $repoRoot $documentRelativePath
+    try {
+      $valid = Test-Json -LiteralPath $documentPath -Schema $schemaText -ErrorAction Stop
+      if ($valid -ne $true) {
+        Add-Issue ([ref]$issues) "$documentRelativePath failed schema validation against $schemaRelativePath"
+      }
+    } catch {
+      Add-Issue ([ref]$issues) "$documentRelativePath failed schema validation against $schemaRelativePath`: $($_.Exception.Message)"
+    }
+  }
+}
+
+if ($issues.Count -gt 0) {
+  throw ($issues -join "`n")
+}
+
+Write-Host 'JSON schema manifest OK'


### PR DESCRIPTION
## Summary

- add a manifest-driven generic JSON Schema validation runner for structural JSON artifact checks
- add initial coverage for repository surfaces, maintainer toolchain, normalization aliases, and external frame atlas JSON artifacts
- document the runner boundary and keep semantic validators as authority for policy, cross-file, generated-output, and current-fact checks

Closes #252

## Validation

- pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-json-schema-manifest.ps1
- pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-v2-contracts.ps1
- pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1
- pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 -Lane read-only
- pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1
- git diff --check
- git diff --check origin/main...HEAD

## Notes

- Semantic validators are not replaced.
- Markdown front matter contracts stay under dedicated validators.
- No artifact schemas, current facts, generated runtime assets, official_raw, public sf6-agent behavior, or package executable behavior changed.
- No external schema validation dependency is added.
- No Hermes local state, raw transcripts, memory, sessions, logs, caches, credentials, or secrets are committed.