### PR TITLE
[v2.6] Add eval score report contract

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -39,6 +39,11 @@ When `source_refs.path` points to a migrated legacy file, `source_revision` iden
 - `evidence-card.schema.json`: evidence authority and source-boundary card contract.
 - `answer-plan.schema.json`: answer planning contract combining intent, evidence cards, web state, hold reasons, and response requirements.
 
+## Eval Contracts
+
+- `eval-case.schema.json`: answer-quality case contract for `evals/questions/*.yaml`.
+- `eval-score-report.schema.json`: answer-quality / regression observability report contract. Score reports are not SF6 gameplay authority and do not store raw transcripts or local agent state.
+
 ## Query Normalization Contracts
 
 - `normalization-aliases.schema.json`: query-normalization alias contract for mapping user language to structured lookup inputs.

--- a/contracts/eval-score-report.schema.json
+++ b/contracts/eval-score-report.schema.json
@@ -1,0 +1,246 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sf6-knowledge-agent-kit.local/eval-score-report.schema.json",
+  "title": "Eval Score Report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "report_type",
+    "run_id",
+    "run_date",
+    "tracking_issue",
+    "report_mode",
+    "evaluator",
+    "agent_surface",
+    "eval_sources",
+    "not_gameplay_authority",
+    "normal_public_answer_authority",
+    "raw_transcript_committed",
+    "local_state_committed",
+    "case_results",
+    "summary",
+    "notes"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "eval-score-report/v1"
+    },
+    "report_type": {
+      "const": "answer_quality_score_report"
+    },
+    "run_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "run_date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+    "tracking_issue": {
+      "type": "string",
+      "pattern": "^#\\d+$"
+    },
+    "source_pr": {
+      "type": "string",
+      "pattern": "^#\\d+$"
+    },
+    "report_mode": {
+      "enum": [
+        "manual_static_scorecard",
+        "manual_agent_smoke_scorecard",
+        "live_runner_output"
+      ]
+    },
+    "evaluator": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "name"
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "manual_reviewer",
+            "scripted_fixture",
+            "llm_judge"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "agent_surface": {
+      "enum": [
+        "sf6_agent_deferred_adapter",
+        "repo_local_hermes",
+        "unknown_or_not_run"
+      ]
+    },
+    "eval_sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "path"
+        ],
+        "properties": {
+          "path": {
+            "type": "string",
+            "pattern": "^evals/questions/[A-Za-z0-9._/-]+\\.yaml$"
+          }
+        }
+      }
+    },
+    "not_gameplay_authority": {
+      "const": true
+    },
+    "normal_public_answer_authority": {
+      "const": false
+    },
+    "raw_transcript_committed": {
+      "const": false
+    },
+    "local_state_committed": {
+      "const": false
+    },
+    "case_results": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/case_result"
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "total_cases",
+        "pass_count",
+        "fail_count",
+        "skip_count",
+        "hold_review_count",
+        "mode_pass_count",
+        "grounding_pass_count",
+        "must_not_include_pass_count"
+      ],
+      "properties": {
+        "total_cases": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "pass_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "fail_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "skip_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "hold_review_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "mode_pass_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "grounding_pass_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "must_not_include_pass_count": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "notes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "$defs": {
+    "answer_mode_or_not_run": {
+      "enum": [
+        "stable_concept",
+        "verified_current_fact",
+        "strategy_or_matchup_knowledge",
+        "observation",
+        "unresolved_or_hold",
+        "not_run"
+      ]
+    },
+    "nullable_boolean": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "case_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "case_id",
+        "source_file",
+        "expected_answer_mode",
+        "observed_answer_mode",
+        "mode_pass",
+        "grounding_pass",
+        "must_not_include_pass",
+        "overall_result",
+        "notes"
+      ],
+      "properties": {
+        "case_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_file": {
+          "type": "string",
+          "pattern": "^evals/questions/[A-Za-z0-9._/-]+\\.yaml$"
+        },
+        "expected_answer_mode": {
+          "$ref": "#/$defs/answer_mode_or_not_run"
+        },
+        "observed_answer_mode": {
+          "$ref": "#/$defs/answer_mode_or_not_run"
+        },
+        "mode_pass": {
+          "$ref": "#/$defs/nullable_boolean"
+        },
+        "grounding_pass": {
+          "$ref": "#/$defs/nullable_boolean"
+        },
+        "must_not_include_pass": {
+          "$ref": "#/$defs/nullable_boolean"
+        },
+        "overall_result": {
+          "enum": [
+            "pass",
+            "fail",
+            "skip",
+            "hold_review"
+          ]
+        },
+        "notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/data/repository-surfaces.json
+++ b/data/repository-surfaces.json
@@ -276,12 +276,15 @@
       "public_distribution_status": "not_distribution",
       "normal_public_answer_authority": false,
       "validation_expectation": [
-        "evals_valid"
+        "evals_valid",
+        "eval_score_reports_valid"
       ],
       "policy_refs": [
-        "AGENTS.md"
+        "AGENTS.md",
+        "evals/README.md",
+        "contracts/eval-score-report.schema.json"
       ],
-      "notes": "Canonical for answer-quality expectations, not direct current-fact evidence."
+      "notes": "Canonical for answer-quality expectations, not direct current-fact evidence. Eval score reports are regression observability and not gameplay authority."
     },
     {
       "id": "generated_knowledge_references",

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -48,6 +48,7 @@ Manual validator set:
 - `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-video-artifacts.ps1`
 - `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-combo-damage-fixtures.ps1`
 - `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-evals.ps1`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-eval-score-reports.ps1`
 - `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-roster-source.ps1`
 - `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-frame-current-assets.ps1`
 - `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-generated-knowledge.ps1`

--- a/evals/README.md
+++ b/evals/README.md
@@ -3,3 +3,15 @@
 `evals/` is canonical for agent-agnostic answer-quality cases and rubrics.
 
 Eval cases check answer mode, grounding, uncertainty, current-fact separation, patch sensitivity, and must-not-include behavior.
+
+Eval score reports are answer-quality / regression observability artifacts,
+not SF6 gameplay authority or normal public answer authority. The current
+offline contract is `contracts/eval-score-report.schema.json`, with semantic
+validation in `tests/validation/validate-eval-score-reports.ps1`.
+
+Validate eval cases and score reports with:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-evals.ps1
+pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-eval-score-reports.ps1
+```

--- a/tests/fixtures/eval-score-reports/minimal-manual-scorecard.json
+++ b/tests/fixtures/eval-score-reports/minimal-manual-scorecard.json
@@ -1,0 +1,83 @@
+{
+  "schema_version": "eval-score-report/v1",
+  "report_type": "answer_quality_score_report",
+  "run_id": "minimal-manual-scorecard-20260518",
+  "run_date": "2026-05-18",
+  "tracking_issue": "#266",
+  "report_mode": "manual_static_scorecard",
+  "evaluator": {
+    "type": "manual_reviewer",
+    "name": "repo-fixture"
+  },
+  "agent_surface": "unknown_or_not_run",
+  "eval_sources": [
+    {
+      "path": "evals/questions/concepts.yaml"
+    },
+    {
+      "path": "evals/questions/current-fact.yaml"
+    },
+    {
+      "path": "evals/questions/uncertainty.yaml"
+    }
+  ],
+  "not_gameplay_authority": true,
+  "normal_public_answer_authority": false,
+  "raw_transcript_committed": false,
+  "local_state_committed": false,
+  "case_results": [
+    {
+      "case_id": "concept-plus-frames",
+      "source_file": "evals/questions/concepts.yaml",
+      "expected_answer_mode": "stable_concept",
+      "observed_answer_mode": "not_run",
+      "mode_pass": null,
+      "grounding_pass": null,
+      "must_not_include_pass": null,
+      "overall_result": "skip",
+      "notes": [
+        "Static scorecard fixture only; no live agent answer was executed."
+      ]
+    },
+    {
+      "case_id": "current-fact-luke-cr-mp",
+      "source_file": "evals/questions/current-fact.yaml",
+      "expected_answer_mode": "verified_current_fact",
+      "observed_answer_mode": "not_run",
+      "mode_pass": null,
+      "grounding_pass": null,
+      "must_not_include_pass": null,
+      "overall_result": "skip",
+      "notes": [
+        "Static scorecard fixture only; no live agent answer was executed."
+      ]
+    },
+    {
+      "case_id": "uncertainty-patch-sensitive-setup",
+      "source_file": "evals/questions/uncertainty.yaml",
+      "expected_answer_mode": "unresolved_or_hold",
+      "observed_answer_mode": "not_run",
+      "mode_pass": null,
+      "grounding_pass": null,
+      "must_not_include_pass": null,
+      "overall_result": "skip",
+      "notes": [
+        "Static scorecard fixture only; no live agent answer was executed."
+      ]
+    }
+  ],
+  "summary": {
+    "total_cases": 3,
+    "pass_count": 0,
+    "fail_count": 0,
+    "skip_count": 3,
+    "hold_review_count": 0,
+    "mode_pass_count": 0,
+    "grounding_pass_count": 0,
+    "must_not_include_pass_count": 0
+  },
+  "notes": [
+    "This fixture validates the score report contract only.",
+    "It does not contain raw answers, transcripts, Hermes state, or current-fact authority."
+  ]
+}

--- a/tests/validation/eval-case-helpers.ps1
+++ b/tests/validation/eval-case-helpers.ps1
@@ -1,0 +1,169 @@
+Set-StrictMode -Version Latest
+
+function ConvertFrom-EvalYamlScalar {
+  param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Value)
+
+  $trimmed = $Value.Trim()
+  if ($trimmed.Length -ge 2) {
+    $first = $trimmed.Substring(0, 1)
+    $last = $trimmed.Substring($trimmed.Length - 1, 1)
+    if (($first -eq '"' -and $last -eq '"') -or ($first -eq "'" -and $last -eq "'")) {
+      return $trimmed.Substring(1, $trimmed.Length - 2).Replace('\"', '"').Replace("''", "'")
+    }
+  }
+  return $trimmed
+}
+
+function ConvertTo-StringArray {
+  param([AllowNull()][object]$Value)
+
+  if ($null -eq $Value) {
+    return @()
+  }
+  return @($Value | ForEach-Object { [string]$_ })
+}
+
+function Read-EvalQuestionFile {
+  param(
+    [Parameter(Mandatory = $true)][string]$RepoRoot,
+    [Parameter(Mandatory = $true)][string]$RelativePath
+  )
+
+  $path = Join-Path $RepoRoot $RelativePath
+  if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+    throw "Missing eval file: $RelativePath"
+  }
+
+  $content = Get-Content -LiteralPath $path -Raw -Encoding UTF8
+  $normalized = $content -replace "`r`n", "`n"
+  $lines = $normalized -split "`n"
+  $cases = @()
+  $issues = @()
+  $currentCase = $null
+  $currentListKey = $null
+  $seenCasesRoot = $false
+
+  for ($index = 0; $index -lt $lines.Count; $index++) {
+    $line = $lines[$index]
+    $lineNumber = $index + 1
+
+    if ([string]::IsNullOrWhiteSpace($line)) {
+      continue
+    }
+
+    if ($line -match '^cases:\s*$') {
+      $seenCasesRoot = $true
+      continue
+    }
+
+    if ($line -match '^([A-Za-z0-9_]+):') {
+      $issues += "$RelativePath line $lineNumber has unsupported top-level eval key: $($Matches[1])"
+      continue
+    }
+
+    if ($line -match '^  -\s+([A-Za-z0-9_]+):\s*(.*)$') {
+      if ($null -ne $currentCase) {
+        $cases += [pscustomobject]$currentCase
+      }
+
+      $currentCase = [ordered]@{
+        source_file = $RelativePath
+      }
+      $key = $Matches[1]
+      $currentCase[$key] = ConvertFrom-EvalYamlScalar $Matches[2]
+      $currentListKey = $null
+      continue
+    }
+
+    if ($line -match '^    ([A-Za-z0-9_]+):\s*(.*)$') {
+      if ($null -eq $currentCase) {
+        $issues += "$RelativePath line $lineNumber defines a case field before a case item"
+        continue
+      }
+
+      $key = $Matches[1]
+      $value = $Matches[2]
+      if ([string]::IsNullOrWhiteSpace($value)) {
+        $currentCase[$key] = @()
+        $currentListKey = $key
+      } else {
+        $currentCase[$key] = ConvertFrom-EvalYamlScalar $value
+        $currentListKey = $null
+      }
+      continue
+    }
+
+    if ($line -match '^      -\s*(.*)$') {
+      if ($null -eq $currentCase -or [string]::IsNullOrWhiteSpace($currentListKey)) {
+        $issues += "$RelativePath line $lineNumber has a list item outside a list field"
+        continue
+      }
+      $currentCase[$currentListKey] = @(ConvertTo-StringArray $currentCase[$currentListKey]) + @(ConvertFrom-EvalYamlScalar $Matches[1])
+      continue
+    }
+
+    $issues += "$RelativePath line $lineNumber has unsupported YAML shape"
+  }
+
+  if ($null -ne $currentCase) {
+    $cases += [pscustomobject]$currentCase
+  }
+
+  if (-not $seenCasesRoot) {
+    $issues += "$RelativePath missing top-level cases key"
+  }
+  if ($cases.Count -eq 0) {
+    $issues += "$RelativePath contains no eval cases"
+  }
+
+  return [pscustomobject]@{
+    RelativePath = $RelativePath
+    Cases = $cases
+    Issues = $issues
+  }
+}
+
+function Get-EvalQuestionFiles {
+  param([Parameter(Mandatory = $true)][string]$RepoRoot)
+
+  $questionRoot = Join-Path $RepoRoot 'evals/questions'
+  if (-not (Test-Path -LiteralPath $questionRoot -PathType Container)) {
+    throw 'Missing eval question directory: evals/questions'
+  }
+
+  return @(
+    Get-ChildItem -LiteralPath $questionRoot -File -Filter '*.yaml' |
+      Sort-Object FullName |
+      ForEach-Object { $_.FullName.Substring($RepoRoot.Length + 1).Replace('\', '/') }
+  )
+}
+
+function Get-EvalCaseIndex {
+  param(
+    [Parameter(Mandatory = $true)][string]$RepoRoot,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  $index = @{}
+  foreach ($relativePath in @(Get-EvalQuestionFiles $RepoRoot)) {
+    $parsed = Read-EvalQuestionFile -RepoRoot $RepoRoot -RelativePath $relativePath
+    foreach ($issue in @($parsed.Issues)) {
+      $Issues.Value += $issue
+    }
+
+    foreach ($case in @($parsed.Cases)) {
+      $caseId = if ($null -ne $case.PSObject.Properties['id']) { [string]$case.id } else { '' }
+      if ([string]::IsNullOrWhiteSpace($caseId)) {
+        $Issues.Value += "$relativePath contains an eval case with an empty id"
+        continue
+      }
+      if ($index.ContainsKey($caseId)) {
+        $Issues.Value += "Duplicate eval case id: $caseId ($($index[$caseId].source_file), $relativePath)"
+      } else {
+        $index[$caseId] = $case
+      }
+    }
+  }
+
+  return $index
+}

--- a/tests/validation/run-all.ps1
+++ b/tests/validation/run-all.ps1
@@ -76,6 +76,7 @@ $readOnlyValidationScripts = @(
   'tests/validation/validate-no-video-binary-assets.ps1',
   'tests/validation/validate-combo-damage-fixtures.ps1',
   'tests/validation/validate-evals.ps1',
+  'tests/validation/validate-eval-score-reports.ps1',
   'tests/validation/validate-roster-source.ps1',
   'tests/validation/validate-raw-snapshot-minimality.ps1',
   'tests/validation/validate-raw-snapshot-retention-adr.ps1',

--- a/tests/validation/schema-validation-manifest.json
+++ b/tests/validation/schema-validation-manifest.json
@@ -61,6 +61,14 @@
         "data/exports/_index/manual-review-debt.json"
       ],
       "notes": "Structural manual-review debt index shape only; validate-manual-review-debt-index.ps1 remains generated-drift authority."
+    },
+    {
+      "id": "eval_score_reports",
+      "schema_path": "contracts/eval-score-report.schema.json",
+      "document_globs": [
+        "tests/fixtures/eval-score-reports/*.json"
+      ],
+      "notes": "Structural score report shape only; validate-eval-score-reports.ps1 remains semantic authority."
     }
   ]
 }

--- a/tests/validation/validate-eval-score-reports.ps1
+++ b/tests/validation/validate-eval-score-reports.ps1
@@ -1,0 +1,149 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+. (Join-Path $PSScriptRoot 'eval-case-helpers.ps1')
+
+$schemaRelativePath = 'contracts/eval-score-report.schema.json'
+$fixtureRootRelativePath = 'tests/fixtures/eval-score-reports'
+$fixtureRoot = Join-Path $repoRoot $fixtureRootRelativePath
+$forbiddenReportPatterns = @(
+  '"raw_transcript"\s*:',
+  '"raw_response"\s*:',
+  '"full_response"\s*:',
+  '"session_id"\s*:',
+  '"hermes_memory"\s*:',
+  '\.hermes/',
+  '\.env',
+  'auth\.json',
+  'state\.db',
+  'data/exports/',
+  'official_raw',
+  'skills/sf6-agent/assets/frame-current',
+  'skills/sf6-agent/references/generated-'
+)
+
+function Test-Property {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name
+  )
+  return $null -ne $Object.PSObject.Properties[$Name]
+}
+
+function Add-Issue {
+  param(
+    [Parameter(Mandatory = $true)][ref]$Issues,
+    [Parameter(Mandatory = $true)][string]$Message
+  )
+  $Issues.Value += $Message
+}
+
+function Assert-SummaryCount {
+  param(
+    [Parameter(Mandatory = $true)][object]$Summary,
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][int]$Expected,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  if (-not (Test-Property $Summary $Name)) {
+    Add-Issue $Issues "$Context summary missing count: $Name"
+    return
+  }
+  if ([int]$Summary.$Name -ne $Expected) {
+    Add-Issue $Issues "$Context summary $Name must be $Expected, got $($Summary.$Name)"
+  }
+}
+
+if (-not (Test-Path -LiteralPath (Join-Path $repoRoot $schemaRelativePath) -PathType Leaf)) {
+  throw "Missing eval score report schema: $schemaRelativePath"
+}
+if (-not (Test-Path -LiteralPath $fixtureRoot -PathType Container)) {
+  throw "Missing eval score report fixture directory: $fixtureRootRelativePath"
+}
+
+$schemaText = Get-Content -LiteralPath (Join-Path $repoRoot $schemaRelativePath) -Raw -Encoding UTF8
+$issues = @()
+$caseIndex = Get-EvalCaseIndex -RepoRoot $repoRoot -Issues ([ref]$issues)
+
+$reportFiles = @(
+  Get-ChildItem -LiteralPath $fixtureRoot -File -Filter '*.json' |
+    Sort-Object FullName
+)
+if ($reportFiles.Count -eq 0) {
+  $issues += "No eval score report fixtures found under $fixtureRootRelativePath"
+}
+
+foreach ($reportFile in $reportFiles) {
+  $relativePath = $reportFile.FullName.Substring($repoRoot.Length + 1).Replace('\', '/')
+  $raw = Get-Content -LiteralPath $reportFile.FullName -Raw -Encoding UTF8
+  try {
+    $valid = Test-Json -LiteralPath $reportFile.FullName -Schema $schemaText -ErrorAction Stop
+    if ($valid -ne $true) {
+      $issues += "$relativePath failed schema validation against $schemaRelativePath"
+    }
+  } catch {
+    $issues += "$relativePath failed schema validation against $schemaRelativePath`: $($_.Exception.Message)"
+    continue
+  }
+
+  foreach ($pattern in $forbiddenReportPatterns) {
+    if ($raw -match $pattern) {
+      $issues += "$relativePath contains forbidden score-report content pattern: $pattern"
+    }
+  }
+
+  $report = $raw | ConvertFrom-Json
+  if ($report.not_gameplay_authority -ne $true) {
+    $issues += "$relativePath must declare not_gameplay_authority true"
+  }
+  if ($report.normal_public_answer_authority -ne $false) {
+    $issues += "$relativePath must not be normal public answer authority"
+  }
+  if ($report.raw_transcript_committed -ne $false) {
+    $issues += "$relativePath must not commit raw transcripts"
+  }
+  if ($report.local_state_committed -ne $false) {
+    $issues += "$relativePath must not commit local state"
+  }
+
+  $caseResults = @($report.case_results)
+  foreach ($result in $caseResults) {
+    $caseId = [string]$result.case_id
+    $context = "$relativePath case_results[$caseId]"
+    if (-not $caseIndex.ContainsKey($caseId)) {
+      $issues += "$context references unknown eval case"
+      continue
+    }
+
+    $canonicalCase = $caseIndex[$caseId]
+    if ([string]$result.source_file -ne [string]$canonicalCase.source_file) {
+      $issues += "$context source_file must be $($canonicalCase.source_file)"
+    }
+    if ([string]$result.expected_answer_mode -ne [string]$canonicalCase.expected_answer_mode) {
+      $issues += "$context expected_answer_mode must be $($canonicalCase.expected_answer_mode)"
+    }
+  }
+
+  $resultValues = @($caseResults | ForEach-Object { [string]$_.overall_result })
+  $modePassValues = @($caseResults | Where-Object { $_.mode_pass -eq $true })
+  $groundingPassValues = @($caseResults | Where-Object { $_.grounding_pass -eq $true })
+  $mustNotIncludePassValues = @($caseResults | Where-Object { $_.must_not_include_pass -eq $true })
+
+  Assert-SummaryCount $report.summary 'total_cases' $caseResults.Count $relativePath ([ref]$issues)
+  Assert-SummaryCount $report.summary 'pass_count' @($resultValues | Where-Object { $_ -eq 'pass' }).Count $relativePath ([ref]$issues)
+  Assert-SummaryCount $report.summary 'fail_count' @($resultValues | Where-Object { $_ -eq 'fail' }).Count $relativePath ([ref]$issues)
+  Assert-SummaryCount $report.summary 'skip_count' @($resultValues | Where-Object { $_ -eq 'skip' }).Count $relativePath ([ref]$issues)
+  Assert-SummaryCount $report.summary 'hold_review_count' @($resultValues | Where-Object { $_ -eq 'hold_review' }).Count $relativePath ([ref]$issues)
+  Assert-SummaryCount $report.summary 'mode_pass_count' $modePassValues.Count $relativePath ([ref]$issues)
+  Assert-SummaryCount $report.summary 'grounding_pass_count' $groundingPassValues.Count $relativePath ([ref]$issues)
+  Assert-SummaryCount $report.summary 'must_not_include_pass_count' $mustNotIncludePassValues.Count $relativePath ([ref]$issues)
+}
+
+if ($issues.Count -gt 0) {
+  throw ($issues -join '; ')
+}
+
+Write-Host 'Eval score reports OK'

--- a/tests/validation/validate-evals.ps1
+++ b/tests/validation/validate-evals.ps1
@@ -1,84 +1,81 @@
 Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+. (Join-Path $PSScriptRoot 'eval-case-helpers.ps1')
 
-$questionFiles = @(
-  'evals/questions/concepts.yaml',
-  'evals/questions/current-fact.yaml',
-  'evals/questions/strategy.yaml',
-  'evals/questions/matchup.yaml',
-  'evals/questions/sf6-system-mechanics-math-reasoning.yaml',
-  'evals/questions/video-observation.yaml',
-  'evals/questions/uncertainty.yaml'
-)
-
+$schemaRelativePath = 'contracts/eval-case.schema.json'
 $rubricFiles = @(
   'evals/rubrics/answer-modes.md',
   'evals/rubrics/grounding.md'
 )
 
-foreach ($relativePath in $questionFiles + $rubricFiles) {
+foreach ($relativePath in @($schemaRelativePath) + $rubricFiles) {
   if (-not (Test-Path -LiteralPath (Join-Path $repoRoot $relativePath) -PathType Leaf)) {
-    throw "Missing eval file: $relativePath"
+    throw "Missing eval contract file: $relativePath"
   }
 }
 
-$allowedTopLevelKeys = @('cases')
-$allowedCaseKeys = @(
-  'id',
-  'question',
-  'expected_answer_mode',
-  'evidence_boundary',
-  'must_not_include'
-)
+$schema = Get-Content -LiteralPath (Join-Path $repoRoot $schemaRelativePath) -Raw -Encoding UTF8 | ConvertFrom-Json
+$requiredCaseKeys = @($schema.required | ForEach-Object { [string]$_ })
+$allowedCaseKeys = @($schema.properties.PSObject.Properties.Name | ForEach-Object { [string]$_ })
+$allowedAnswerModes = @($schema.properties.expected_answer_mode.enum | ForEach-Object { [string]$_ })
 
-foreach ($relativePath in $questionFiles) {
-  $content = Get-Content -LiteralPath (Join-Path $repoRoot $relativePath) -Raw -Encoding UTF8
-  $normalized = $content -replace "`r`n", "`n"
-  $violations = @()
+foreach ($requiredKey in @('id', 'question', 'expected_answer_mode', 'evidence_boundary', 'must_not_include')) {
+  if ($requiredCaseKeys -notcontains $requiredKey) {
+    throw "$schemaRelativePath missing required eval case key: $requiredKey"
+  }
+}
 
-  foreach ($line in ($normalized -split "`n")) {
-    if ($line -match '^([A-Za-z0-9_]+):') {
-      $key = $Matches[1]
-      if ($key -notin $allowedTopLevelKeys) {
-        $violations += "$relativePath has unsupported top-level eval key: $key"
-      }
-    } elseif ($line -match '^ {2}-\s+([A-Za-z0-9_]+):') {
-      $key = $Matches[1]
-      if ($key -notin $allowedCaseKeys) {
-        $violations += "$relativePath has unsupported eval case key: $key"
-      }
-    } elseif ($line -match '^ {4}([A-Za-z0-9_]+):') {
-      $key = $Matches[1]
-      if ($key -notin $allowedCaseKeys) {
-        $violations += "$relativePath has unsupported eval case key: $key"
-      }
+$issues = @()
+$caseIndex = Get-EvalCaseIndex -RepoRoot $repoRoot -Issues ([ref]$issues)
+
+foreach ($caseId in @($caseIndex.Keys | Sort-Object)) {
+  $case = $caseIndex[$caseId]
+  $context = "$($case.source_file)#$caseId"
+  $caseKeys = @(
+    $case.PSObject.Properties.Name |
+      Where-Object { $_ -ne 'source_file' } |
+      ForEach-Object { [string]$_ }
+  )
+
+  foreach ($key in $caseKeys) {
+    if ($allowedCaseKeys -notcontains $key) {
+      $issues += "$context has unsupported eval case key: $key"
     }
   }
 
-  foreach ($needle in @('id:', 'question:', 'expected_answer_mode:', 'evidence_boundary:', 'must_not_include:')) {
-    if ($content -notmatch [regex]::Escape($needle)) {
-      $violations += "$relativePath missing eval metadata: $needle"
-    }
-  }
-  $modeMatches = [regex]::Matches($content, 'expected_answer_mode:\s*([A-Za-z0-9_/-]+)')
-  foreach ($modeMatch in $modeMatches) {
-    $mode = $modeMatch.Groups[1].Value
-    if ($mode -notin @('stable_concept', 'verified_current_fact', 'strategy_or_matchup_knowledge', 'observation', 'unresolved_or_hold')) {
-      $violations += "$relativePath has unsupported expected_answer_mode: $mode"
+  foreach ($key in $requiredCaseKeys) {
+    if ($caseKeys -notcontains $key) {
+      $issues += "$context missing eval case key: $key"
     }
   }
 
-  if ($violations.Count -gt 0) {
-    throw ($violations -join '; ')
+  foreach ($key in @('id', 'question', 'expected_answer_mode', 'evidence_boundary')) {
+    if (($caseKeys -contains $key) -and [string]::IsNullOrWhiteSpace([string]$case.$key)) {
+      $issues += "$context has empty eval case key: $key"
+    }
+  }
+
+  if (($caseKeys -contains 'expected_answer_mode') -and $allowedAnswerModes -notcontains [string]$case.expected_answer_mode) {
+    $issues += "$context has unsupported expected_answer_mode: $($case.expected_answer_mode)"
+  }
+
+  $mustNotInclude = if ($caseKeys -contains 'must_not_include') { @(ConvertTo-StringArray $case.must_not_include) } else { @() }
+  if ($mustNotInclude.Count -eq 0) {
+    $issues += "$context must include at least one must_not_include entry"
   }
 }
 
 $answerModes = Get-Content -LiteralPath (Join-Path $repoRoot 'evals/rubrics/answer-modes.md') -Raw -Encoding UTF8
-foreach ($mode in @('stable_concept', 'verified_current_fact', 'strategy_or_matchup_knowledge', 'observation', 'unresolved_or_hold')) {
+foreach ($mode in $allowedAnswerModes) {
   if ($answerModes -notmatch [regex]::Escape($mode)) {
-    throw "answer mode rubric missing mode: $mode"
+    $issues += "answer mode rubric missing mode: $mode"
   }
+}
+
+if ($issues.Count -gt 0) {
+  throw ($issues -join '; ')
 }
 
 Write-Host 'Evals OK'

--- a/tests/validation/validate-v2-contracts.ps1
+++ b/tests/validation/validate-v2-contracts.ps1
@@ -8,6 +8,7 @@ $requiredJsonSchemas = @(
   'contracts/knowledge-page.schema.json',
   'contracts/generated-surface.schema.json',
   'contracts/eval-case.schema.json',
+  'contracts/eval-score-report.schema.json',
   'contracts/video-observation.schema.json',
   'contracts/answer-intent.schema.json',
   'contracts/evidence-card.schema.json',


### PR DESCRIPTION
## Summary

- Add `contracts/eval-score-report.schema.json` for offline answer-quality / regression score reports.
- Add `tests/fixtures/eval-score-reports/minimal-manual-scorecard.json` as a static scorecard fixture with no live agent answer content.
- Add `tests/validation/validate-eval-score-reports.ps1` and an eval case helper to check score reports against canonical `evals/questions/*.yaml` cases.
- Strengthen `tests/validation/validate-evals.ps1` so eval case IDs are unique and answer-mode validation is driven by `contracts/eval-case.schema.json`.
- Wire the new validator into read-only `run-all.ps1`, schema manifest validation, contracts docs, eval docs, testing docs, and repository surface metadata.

## Hermes

- Hermes `sf6ingest` was used for read-only primary draft analysis.
- Hermes recommended a validator-only/static scorecard contract before any live runner or LLM judge.
- Hermes output was treated as primary draft input only; no Hermes local state, raw transcript, memory, sessions, logs, caches, credentials, or profile output was committed.
- Provider Codex was not used by Hermes for implementation.

## Validation

- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-evals.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-eval-score-reports.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-json-schema-manifest.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-v2-contracts.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-repository-surfaces.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 -Lane read-only`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1`
- `git diff --cached --check`
- `git diff --check origin/main...HEAD`

## Non-goals

- No live agent execution runner.
- No LLM judge scoring.
- No public `sf6-agent` behavior changes.
- No current facts, `official_raw`, data exports, frame-current assets, generated refs, normalized assets, or distribution bundle changes.
- No promotion of score reports into gameplay/current-fact authority.

Closes #266
