### PR TITLE
[v2.6] Add current-fact export manifest contract

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -38,6 +38,13 @@ When `source_refs.path` points to a migrated legacy file, `source_revision` iden
 - `normalization-aliases.schema.json`: query-normalization alias contract for mapping user language to structured lookup inputs.
 - `data/aliases/`: canonical query-normalization support, not exact current-fact authority. Exact current facts remain grounded in `data/exports/` and `data/roster/`.
 
+## Current-Fact Export Contracts
+
+- `current-fact-export-manifest.schema.json`: structural contract for
+  `data/exports/<character_slug>/snapshot_manifest.json`.
+- `data/exports/README.md`: maintainer-facing boundary for published export
+  authority, manual-review sidecars, and related validators.
+
 ## Maintainer Toolchain Contracts
 
 - `agent-toolchain.schema.json`: maintainer agent toolchain policy contract for reviewed capabilities and freshness expectations.

--- a/contracts/current-fact-export-manifest.schema.json
+++ b/contracts/current-fact-export-manifest.schema.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sf6-knowledge-agent-kit.local/current-fact-export-manifest.schema.json",
+  "title": "Current Fact Export Manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "character_slug",
+    "schema_version",
+    "export_contract_version",
+    "derivation_rule_version",
+    "repo_generation_registry_version",
+    "repo_generation_registry_sha256",
+    "repo_generation_binding_policy_version",
+    "repo_generation_binding_policy_sha256",
+    "datasets"
+  ],
+  "properties": {
+    "character_slug": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9_]*$"
+    },
+    "schema_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "export_contract_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "derivation_rule_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "repo_generation_registry_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "repo_generation_registry_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "repo_generation_binding_policy_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "repo_generation_binding_policy_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "datasets": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "official_raw",
+        "supercombo_enrichment",
+        "derived_metrics"
+      ],
+      "properties": {
+        "official_raw": {
+          "$ref": "#/$defs/dataset_entry"
+        },
+        "supercombo_enrichment": {
+          "$ref": "#/$defs/dataset_entry"
+        },
+        "derived_metrics": {
+          "$ref": "#/$defs/dataset_entry"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "sha256_or_null": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "version_or_null": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 1
+    },
+    "run_id_or_null": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 1
+    },
+    "dataset_entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "publication_state",
+        "published_run_id",
+        "published_snapshot_ids",
+        "published_record_count",
+        "withheld_review_count",
+        "registry_version",
+        "registry_sha256",
+        "binding_policy_version",
+        "binding_policy_sha256",
+        "content_hash"
+      ],
+      "properties": {
+        "publication_state": {
+          "type": "string",
+          "enum": [
+            "available",
+            "unavailable"
+          ]
+        },
+        "published_run_id": {
+          "$ref": "#/$defs/run_id_or_null"
+        },
+        "published_snapshot_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "published_record_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "withheld_review_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "registry_version": {
+          "$ref": "#/$defs/version_or_null"
+        },
+        "registry_sha256": {
+          "$ref": "#/$defs/sha256_or_null"
+        },
+        "binding_policy_version": {
+          "$ref": "#/$defs/version_or_null"
+        },
+        "binding_policy_sha256": {
+          "$ref": "#/$defs/sha256_or_null"
+        },
+        "content_hash": {
+          "$ref": "#/$defs/sha256_or_null"
+        }
+      }
+    }
+  }
+}

--- a/data/exports/README.md
+++ b/data/exports/README.md
@@ -1,0 +1,98 @@
+# Current Fact Exports
+
+`data/exports/` は、公開済みの exact current-fact export surface です。
+
+この directory は通常回答で使う move-specific current facts の authority ですが、
+すべての tracked file が同じ authority を持つわけではありません。
+
+## Authority Boundary
+
+- `official_raw.{json,csv}` は公式 raw frame-data export の公開面です。
+- `derived_metrics.{json,csv}` は `official_raw` だけから再計算された派生 metric です。
+- `supercombo_enrichment.{json,csv}` は `official_raw` の safe subset に束縛された enrichment です。
+- `snapshot_manifest.json` は character ごとの published export provenance です。
+- `*_manual_review.{json,csv}` は withheld row / review reason / audit sidecar です。
+
+`*_manual_review.*` は normal public answer authority ではありません。通常回答や
+runtime current-fact lookup に混ぜる前に、review と publish workflow を通して
+main export へ昇格させる必要があります。
+
+## Layout
+
+Character ごとの directory は次の形を持ちます。
+
+```text
+data/exports/<character_slug>/
+  official_raw.json
+  official_raw.csv
+  official_raw_manual_review.json
+  official_raw_manual_review.csv
+  derived_metrics.json
+  derived_metrics.csv
+  derived_metrics_manual_review.json
+  derived_metrics_manual_review.csv
+  supercombo_enrichment.json
+  supercombo_enrichment.csv
+  supercombo_enrichment_manual_review.json
+  supercombo_enrichment_manual_review.csv
+  snapshot_manifest.json
+```
+
+`snapshot_manifest.json` は `contracts/current-fact-export-manifest.schema.json`
+に従います。この schema は structural validation 用です。published raw
+snapshot の keep-set、runtime asset reproducibility、manual-review debt などの
+cross-file semantics は専用 validator が扱います。
+
+## Dataset Semantics
+
+Current dataset keys are:
+
+- `official_raw`
+- `derived_metrics`
+- `supercombo_enrichment`
+
+Each dataset entry records:
+
+- `publication_state`
+- `published_run_id`
+- `published_snapshot_ids`
+- `published_record_count`
+- `withheld_review_count`
+- `registry_version` / `registry_sha256`
+- `binding_policy_version` / `binding_policy_sha256`
+- `content_hash`
+
+`publication_state` is `available` or `unavailable`. Available datasets have
+published export files and provenance. Unavailable datasets keep an explicit
+manifest entry so downstream code can distinguish absence from omission.
+
+## Non-Authority Surfaces
+
+The following are not normal public answer authority:
+
+- `data/raw/`
+- `data/normalized/`
+- `*_manual_review.*`
+- run-local scraper state
+- browser/cache/log output
+- Hermes memory, sessions, local skills, Curator output, checkpoints, or raw transcripts
+
+Exact current facts must not be inferred from those surfaces alone.
+
+## Validation
+
+Run the focused structural contract check:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-json-schema-manifest.ps1
+```
+
+Run related semantic checks:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-frame-current-assets.ps1
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-raw-snapshot-minimality.ps1
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-current-fact-boundaries.ps1
+```
+
+Use `tests/validation/run-all.ps1` before claiming broad validation.

--- a/data/repository-surfaces.json
+++ b/data/repository-surfaces.json
@@ -69,6 +69,7 @@
       "id": "data_exports",
       "title": "Current Fact Exports",
       "path_globs": [
+        "data/exports/README.md",
         "data/exports/*/snapshot_manifest.json",
         "data/exports/*/official_raw.json",
         "data/exports/*/derived_metrics.json",
@@ -87,11 +88,14 @@
       "public_distribution_status": "not_distribution",
       "normal_public_answer_authority": true,
       "validation_expectation": [
+        "current_fact_export_manifest_schema_valid",
         "ingest_artifacts_valid",
         "raw_snapshot_manifest_consistent"
       ],
       "policy_refs": [
         "AGENTS.md",
+        "data/exports/README.md",
+        "contracts/current-fact-export-manifest.schema.json",
         "ingest/frame_data/README.md"
       ],
       "notes": "Published current facts are canonical; manual-review sidecars remain non-canonical."

--- a/docs/architecture/schema-validation-runner.md
+++ b/docs/architecture/schema-validation-runner.md
@@ -33,6 +33,7 @@ JSON artifact に限定する。
 | `contracts/normalization-aliases.schema.json` | `data/aliases/ja-query-fixtures.json` |
 | `contracts/external-frame-atlas-source-evaluation.schema.json` | `data/external-frame-atlas/evaluation/source-evaluation-matrix.json` |
 | `contracts/external-frame-atlas-source.schema.json` | `tests/fixtures/external-frame-atlas/*.json` |
+| `contracts/current-fact-export-manifest.schema.json` | `data/exports/*/snapshot_manifest.json` |
 
 Schemas with external relative `$ref` files, markdown front matter contracts,
 or command-generated traces stay under dedicated validators until a later PR

--- a/ingest/frame_data/README.md
+++ b/ingest/frame_data/README.md
@@ -157,6 +157,10 @@ Published exports:
 - `data/exports/<character_slug>/derived_metrics.{json,csv}`
 - `data/exports/<character_slug>/snapshot_manifest.json`
 
+See `data/exports/README.md` for the current-fact export authority boundary.
+`snapshot_manifest.json` follows
+`contracts/current-fact-export-manifest.schema.json` for structural validation.
+
 ## Manifest Rules
 
 `run_manifest.json` records a normalized attempt and includes:

--- a/tests/validation/schema-validation-manifest.json
+++ b/tests/validation/schema-validation-manifest.json
@@ -45,6 +45,14 @@
         "tests/fixtures/external-frame-atlas/*.json"
       ],
       "notes": "Structural external source fixture shape only; external atlas fixture validator remains semantic authority."
+    },
+    {
+      "id": "current_fact_export_manifests",
+      "schema_path": "contracts/current-fact-export-manifest.schema.json",
+      "document_globs": [
+        "data/exports/*/snapshot_manifest.json"
+      ],
+      "notes": "Structural current-fact export manifest shape only; frame-current and raw snapshot validators remain semantic authority."
     }
   ]
 }

--- a/tests/validation/validate-v2-contracts.ps1
+++ b/tests/validation/validate-v2-contracts.ps1
@@ -15,7 +15,8 @@ $requiredJsonSchemas = @(
   'contracts/calculation-trace.schema.json',
   'contracts/normalization-aliases.schema.json',
   'contracts/agent-toolchain.schema.json',
-  'contracts/repository-surface.schema.json'
+  'contracts/repository-surface.schema.json',
+  'contracts/current-fact-export-manifest.schema.json'
 )
 
 $requiredDocs = @(


### PR DESCRIPTION
## Summary

- Add data/exports/README.md to document the current-fact export authority boundary, manual-review sidecars, and related validators.
- Add contracts/current-fact-export-manifest.schema.json for structural validation of data/exports/*/snapshot_manifest.json.
- Register the new schema in the generic schema validation manifest and repository surface registry.

## Validation

- pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-json-schema-manifest.ps1
- pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-v2-contracts.ps1
- pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-repository-surfaces.ps1
- pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1
- pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-frame-current-assets.ps1
- pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-raw-snapshot-minimality.ps1
- pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-current-fact-boundaries.ps1
- pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 -Lane read-only
- pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1
- git diff --cached --check
- git diff --check origin/main...HEAD

## Notes

- No current facts, official_raw, data/raw, data/normalized, generated runtime assets, public adapter behavior, or Hermes local state changed.
- Closes #254
- Parent #197