### PR TITLE
[v2.6] Add raw snapshot retention ADR

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ The ADR selecting removal of the public adapter after runtime relocation is in
 The ADR selecting interim legacy-lane handling and later deletion for `.dist`,
 installers, and distribution docs is in
 [`docs/architecture/decisions/0004-retire-deferred-distribution-surfaces.md`](./docs/architecture/decisions/0004-retire-deferred-distribution-surfaces.md).
+The ADR selecting minimal Git retention for raw snapshots and deferring broader
+raw cache/hash references to repo-external storage is in
+[`docs/architecture/decisions/0005-raw-snapshot-retention.md`](./docs/architecture/decisions/0005-raw-snapshot-retention.md).
 Package directory classifications are in
 [`docs/architecture/package-surface-classification.md`](./docs/architecture/package-surface-classification.md).
 Generic JSON Schema validation runner guidance is in

--- a/data/repository-surfaces.json
+++ b/data/repository-surfaces.json
@@ -687,13 +687,15 @@
       "normal_public_answer_authority": false,
       "validation_expectation": [
         "raw_snapshot_minimality_valid",
+        "raw_snapshot_retention_adr_valid",
         "not_normal_public_answer_authority"
       ],
       "policy_refs": [
         "AGENTS.md",
-        "ingest/frame_data/README.md"
+        "ingest/frame_data/README.md",
+        "docs/architecture/decisions/0005-raw-snapshot-retention.md"
       ],
-      "notes": "Raw snapshots support reproducibility and ingestion review. They are not final evidence for normal public answers."
+      "notes": "Raw snapshots support minimal current published export reproducibility and ingestion review. ADR-0005 keeps broader raw cache or history storage repo-external by default. They are not final evidence for normal public answers."
     },
     {
       "id": "normalized_intermediate_state",

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -7,6 +7,7 @@ Architecture docs define the v2 source-of-truth model.
 - [decisions/0002-private-hermes-first-operation.md](./decisions/0002-private-hermes-first-operation.md)
 - [decisions/0003-retire-public-sf6-agent-adapter.md](./decisions/0003-retire-public-sf6-agent-adapter.md)
 - [decisions/0004-retire-deferred-distribution-surfaces.md](./decisions/0004-retire-deferred-distribution-surfaces.md)
+- [decisions/0005-raw-snapshot-retention.md](./decisions/0005-raw-snapshot-retention.md)
 - [hermes-v2.1-roadmap.md](./hermes-v2.1-roadmap.md)
 - [hermes-growth-harness-map.md](./hermes-growth-harness-map.md)
 - [agent-toolchain-freshness.md](./agent-toolchain-freshness.md)

--- a/docs/architecture/decisions/0005-raw-snapshot-retention.md
+++ b/docs/architecture/decisions/0005-raw-snapshot-retention.md
@@ -1,0 +1,197 @@
+---
+id: adr-0005
+title: Raw Snapshot Retention Boundary
+status: accepted
+date: 2026-05-18
+decision_type: architecture_decision
+scope: raw_snapshot_retention
+tracking_issue: "#258"
+
+selected_retention_model: current_published_manifest_minimal_git_set
+git_tracked_raw_snapshot_role: minimal_reproducibility_artifact
+repo_external_raw_cache_role: future_metadata_reference_only
+retention_exception_artifact: required_for_unreferenced_git_raw_retention
+normal_public_answer_authority: false
+immediate_data_change: false
+
+depends_on:
+  - raw_snapshot_minimality_validator
+  - current_fact_export_manifest_contract
+  - manual_review_debt_index
+
+markers:
+  - sf6.boundary.raw_snapshots_git_tracked_minimal_reproducibility
+  - sf6.boundary.unreferenced_raw_snapshots_removable_without_exception
+  - sf6.boundary.repo_external_raw_cache_metadata_only
+  - sf6.boundary.raw_snapshots_not_public_answer_authority
+  - sf6.boundary.no_raw_snapshot_data_change_in_adr
+---
+
+# Raw Snapshot Retention Boundary
+
+## Decision
+
+Use **current published manifest minimal Git set** as the raw snapshot retention
+model.
+
+This means:
+
+- Git-tracked `data/raw/` snapshots are retained only as the minimal
+  reproducibility input for the current published exports in `data/exports/`.
+- `data/exports/<character_slug>/snapshot_manifest.json` is the reviewed keep
+  set source for checked-in raw snapshot directories.
+- A tracked raw snapshot directory that is not referenced by the current
+  published manifests is removable residue unless a later reviewed
+  retention-exception artifact explicitly allows it.
+- Future repo-external raw caches may be used only as maintainer-local or
+  repo-external storage. The repository may commit sanitized metadata, content
+  hashes, or source references for those caches only after a later reviewed
+  issue defines the artifact shape.
+- Raw snapshots are not normal public answer authority.
+
+In short, Git keeps the minimum raw input needed to reproduce the current
+published export surface. Anything broader belongs outside the repo unless a
+reviewed exception artifact says otherwise.
+
+This ADR is design-only. It does not add, delete, refetch, rewrite, normalize,
+or re-hash raw snapshots. It does not change current facts, exports, roster
+data, generated runtime assets, normalized runs, manual-review sidecars, or
+public adapter behavior.
+
+Design-only guard: this ADR does not add, delete, refetch, rewrite, normalize, or re-hash raw snapshots.
+
+## Context
+
+The frame-data ingestion pipeline writes raw snapshots before parsing. The raw
+byte payload plus `metadata.json` is the reproducibility input for current
+published exports, while decoded HTML and normalized rows are derived from those
+snapshots.
+
+The repository already has:
+
+- `data/exports/<character_slug>/snapshot_manifest.json` as the current
+  published provenance surface.
+- `tests/validation/validate-raw-snapshot-minimality.ps1` to verify every
+  checked-in raw snapshot directory is referenced by the current published
+  manifests.
+- `data/exports/_index/manual-review-debt.json` to expose withheld row debt
+  without promoting manual-review rows to normal public answer authority.
+
+The missing repository-level decision was whether raw snapshots should become a
+historical archive, an external cache reference surface, or a minimal
+reproducibility surface.
+
+## Options Considered
+
+### Option A: Keep All Historical Raw Snapshots In Git
+
+Keep every fetched raw snapshot as checked-in history.
+
+Rejected. This turns `data/raw/` into a growing historical archive and weakens
+the current published manifest boundary. It also makes future patch refreshes
+carry unrelated raw residue unless every old snapshot receives a separate
+retention justification.
+
+### Option B: Keep No Raw Snapshots In Git
+
+Remove checked-in raw snapshots and rely on refetching or external caches.
+
+Rejected for the current repository. The published export surface would lose its
+reviewable reproduction input. Missing source pages or upstream changes would
+make current checked-in exports harder to audit.
+
+### Option C: Keep Only Current Published Manifest References
+
+Keep only the raw snapshot directories referenced by current published
+`snapshot_manifest.json` files.
+
+Accepted. This is the existing validator model and matches the current
+reproducibility need without making Git the long-term raw archive.
+
+## Retention Rules
+
+Git-tracked raw snapshots:
+
+- must live under `data/raw/official/<character_slug>/<snapshot_id>/` or
+  `data/raw/supercombo/<character_slug>/<snapshot_id>/`;
+- must contain the expected snapshot payload and metadata files for the ingest
+  source;
+- must be referenced by an `available` dataset in the current published
+  manifest keep set;
+- are reproducibility artifacts only;
+- are not normal public answer authority.
+
+Unreferenced checked-in raw snapshots:
+
+- are removable residue by default;
+- must not be kept for historical curiosity alone;
+- may be retained only if a later reviewed retention-exception artifact defines
+  the exception id, source, reason, review owner, expiry or review date, and
+  validation expectations.
+
+Missing referenced raw snapshots:
+
+- break current export reproducibility;
+- must be restored, regenerated through the ingest workflow, or resolved by
+  republishing the affected dataset before broad validation is claimed.
+
+## Repo-External Cache Boundary
+
+Future raw cache or raw-history work must use a repo-external location by
+default, such as a maintainer-local cache root under `$XDG_CACHE_HOME` or another
+reviewed external storage mechanism.
+
+Repo-external raw cache references, if introduced later, may commit only
+sanitized metadata such as:
+
+- source id;
+- source URL or reviewed source reference;
+- content hash;
+- byte size;
+- acquisition time;
+- cache policy;
+- review status;
+- intentionally non-local storage locator or opaque external reference.
+
+They must not commit:
+
+- raw cache payloads outside the minimal manifest keep set;
+- local absolute cache paths;
+- browser cache state;
+- credentials, tokens, sessions, or cookies;
+- Hermes memory, raw transcripts, logs, local skills, Curator state, or
+  checkpoints.
+
+This ADR does not implement repo-external cache sync. A later issue must define
+the artifact contract and validators before any raw cache/hash reference surface
+is introduced.
+
+## Validation
+
+The current strict validator remains:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-raw-snapshot-minimality.ps1
+```
+
+The validator must continue to fail when:
+
+- a referenced raw snapshot directory is missing;
+- a tracked raw snapshot directory is not referenced by current published
+  manifests;
+- a tracked raw file uses an unexpected layout.
+
+If a retention-exception artifact is introduced later, that PR must update this
+ADR or add a follow-up ADR, update the validator, and make the exception
+machine-reviewable.
+
+## Non-Goals
+
+- This ADR does not add, remove, refetch, rewrite, normalize, or re-hash raw
+  snapshots.
+- This ADR does not implement repo-external raw cache sync or cache manifests.
+- This ADR does not change `data/exports`, `data/roster`, `data/normalized`,
+  generated runtime assets, manual-review sidecars, or public adapter behavior.
+- This ADR does not make `data/raw/` normal public answer authority.
+- This ADR does not commit local cache paths, raw media, browser state, Hermes
+  memory, sessions, raw transcripts, logs, credentials, secrets, or tokens.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -6,3 +6,4 @@ Architecture decision records capture accepted repository-level decisions that s
 - [0002-private-hermes-first-operation.md](./0002-private-hermes-first-operation.md)
 - [0003-retire-public-sf6-agent-adapter.md](./0003-retire-public-sf6-agent-adapter.md)
 - [0004-retire-deferred-distribution-surfaces.md](./0004-retire-deferred-distribution-surfaces.md)
+- [0005-raw-snapshot-retention.md](./0005-raw-snapshot-retention.md)

--- a/docs/architecture/repository-surface-registry-policy.md
+++ b/docs/architecture/repository-surface-registry-policy.md
@@ -119,12 +119,15 @@ Policy reference:
 
 | ID | 境界 |
 |---|---|
-| `raw_snapshots` | reproducibility / ingest review の入力。normal public answer evidence ではない。 |
+| `raw_snapshots` | current published exports を再現するための最小 Git-tracked input。ADR-0005 により、それ以上の raw cache / history は repo-external が既定。normal public answer evidence ではない。 |
 | `normalized_intermediate_state` | intermediate state。現在は `documented_absent`。 |
 | `manual_review_sidecars` | withheld rows や review holds。runtime current fact payload に入れない。 |
 
 これらを accepted answer authority に昇格しない。必要な情報は review / curated /
 exported current-fact surface へ、明示的な workflow と validator を通して移す。
+
+Raw snapshot retention boundary:
+`docs/architecture/decisions/0005-raw-snapshot-retention.md`。
 
 ## Maintainer Rule
 

--- a/ingest/frame_data/README.md
+++ b/ingest/frame_data/README.md
@@ -53,6 +53,13 @@ is not referenced by the current published manifests is removable residue unless
 a future reviewed retention-exception artifact explicitly allows it. This repo
 currently has no raw snapshot retention exceptions.
 
+ADR-0005 fixes this as the repository retention model:
+`docs/architecture/decisions/0005-raw-snapshot-retention.md`. Checked-in raw
+snapshots are the minimal Git-tracked reproducibility set for current published
+exports. Broader raw-history or raw-cache work must stay repo-external by
+default and may commit only reviewed metadata/hash references after a later
+artifact contract is defined.
+
 Validate the checked-in surface from the repo root:
 
 ```powershell

--- a/tests/validation/run-all.ps1
+++ b/tests/validation/run-all.ps1
@@ -76,6 +76,7 @@ $readOnlyValidationScripts = @(
   'tests/validation/validate-evals.ps1',
   'tests/validation/validate-roster-source.ps1',
   'tests/validation/validate-raw-snapshot-minimality.ps1',
+  'tests/validation/validate-raw-snapshot-retention-adr.ps1',
   'tests/validation/validate-manual-review-debt-index.ps1',
   'tests/validation/validate-frame-current-assets.ps1',
   'tests/validation/validate-generated-knowledge.ps1',

--- a/tests/validation/validate-raw-snapshot-retention-adr.ps1
+++ b/tests/validation/validate-raw-snapshot-retention-adr.ps1
@@ -1,0 +1,127 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$adrPath = 'docs/architecture/decisions/0005-raw-snapshot-retention.md'
+$decisionsReadmePath = 'docs/architecture/decisions/README.md'
+$architectureReadmePath = 'docs/architecture/README.md'
+$readmePath = 'README.md'
+$ingestReadmePath = 'ingest/frame_data/README.md'
+$workflowPath = 'workflows/update-frame-data.md'
+$registryPath = 'data/repository-surfaces.json'
+$registryPolicyPath = 'docs/architecture/repository-surface-registry-policy.md'
+
+function Read-Text {
+  param([Parameter(Mandatory = $true)][string]$RelativePath)
+  return Get-Content -LiteralPath (Join-Path $repoRoot $RelativePath) -Raw -Encoding UTF8
+}
+
+function Assert-Contains {
+  param(
+    [Parameter(Mandatory = $true)][string]$Text,
+    [Parameter(Mandatory = $true)][string]$Needle,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  if (-not $Text.Contains($Needle)) {
+    $Issues.Value += "$Context must mention: $Needle"
+  }
+}
+
+$issues = @()
+
+foreach ($relativePath in @(
+  $adrPath,
+  $decisionsReadmePath,
+  $architectureReadmePath,
+  $readmePath,
+  $ingestReadmePath,
+  $workflowPath,
+  $registryPath,
+  $registryPolicyPath
+)) {
+  if (-not (Test-Path -LiteralPath (Join-Path $repoRoot $relativePath) -PathType Leaf)) {
+    $issues += "Missing raw snapshot retention file: $relativePath"
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot $adrPath) -PathType Leaf) {
+  $adr = Read-Text $adrPath
+  foreach ($needle in @(
+    'id: adr-0005',
+    'status: accepted',
+    'tracking_issue: "#258"',
+    'selected_retention_model: current_published_manifest_minimal_git_set',
+    'git_tracked_raw_snapshot_role: minimal_reproducibility_artifact',
+    'repo_external_raw_cache_role: future_metadata_reference_only',
+    'retention_exception_artifact: required_for_unreferenced_git_raw_retention',
+    'normal_public_answer_authority: false',
+    'immediate_data_change: false',
+    'sf6.boundary.raw_snapshots_git_tracked_minimal_reproducibility',
+    'sf6.boundary.unreferenced_raw_snapshots_removable_without_exception',
+    'sf6.boundary.repo_external_raw_cache_metadata_only',
+    'sf6.boundary.raw_snapshots_not_public_answer_authority',
+    'sf6.boundary.no_raw_snapshot_data_change_in_adr',
+    'current published manifest minimal Git set',
+    'data/exports/<character_slug>/snapshot_manifest.json',
+    'tests/validation/validate-raw-snapshot-minimality.ps1',
+    'repo-external raw caches',
+    'sanitized metadata',
+    'content hash',
+    'This ADR is design-only',
+    'does not add, delete, refetch, rewrite, normalize, or re-hash raw snapshots',
+    'does not make `data/raw/` normal public answer authority'
+  )) {
+    Assert-Contains $adr $needle $adrPath ([ref]$issues)
+  }
+}
+
+foreach ($doc in @(
+  $decisionsReadmePath,
+  $architectureReadmePath,
+  $readmePath,
+  $ingestReadmePath,
+  $workflowPath,
+  $registryPolicyPath
+)) {
+  if (Test-Path -LiteralPath (Join-Path $repoRoot $doc) -PathType Leaf) {
+    $text = Read-Text $doc
+    if ($doc -in @($decisionsReadmePath, $architectureReadmePath)) {
+      Assert-Contains $text '0005-raw-snapshot-retention.md' $doc ([ref]$issues)
+    } else {
+      Assert-Contains $text $adrPath $doc ([ref]$issues)
+    }
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot $registryPath) -PathType Leaf) {
+  $registry = Get-Content -LiteralPath (Join-Path $repoRoot $registryPath) -Raw -Encoding UTF8 | ConvertFrom-Json
+  $rawSnapshots = @($registry.surfaces | Where-Object { $_.id -eq 'raw_snapshots' })
+  if ($rawSnapshots.Count -ne 1) {
+    $issues += "$registryPath must contain exactly one raw_snapshots surface"
+  } else {
+    $surface = $rawSnapshots[0]
+    if ($surface.surface_role -ne 'non_canonical') {
+      $issues += 'raw_snapshots must remain non_canonical'
+    }
+    if ($surface.normal_public_answer_authority -ne $false) {
+      $issues += 'raw_snapshots must not be normal public answer authority'
+    }
+    if (@($surface.policy_refs) -notcontains $adrPath) {
+      $issues += "raw_snapshots must reference $adrPath"
+    }
+    if (@($surface.validation_expectation) -notcontains 'raw_snapshot_retention_adr_valid') {
+      $issues += 'raw_snapshots validation_expectation must include raw_snapshot_retention_adr_valid'
+    }
+    if (-not ([string]$surface.notes).Contains('ADR-0005 keeps broader raw cache or history storage repo-external by default')) {
+      $issues += 'raw_snapshots notes must record the ADR-0005 repo-external cache boundary'
+    }
+  }
+}
+
+if ($issues.Count -gt 0) {
+  throw ($issues -join "`n")
+}
+
+Write-Host 'Raw snapshot retention ADR OK'

--- a/workflows/update-frame-data.md
+++ b/workflows/update-frame-data.md
@@ -94,6 +94,10 @@ Raw snapshot minimality is a strict data hygiene check. Unreferenced checked-in
 raw snapshots are removable residue unless a reviewed retention-exception
 artifact is explicitly introduced. Missing referenced raw snapshots break
 reproducibility and must be fixed before reporting the refresh as complete.
+ADR-0005 records this boundary:
+`docs/architecture/decisions/0005-raw-snapshot-retention.md`. Broader raw-cache
+or raw-history storage stays repo-external unless a later reviewed artifact
+contract is introduced.
 
 ## Reporting
 


### PR DESCRIPTION
## Summary

- Add ADR-0005 for raw snapshot retention boundaries.
- Define Git-tracked raw snapshots as the minimal reproducibility set for current published exports.
- Keep broader raw cache/history storage repo-external by default and require a later reviewed artifact contract before committing metadata/hash references.
- Register the ADR in architecture docs, ingest/update workflows, repository surface policy, and raw snapshot surface metadata.
- Add a focused validator for the ADR and wire it into `run-all.ps1`.

## Validation

- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-raw-snapshot-retention-adr.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-raw-snapshot-minimality.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-repository-surfaces.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 -Lane read-only`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1`
- `git diff --check`
- `git diff --cached --check`
- `git diff --check origin/main...HEAD`

## Notes

- Design-only PR: no raw snapshots were added, removed, refetched, rewritten, normalized, or re-hashed.
- No `data/exports`, `data/roster`, `data/normalized`, generated runtime assets, manual-review sidecars, public adapter behavior, or Hermes local state changed.
- `data/raw/` remains non-canonical and not normal public answer authority.
- Closes #258
- Parent #197
