### PR TITLE
[v2.6] Enforce noncanonical data authority boundaries

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -16,6 +16,8 @@ reproducibility, current-fact rules, and Markdown front matter contracts.
 
 `tests/validation/validate-current-fact-boundaries.ps1` is the executable contract layer for review-only current-fact candidate metadata under `knowledge/review/current-fact-candidates/`.
 
+`tests/validation/validate-noncanonical-data-authority-boundaries.ps1` is the executable contract layer for keeping `data/raw/`, `data/normalized/`, `*_manual_review.*`, and `data/exports/_index/manual-review-debt.json` out of normal public answer authority.
+
 When `source_refs.path` points to a migrated legacy file, `source_revision` identifies the commit where that historical path can be reviewed.
 
 ## Human-Readable Contracts

--- a/data/exports/README.md
+++ b/data/exports/README.md
@@ -104,6 +104,9 @@ The following are not normal public answer authority:
 - Hermes memory, sessions, local skills, Curator output, checkpoints, or raw transcripts
 
 Exact current facts must not be inferred from those surfaces alone.
+See `docs/architecture/noncanonical-data-authority-boundaries.md` for the
+cross-surface boundary that keeps these inputs and observability files out of
+normal public answer authority.
 
 ## Validation
 
@@ -118,6 +121,7 @@ Run related semantic checks:
 ```powershell
 pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-frame-current-assets.ps1
 pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-raw-snapshot-minimality.ps1
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-noncanonical-data-authority-boundaries.ps1
 pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-manual-review-debt-index.ps1
 pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-current-fact-boundaries.ps1
 ```

--- a/data/repository-surfaces.json
+++ b/data/repository-surfaces.json
@@ -688,11 +688,13 @@
       "validation_expectation": [
         "raw_snapshot_minimality_valid",
         "raw_snapshot_retention_adr_valid",
+        "noncanonical_data_authority_boundary_valid",
         "not_normal_public_answer_authority"
       ],
       "policy_refs": [
         "AGENTS.md",
         "ingest/frame_data/README.md",
+        "docs/architecture/noncanonical-data-authority-boundaries.md",
         "docs/architecture/decisions/0005-raw-snapshot-retention.md"
       ],
       "notes": "Raw snapshots support minimal current published export reproducibility and ingestion review. ADR-0005 keeps broader raw cache or history storage repo-external by default. They are not final evidence for normal public answers."
@@ -717,11 +719,13 @@
       "normal_public_answer_authority": false,
       "validation_expectation": [
         "not_tracked_currently",
+        "noncanonical_data_authority_boundary_valid",
         "not_normal_public_answer_authority"
       ],
       "policy_refs": [
         "AGENTS.md",
-        "ingest/frame_data/README.md"
+        "ingest/frame_data/README.md",
+        "docs/architecture/noncanonical-data-authority-boundaries.md"
       ],
       "notes": "Documented boundary with no currently tracked files. If introduced, it must remain non-canonical unless a later policy changes that."
     },
@@ -746,11 +750,13 @@
       "normal_public_answer_authority": false,
       "validation_expectation": [
         "manual_review_not_runtime",
+        "noncanonical_data_authority_boundary_valid",
         "not_normal_public_answer_authority"
       ],
       "policy_refs": [
         "AGENTS.md",
         "ingest/frame_data/README.md",
+        "docs/architecture/noncanonical-data-authority-boundaries.md",
         "contracts/frame-current-runtime-assets.md"
       ],
       "notes": "Manual-review sidecars record withheld or unresolved rows and must not feed normal public answer authority."
@@ -779,11 +785,13 @@
       "validation_expectation": [
         "manual_review_debt_index_fresh",
         "manual_review_not_runtime",
+        "noncanonical_data_authority_boundary_valid",
         "not_normal_public_answer_authority"
       ],
       "policy_refs": [
         "AGENTS.md",
         "data/exports/README.md",
+        "docs/architecture/noncanonical-data-authority-boundaries.md",
         "contracts/manual-review-debt-index.schema.json"
       ],
       "notes": "Generated summary of withheld row counts, reason-code counts, and published dataset state. It is not current-fact authority."

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -24,6 +24,7 @@ Architecture docs define the v2 source-of-truth model.
 - [language-policy.md](./language-policy.md)
 - [harness-and-distribution-roles.md](./harness-and-distribution-roles.md)
 - [repository-surface-registry-policy.md](./repository-surface-registry-policy.md)
+- [noncanonical-data-authority-boundaries.md](./noncanonical-data-authority-boundaries.md)
 - [package-surface-classification.md](./package-surface-classification.md)
 - [schema-validation-runner.md](./schema-validation-runner.md)
 - [generated-reference-responsibility-plan.md](./generated-reference-responsibility-plan.md)

--- a/docs/architecture/noncanonical-data-authority-boundaries.md
+++ b/docs/architecture/noncanonical-data-authority-boundaries.md
@@ -1,0 +1,79 @@
+---
+title: Non-canonical Data Authority Boundaries
+status: accepted
+last_reviewed: 2026-05-18
+tracking_issue: "#260"
+---
+
+# Non-canonical Data Authority Boundaries
+
+この文書は、`data/raw/`、`data/normalized/`、`*_manual_review.*`、
+`data/exports/_index/manual-review-debt.json` を normal public answer authority
+として扱わないための境界を定義する。
+
+## Scope
+
+対象 surface は次のとおり。
+
+| Surface | Registry ID | Boundary |
+|---|---|---|
+| `data/raw/` | `raw_snapshots` | current published exports を再現するための最小 raw input。normal public answer authority ではない。 |
+| `data/normalized/` | `normalized_intermediate_state` | run-local audit / intermediate state。現在は tracked durable artifact ではない。 |
+| `data/exports/*/*_manual_review.*` | `manual_review_sidecars` | withheld rows / review holds。review と publish workflow 前の normal public answer authority ではない。 |
+| `data/exports/_index/manual-review-debt.json` | `manual_review_debt_index` | manual-review debt の observability index。current-fact authority ではない。 |
+
+## Authority Rule
+
+これらの surface から exact current facts を直接推論して通常回答に使ってはいけない。
+通常回答で使える current-fact authority は、published export / runtime asset / roster
+など、明示された canonical または derived current-fact surface に限る。
+
+`data/raw/` は byte-level reproducibility input であり、published export の根拠を
+再検証するために使う。raw snapshot 自体をユーザー回答の evidence として
+昇格しない。
+
+`data/normalized/` は ingestion run の中間状態である。tracked durable surface として
+導入する場合でも、後続 policy が変更しない限り non-canonical のまま扱う。
+
+`*_manual_review.*` は withheld rows、unresolved rows、review reason を記録する。
+通常回答や runtime lookup に入れるには、review / publish workflow を通して main export
+へ昇格させる必要がある。
+
+`data/exports/_index/manual-review-debt.json` は manual-review debt を見える化する
+observability surface である。生成元が manual-review sidecar であるため、この index
+自体も normal public answer authority ではない。
+
+## Promotion Paths
+
+| Source surface | Allowed promotion path |
+|---|---|
+| `data/raw/` | ingestion / parse / publish workflow により `data/exports/` と `snapshot_manifest.json` に反映する。 |
+| `data/normalized/` | publish workflow により accepted published export surface へ反映する。tracked intermediate state を正本化しない。 |
+| `*_manual_review.*` | review / publish workflow により safe rows だけを main export に移す。 |
+| `manual-review-debt.json` | promotion path なし。observability と prioritization のみ。 |
+
+## Validator Coverage
+
+この boundary は次の validator と docs に分散している。
+
+- `tests/validation/validate-noncanonical-data-authority-boundaries.ps1`
+- `tests/validation/validate-raw-snapshot-minimality.ps1`
+- `tests/validation/validate-raw-snapshot-retention-adr.ps1`
+- `tests/validation/validate-manual-review-debt-index.ps1`
+- `tests/validation/validate-current-fact-boundaries.ps1`
+- `tests/validation/validate-frame-current-assets.ps1`
+- `data/repository-surfaces.json`
+- `docs/architecture/repository-surface-registry-policy.md`
+- `data/exports/README.md`
+- `ingest/frame_data/README.md`
+
+`validate-noncanonical-data-authority-boundaries.ps1` は、registry と docs がこの
+non-canonical boundary を同じ意味で説明しているかを read-only に確認する。
+
+## Non-goals
+
+- `data/raw/`、`data/normalized/`、`data/exports/` の data content を変更しない。
+- `official_raw`、`derived_metrics`、`supercombo_enrichment` の authority を変更しない。
+- `data/raw/` や manual-review sidecar を normal public answer authority にしない。
+- generated frame-current assets、normalization assets、`.dist` を変更しない。
+- Hermes memory、sessions、local skills、Curator output、logs、caches、raw transcript を commit しない。

--- a/docs/architecture/repository-surface-registry-policy.md
+++ b/docs/architecture/repository-surface-registry-policy.md
@@ -122,12 +122,16 @@ Policy reference:
 | `raw_snapshots` | current published exports を再現するための最小 Git-tracked input。ADR-0005 により、それ以上の raw cache / history は repo-external が既定。normal public answer evidence ではない。 |
 | `normalized_intermediate_state` | intermediate state。現在は `documented_absent`。 |
 | `manual_review_sidecars` | withheld rows や review holds。runtime current fact payload に入れない。 |
+| `manual_review_debt_index` | manual-review debt の generated observability index。normal public answer authority ではない。 |
 
 これらを accepted answer authority に昇格しない。必要な情報は review / curated /
 exported current-fact surface へ、明示的な workflow と validator を通して移す。
 
 Raw snapshot retention boundary:
 `docs/architecture/decisions/0005-raw-snapshot-retention.md`。
+
+Cross-surface non-canonical data authority boundary:
+`docs/architecture/noncanonical-data-authority-boundaries.md`。
 
 ## Maintainer Rule
 

--- a/ingest/frame_data/README.md
+++ b/ingest/frame_data/README.md
@@ -165,6 +165,10 @@ Published exports:
 - `data/exports/<character_slug>/snapshot_manifest.json`
 
 See `data/exports/README.md` for the current-fact export authority boundary.
+See `docs/architecture/noncanonical-data-authority-boundaries.md` for the
+cross-surface rule that keeps raw snapshots, normalized intermediate state,
+manual-review sidecars, and manual-review debt observability out of normal
+public answer authority.
 `snapshot_manifest.json` follows
 `contracts/current-fact-export-manifest.schema.json` for structural validation.
 `data/exports/_index/manual-review-debt.json` is a generated observability index

--- a/tests/validation/run-all.ps1
+++ b/tests/validation/run-all.ps1
@@ -77,6 +77,7 @@ $readOnlyValidationScripts = @(
   'tests/validation/validate-roster-source.ps1',
   'tests/validation/validate-raw-snapshot-minimality.ps1',
   'tests/validation/validate-raw-snapshot-retention-adr.ps1',
+  'tests/validation/validate-noncanonical-data-authority-boundaries.ps1',
   'tests/validation/validate-manual-review-debt-index.ps1',
   'tests/validation/validate-frame-current-assets.ps1',
   'tests/validation/validate-generated-knowledge.ps1',

--- a/tests/validation/validate-noncanonical-data-authority-boundaries.ps1
+++ b/tests/validation/validate-noncanonical-data-authority-boundaries.ps1
@@ -1,0 +1,240 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$boundaryDocPath = 'docs/architecture/noncanonical-data-authority-boundaries.md'
+$registryPath = 'data/repository-surfaces.json'
+$registryPolicyPath = 'docs/architecture/repository-surface-registry-policy.md'
+$architectureReadmePath = 'docs/architecture/README.md'
+$exportsReadmePath = 'data/exports/README.md'
+$ingestReadmePath = 'ingest/frame_data/README.md'
+$contractsReadmePath = 'contracts/README.md'
+$agentsPath = 'AGENTS.md'
+$validatorPath = 'tests/validation/validate-noncanonical-data-authority-boundaries.ps1'
+
+function Read-Text {
+  param([Parameter(Mandatory = $true)][string]$RelativePath)
+  return Get-Content -LiteralPath (Join-Path $repoRoot $RelativePath) -Raw -Encoding UTF8
+}
+
+function Assert-Contains {
+  param(
+    [Parameter(Mandatory = $true)][string]$Text,
+    [Parameter(Mandatory = $true)][string]$Needle,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  if (-not $Text.Contains($Needle)) {
+    $Issues.Value += "$Context must mention: $Needle"
+  }
+}
+
+function Test-Property {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name
+  )
+  return $null -ne $Object.PSObject.Properties[$Name]
+}
+
+function Get-Surface {
+  param(
+    [Parameter(Mandatory = $true)][object]$Registry,
+    [Parameter(Mandatory = $true)][string]$Id,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  $matches = @($Registry.surfaces | Where-Object { $_.id -eq $Id })
+  if ($matches.Count -ne 1) {
+    $Issues.Value += "$registryPath must contain exactly one surface: $Id"
+    return $null
+  }
+
+  return $matches[0]
+}
+
+function Assert-SurfaceCommonBoundary {
+  param(
+    [Parameter(Mandatory = $true)][object]$Surface,
+    [Parameter(Mandatory = $true)][string]$Id,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  if (-not (Test-Property $Surface 'normal_public_answer_authority') -or $Surface.normal_public_answer_authority -ne $false) {
+    $Issues.Value += "$Id must not be normal public answer authority"
+  }
+  if (-not (Test-Property $Surface 'public_distribution_status') -or $Surface.public_distribution_status -ne 'not_distribution') {
+    $Issues.Value += "$Id must remain not_distribution"
+  }
+  if (@($Surface.validation_expectation) -notcontains 'noncanonical_data_authority_boundary_valid') {
+    $Issues.Value += "$Id validation_expectation must include noncanonical_data_authority_boundary_valid"
+  }
+  if (@($Surface.validation_expectation) -notcontains 'not_normal_public_answer_authority') {
+    $Issues.Value += "$Id validation_expectation must include not_normal_public_answer_authority"
+  }
+  if (@($Surface.policy_refs) -notcontains $boundaryDocPath) {
+    $Issues.Value += "$Id policy_refs must include $boundaryDocPath"
+  }
+}
+
+$issues = @()
+
+foreach ($relativePath in @(
+  $boundaryDocPath,
+  $registryPath,
+  $registryPolicyPath,
+  $architectureReadmePath,
+  $exportsReadmePath,
+  $ingestReadmePath,
+  $contractsReadmePath,
+  $agentsPath,
+  $validatorPath
+)) {
+  if (-not (Test-Path -LiteralPath (Join-Path $repoRoot $relativePath) -PathType Leaf)) {
+    $issues += "Missing non-canonical authority boundary file: $relativePath"
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot $boundaryDocPath) -PathType Leaf) {
+  $boundaryDoc = Read-Text $boundaryDocPath
+  foreach ($needle in @(
+    'status: accepted',
+    'tracking_issue: "#260"',
+    'data/raw/',
+    'raw_snapshots',
+    'data/normalized/',
+    'normalized_intermediate_state',
+    '*_manual_review.*',
+    'manual_review_sidecars',
+    'data/exports/_index/manual-review-debt.json',
+    'manual_review_debt_index',
+    'normal public answer authority',
+    'current-fact authority ではない',
+    $validatorPath,
+    'tests/validation/validate-raw-snapshot-minimality.ps1',
+    'tests/validation/validate-manual-review-debt-index.ps1',
+    'tests/validation/validate-current-fact-boundaries.ps1',
+    'tests/validation/validate-frame-current-assets.ps1'
+  )) {
+    Assert-Contains $boundaryDoc $needle $boundaryDocPath ([ref]$issues)
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot $architectureReadmePath) -PathType Leaf) {
+  Assert-Contains (Read-Text $architectureReadmePath) 'noncanonical-data-authority-boundaries.md' $architectureReadmePath ([ref]$issues)
+}
+
+foreach ($doc in @(
+  $registryPolicyPath,
+  $exportsReadmePath,
+  $ingestReadmePath
+)) {
+  if (Test-Path -LiteralPath (Join-Path $repoRoot $doc) -PathType Leaf) {
+    Assert-Contains (Read-Text $doc) $boundaryDocPath $doc ([ref]$issues)
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot $exportsReadmePath) -PathType Leaf) {
+  $exportsReadme = Read-Text $exportsReadmePath
+  foreach ($needle in @(
+    'data/raw/',
+    'data/normalized/',
+    '*_manual_review.*',
+    'data/exports/_index/manual-review-debt.json',
+    'not normal public answer authority',
+    'Exact current facts must not be inferred from those surfaces alone.',
+    $validatorPath
+  )) {
+    Assert-Contains $exportsReadme $needle $exportsReadmePath ([ref]$issues)
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot $ingestReadmePath) -PathType Leaf) {
+  $ingestReadme = Read-Text $ingestReadmePath
+  foreach ($needle in @(
+    'data/raw/',
+    'data/normalized/',
+    'manual-review sidecars',
+    'manual-review debt observability',
+    'normal public answer authority',
+    $boundaryDocPath
+  )) {
+    Assert-Contains $ingestReadme $needle $ingestReadmePath ([ref]$issues)
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot $contractsReadmePath) -PathType Leaf) {
+  $contractsReadme = Read-Text $contractsReadmePath
+  foreach ($needle in @(
+    $validatorPath,
+    'data/raw/',
+    'data/normalized/',
+    '*_manual_review.*',
+    'data/exports/_index/manual-review-debt.json',
+    'normal public answer authority'
+  )) {
+    Assert-Contains $contractsReadme $needle $contractsReadmePath ([ref]$issues)
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot $agentsPath) -PathType Leaf) {
+  $agents = Read-Text $agentsPath
+  foreach ($needle in @(
+    'data/raw/...',
+    'data/normalized/...',
+    '*_manual_review.*',
+    'not final evidence for normal public answers'
+  )) {
+    Assert-Contains $agents $needle $agentsPath ([ref]$issues)
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot $registryPath) -PathType Leaf) {
+  $registry = Get-Content -LiteralPath (Join-Path $repoRoot $registryPath) -Raw -Encoding UTF8 | ConvertFrom-Json
+
+  foreach ($id in @(
+    'raw_snapshots',
+    'normalized_intermediate_state',
+    'manual_review_sidecars',
+    'manual_review_debt_index'
+  )) {
+    $surface = Get-Surface $registry $id ([ref]$issues)
+    if ($null -ne $surface) {
+      Assert-SurfaceCommonBoundary $surface $id ([ref]$issues)
+    }
+  }
+
+  foreach ($id in @(
+    'raw_snapshots',
+    'normalized_intermediate_state',
+    'manual_review_sidecars'
+  )) {
+    $surface = Get-Surface $registry $id ([ref]$issues)
+    if ($null -ne $surface -and $surface.surface_role -ne 'non_canonical') {
+      $issues += "$id must remain non_canonical"
+    }
+  }
+
+  $manualReviewDebtIndex = Get-Surface $registry 'manual_review_debt_index' ([ref]$issues)
+  if ($null -ne $manualReviewDebtIndex) {
+    if ($manualReviewDebtIndex.surface_role -ne 'derived') {
+      $issues += 'manual_review_debt_index must remain derived'
+    }
+    if ($manualReviewDebtIndex.generated -ne $true) {
+      $issues += 'manual_review_debt_index must remain generated'
+    }
+    if (-not ([string]$manualReviewDebtIndex.authority_scope).Contains('observability')) {
+      $issues += 'manual_review_debt_index authority_scope must describe observability only'
+    }
+    if (-not ([string]$manualReviewDebtIndex.notes).Contains('not current-fact authority')) {
+      $issues += 'manual_review_debt_index notes must state it is not current-fact authority'
+    }
+  }
+}
+
+if ($issues.Count -gt 0) {
+  throw ($issues -join "`n")
+}
+
+Write-Host 'Non-canonical data authority boundaries OK'

--- a/tests/validation/validate-repository-surfaces.ps1
+++ b/tests/validation/validate-repository-surfaces.ps1
@@ -95,7 +95,8 @@ $requiredSurfaceIds = @(
   'codex_hermes_sf6_pack',
   'raw_snapshots',
   'normalized_intermediate_state',
-  'manual_review_sidecars'
+  'manual_review_sidecars',
+  'manual_review_debt_index'
 )
 
 foreach ($relativePath in @($schemaPath, $registryPath, $policyDocPath, $readmePath, $contractsReadmePath)) {
@@ -257,7 +258,8 @@ if (Test-Path -LiteralPath (Join-Path $repoRoot $policyDocPath) -PathType Leaf) 
     'skill_installers_package',
     'raw_snapshots',
     'normalized_intermediate_state',
-    'manual_review_sidecars'
+    'manual_review_sidecars',
+    'manual_review_debt_index'
   )) {
     Assert-TextContains $policyDoc $requiredText $policyDocPath ([ref]$issues)
   }


### PR DESCRIPTION
## Summary

Closes #260.

- Add `docs/architecture/noncanonical-data-authority-boundaries.md` as the cross-surface policy for `data/raw/`, `data/normalized/`, `*_manual_review.*`, and `data/exports/_index/manual-review-debt.json`.
- Update `data/repository-surfaces.json` so the four relevant surfaces share `noncanonical_data_authority_boundary_valid` and reference the new policy.
- Add `tests/validation/validate-noncanonical-data-authority-boundaries.ps1` and wire it into the read-only validation lane.

## Boundary

This PR does not change data content, current-fact exports, generated frame-current assets, normalization assets, `.dist`, public adapter behavior, or Hermes local state. It only makes the existing non-authority boundary explicit and validator-covered.

## Validation

- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-noncanonical-data-authority-boundaries.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-repository-surfaces.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-current-fact-boundaries.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-frame-current-assets.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-manual-review-debt-index.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-raw-snapshot-retention-adr.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-raw-snapshot-minimality.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 -Lane read-only`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1`
- `git diff --check`
- `git diff --check origin/main...HEAD`
