### PR TITLE
[v2.6] Record SymPy calculation backend decision

### DIFF
--- a/contracts/calculation-executor-trace.md
+++ b/contracts/calculation-executor-trace.md
@@ -43,6 +43,11 @@ Third-party or wild math skills are allowed only as executor implementations or
 operator instructions after dependency review. Their output is a calculation
 trace candidate, not authority.
 
+The v2.6 initial backend decision uses SymPy and the pinned K-Dense SymPy Agent
+Skill as maintainer-local executor / operator-instruction dependencies only.
+They do not supply accepted SF6 formulas, rounding rules, input truth, current
+facts, or public answer behavior.
+
 ## Trace Fields
 
 A calculation trace should include enough structured information to reproduce

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -27,6 +27,7 @@ Architecture docs define the v2 source-of-truth model.
 - [noncanonical-data-authority-boundaries.md](./noncanonical-data-authority-boundaries.md)
 - [package-surface-classification.md](./package-surface-classification.md)
 - [schema-validation-runner.md](./schema-validation-runner.md)
+- [calculation-backend-policy.md](./calculation-backend-policy.md)
 - [generated-reference-responsibility-plan.md](./generated-reference-responsibility-plan.md)
 - [frame-current-runtime-separation-plan.md](./frame-current-runtime-separation-plan.md)
 - [powershell-compatibility-policy.md](./powershell-compatibility-policy.md)

--- a/docs/architecture/agent-skill-dependency-policy.md
+++ b/docs/architecture/agent-skill-dependency-policy.md
@@ -94,6 +94,26 @@ authority promotions. A maintainer must still review:
 - security/audit output
 - whether the skill remains executor-only for SF6 work
 
+## Current Math Skill Decision
+
+v2.6 selects only the K-Dense-AI `scientific-agent-skills` SymPy skill as the
+initial external Agent Skill dependency for maintainer-local calculation work.
+
+```yaml
+dependencies:
+  apm:
+    # renovate: datasource=git-tags depName=K-Dense-AI/scientific-agent-skills
+    - K-Dense-AI/scientific-agent-skills/scientific-skills/sympy#v2.38.0
+```
+
+This is a selected subset, not adoption of the whole scientific skill bundle.
+SageMath skills, statistics skills, MCP servers, and broad math/science bundles
+remain deferred until a later issue defines a task-scoped adoption policy.
+The lockfile must preserve `virtual_path: scientific-skills/sympy` so reviewers
+can verify that the selected subset, not the broad bundle, is installed.
+
+See `docs/architecture/calculation-backend-policy.md`.
+
 ## Math Skill Boundary
 
 Math-related skills such as SymPy / SageMath operator instructions are managed

--- a/docs/architecture/calculation-backend-policy.md
+++ b/docs/architecture/calculation-backend-policy.md
@@ -1,0 +1,107 @@
+# Calculation Backend Policy
+
+この文書は、v2.6 で repo-local maintainer が計算を必要とする場合の
+backend selection と dependency boundary を定義します。
+
+## Decision
+
+v2.6 では、maintainer-local calculation execution の初期既定 backend
+として SymPy を採用します。
+
+SymPy は symbolic math / exact arithmetic backend として使います。
+これは SF6 公式値、式、丸め規則、system mechanics、current facts、
+public answer authority を repo が所有するという意味ではありません。
+
+Validator anchor: SymPy is the initial default maintainer-local calculation backend.
+
+## Managed Dependencies
+
+Python package dependency は `packages/calculation-executor/` の
+package-local project で管理します。
+
+- package file: `packages/calculation-executor/pyproject.toml`
+- lockfile: `packages/calculation-executor/uv.lock`
+- dependency: `sympy==1.14.0`
+
+この dependency は calculation trace helper の実行環境を固定するための
+ものです。`packages/calculation-executor/` を custom SF6 math engine に
+拡張するためのものではありません。
+
+External Agent Skill dependency は maintainer-only APM manifest で管理します。
+
+- manifest: `tools/agent-skills/apm.yml`
+- lockfile: `tools/agent-skills/apm.lock.yaml`
+- selected dependency:
+  `K-Dense-AI/scientific-agent-skills/scientific-skills/sympy#v2.38.0`
+
+The K-Dense SymPy skill is an executor / operator instruction dependency only.
+It is not SF6 formula authority, rounding authority, input truth authority,
+current-fact authority, or public answer behavior.
+
+## Deferred Choices
+
+SageMath is deferred in v2.6.
+
+Reasons:
+
+- It is a heavier CAS and install/runtime surface than the first-tranche
+  maintainer calculation workflow needs.
+- It needs a separate install, lock, security, and update policy before adoption.
+- SymPy is sufficient for the initial backend decision and smaller PR scope.
+
+MCP servers are deferred in v2.6.
+
+Reasons:
+
+- MCP server defaults are outside the current Agent Skill dependency manifest.
+- MCP adoption needs server allowlists, no-secret config handling, output
+  boundary rules, and validator coverage.
+
+Additional K-Dense skills such as statistics are catalogued candidates only.
+Do not add them to `tools/agent-skills/apm.yml` until a later issue defines a
+specific maintainer task, selected skill subset, security review, and validator
+expectation.
+
+Broad scientific skill bundles are not adopted. Add only reviewed, task-scoped
+skill subsets.
+
+## SF6 Calculation Boundary
+
+Do not add repo-owned:
+
+- combo damage formulas
+- scaling tables
+- minimum guarantees
+- frame advantage interpretation rules
+- punish-window logic
+- meaty or oki timing formulas
+- resource formulas
+- SF6 rounding rules
+- current-system exception tables
+
+If SF6-specific calculation is needed, the reusable knowledge should be a
+repo-reviewed operator instruction or handoff prompt for the selected backend,
+not accepted repo formula authority.
+
+Calculation outputs remain trace candidates. If an input, route mapping,
+formula-like instruction, or rounding instruction is missing or uncertain, the
+trace must remain hold / blocked rather than public answer authority.
+
+## Not Committed
+
+Do not commit:
+
+- Hermes memory, sessions, raw transcripts, local skills, Curator output,
+  checkpoints, logs, caches, credentials, or profile state
+- local installed Agent Skill directories
+- API keys, `.env`, `auth.json`, or provider output
+- generated frame-current assets, generated references, `.dist`, or public
+  `sf6-agent` behavior for this decision
+
+## References
+
+- `docs/architecture/agent-skill-dependency-policy.md`
+- `contracts/calculation-executor-trace.md`
+- `packages/calculation-executor/README.md`
+- `tools/agent-skills/apm.yml`
+- `tools/agent-skills/apm.lock.yaml`

--- a/packages/calculation-executor/README.md
+++ b/packages/calculation-executor/README.md
@@ -9,6 +9,10 @@ The executor exists to reduce LLM arithmetic errors. It is not SF6 authority,
 formula authority, rounding authority, current-fact authority, or public answer
 behavior.
 
+SymPy is the initial default maintainer-local symbolic math backend dependency
+for calculation execution. It is pinned package-locally in `pyproject.toml` and
+`uv.lock` so dependency updates are reviewable.
+
 Use it only with explicit JSON inputs and the non-authority boundaries from
 `contracts/calculation-executor-trace.md`. Do not extend it into a custom SF6
 math engine. If SF6-specific calculation is needed, prefer a reviewed external
@@ -44,6 +48,11 @@ Supported operations are generic arithmetic only:
 The executor does not implement SF6 combo damage formulas, scaling tables,
 minimum guarantees, frame advantage interpretation, punish-window logic,
 meaty/oki timing, resource formulas, or SF6 rounding rules.
+
+The SymPy dependency is not SF6 combo damage formula authority. It also does
+not add scaling tables, minimum guarantees, frame interpretation, punish logic,
+oki timing, resource formulas, SF6 rounding rules, current-system exceptions,
+or public answer behavior.
 
 ## Authority boundary
 

--- a/packages/calculation-executor/pyproject.toml
+++ b/packages/calculation-executor/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sf6-calculation-executor"
+version = "0.1.0"
+description = "Repo-local calculation trace helper for SF6 maintainer workflows."
+readme = "README.md"
+requires-python = ">=3.14"
+dependencies = [
+  "sympy==1.14.0",
+]
+
+[tool.setuptools]
+py-modules = ["sf6_calculation_executor"]

--- a/packages/calculation-executor/uv.lock
+++ b/packages/calculation-executor/uv.lock
@@ -1,0 +1,35 @@
+version = 1
+revision = 3
+requires-python = ">=3.14"
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "sf6-calculation-executor"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "sympy" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "sympy", specifier = "==1.14.0" }]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]

--- a/tests/validation/validate-agent-toolchain.ps1
+++ b/tests/validation/validate-agent-toolchain.ps1
@@ -106,6 +106,7 @@ $requiredFiles = @(
   '.github/renovate.json',
   'docs/architecture/agent-toolchain-freshness.md',
   'docs/architecture/agent-skill-dependency-policy.md',
+  'docs/architecture/calculation-backend-policy.md',
   'docs/architecture/hermes-curator-worktree-checkpoint-policy.md',
   'docs/architecture/hermes-memory-policy.md',
   'docs/architecture/hermes-maintainer-profile-policy.md',
@@ -114,6 +115,8 @@ $requiredFiles = @(
   $schemaPath,
   'data/toolchain/README.md',
   $manifestPath,
+  'tools/agent-skills/.gitignore',
+  'tools/agent-skills/apm.lock.yaml',
   'tools/agent-skills/apm.yml',
   'workflows/check-agent-toolchain-freshness.md'
 )
@@ -304,11 +307,23 @@ if (Test-Path -LiteralPath (Join-Path $repoRoot 'tools/agent-skills/apm.yml') -P
     'targets:',
     '- agent-skills',
     'dependencies:',
-    'apm: []',
+    'renovate: datasource=git-tags depName=K-Dense-AI/scientific-agent-skills',
+    'K-Dense-AI/scientific-agent-skills/scientific-skills/sympy#v2.38.0',
     'devDependencies:'
   )) {
     if ($apmText -notmatch [regex]::Escape($needle)) {
       $issues += "tools/agent-skills/apm.yml missing required text: $needle"
+    }
+  }
+  foreach ($forbiddenDependency in @(
+    'K-Dense-AI/scientific-agent-skills#',
+    'K-Dense-AI/scientific-agent-skills/main',
+    'scientific-skills/statistics',
+    'sagemath',
+    'mcp'
+  )) {
+    if ($apmText.ToLowerInvariant() -match [regex]::Escape($forbiddenDependency.ToLowerInvariant())) {
+      $issues += "tools/agent-skills/apm.yml contains deferred or broad dependency text: $forbiddenDependency"
     }
   }
   foreach ($forbidden in @(
@@ -333,11 +348,62 @@ if (Test-Path -LiteralPath (Join-Path $repoRoot 'tools/agent-skills/apm.yml') -P
   }
 }
 
+if (Test-Path -LiteralPath (Join-Path $repoRoot 'tools/agent-skills/.gitignore') -PathType Leaf) {
+  $apmGitignore = Read-Text 'tools/agent-skills/.gitignore'
+  foreach ($needle in @(
+    '.agents/',
+    'apm_modules/'
+  )) {
+    if ($apmGitignore -notmatch [regex]::Escape($needle)) {
+      $issues += "tools/agent-skills/.gitignore missing ignored APM output text: $needle"
+    }
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot 'tools/agent-skills/apm.lock.yaml') -PathType Leaf) {
+  $apmLockText = Read-Text 'tools/agent-skills/apm.lock.yaml'
+  foreach ($needle in @(
+    "lockfile_version: '1'",
+    'apm_version:',
+    'repo_url: K-Dense-AI/scientific-agent-skills',
+    'resolved_ref: v2.38.0',
+    'virtual_path: scientific-skills/sympy',
+    'is_virtual: true',
+    'package_type: claude_skill',
+    'deployed_files:',
+    '- .agents/skills/sympy',
+    'content_hash: sha256:'
+  )) {
+    if ($apmLockText -notmatch [regex]::Escape($needle)) {
+      $issues += "tools/agent-skills/apm.lock.yaml missing required lock text: $needle"
+    }
+  }
+  foreach ($forbiddenLockText in @(
+    'scientific-skills/statistical-analysis',
+    'scientific-skills/statsmodels',
+    'scientific-skills/simpy',
+    'sagemath',
+    'mcp',
+    'secret',
+    'token',
+    'credential',
+    'memories/',
+    'sessions/',
+    'state.db',
+    'logs/'
+  )) {
+    if ($apmLockText.ToLowerInvariant() -match [regex]::Escape($forbiddenLockText.ToLowerInvariant())) {
+      $issues += "tools/agent-skills/apm.lock.yaml contains deferred or forbidden text: $forbiddenLockText"
+    }
+  }
+}
+
 if (Test-Path -LiteralPath (Join-Path $repoRoot 'docs/architecture/agent-skill-dependency-policy.md') -PathType Leaf) {
   $agentSkillPolicy = Read-Text 'docs/architecture/agent-skill-dependency-policy.md'
   foreach ($needle in @(
     'tools/agent-skills/apm.yml',
     'tools/agent-skills/apm.lock.yaml',
+    'docs/architecture/calculation-backend-policy.md',
     'executor / operator instruction dependency',
     'reviewed tag or immutable SHA',
     'Renovate',
@@ -345,10 +411,30 @@ if (Test-Path -LiteralPath (Join-Path $repoRoot 'docs/architecture/agent-skill-d
     'git-refs',
     'SymPy',
     'SageMath',
+    'K-Dense-AI/scientific-agent-skills/scientific-skills/sympy#v2.38.0',
     'must not become repo-owned SF6 formula authority'
   )) {
     if ($agentSkillPolicy -notmatch [regex]::Escape($needle)) {
       $issues += "docs/architecture/agent-skill-dependency-policy.md missing policy text: $needle"
+    }
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot 'docs/architecture/calculation-backend-policy.md') -PathType Leaf) {
+  $calculationBackendPolicy = Read-Text 'docs/architecture/calculation-backend-policy.md'
+  foreach ($needle in @(
+    'SymPy is the initial default maintainer-local calculation backend',
+    'sympy==1.14.0',
+    'K-Dense-AI/scientific-agent-skills/scientific-skills/sympy#v2.38.0',
+    'tools/agent-skills/apm.lock.yaml',
+    'SageMath is deferred',
+    'MCP servers are deferred',
+    'statistics are catalogued candidates only',
+    'not SF6 formula authority',
+    'not accepted repo formula authority'
+  )) {
+    if ($calculationBackendPolicy -notmatch [regex]::Escape($needle)) {
+      $issues += "docs/architecture/calculation-backend-policy.md missing policy text: $needle"
     }
   }
 }

--- a/tests/validation/validate-calculation-executor.ps1
+++ b/tests/validation/validate-calculation-executor.ps1
@@ -3,6 +3,10 @@ $ErrorActionPreference = 'Stop'
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 $scriptPath = Join-Path $repoRoot 'packages/calculation-executor/sf6_calculation_executor.py'
+$packageRoot = Join-Path $repoRoot 'packages/calculation-executor'
+$pyprojectPath = Join-Path $packageRoot 'pyproject.toml'
+$uvLockPath = Join-Path $packageRoot 'uv.lock'
+$readmePath = Join-Path $packageRoot 'README.md'
 $fixtureRoot = Join-Path $repoRoot 'tests/fixtures/calculation-executor'
 
 $allowedExecutorRoles = @('calculation_executor', 'trace_generator', 'arithmetic_consistency_checker')
@@ -59,8 +63,48 @@ $issues = @()
 if (-not (Test-Path -LiteralPath $scriptPath -PathType Leaf)) {
   throw 'Missing calculation executor script'
 }
+if (-not (Test-Path -LiteralPath $pyprojectPath -PathType Leaf)) {
+  throw 'Missing calculation executor pyproject.toml'
+}
+if (-not (Test-Path -LiteralPath $uvLockPath -PathType Leaf)) {
+  throw 'Missing calculation executor uv.lock'
+}
 if (-not (Test-Path -LiteralPath $fixtureRoot -PathType Container)) {
   throw 'Missing calculation executor fixture directory'
+}
+
+$pyprojectText = Get-Content -LiteralPath $pyprojectPath -Raw -Encoding UTF8
+foreach ($needle in @(
+  'name = "sf6-calculation-executor"',
+  'requires-python = ">=3.14"',
+  '"sympy==1.14.0"'
+)) {
+  if ($pyprojectText -notmatch [regex]::Escape($needle)) {
+    Add-Issue ([ref]$issues) "packages/calculation-executor/pyproject.toml missing required text: $needle"
+  }
+}
+
+$uvLockText = Get-Content -LiteralPath $uvLockPath -Raw -Encoding UTF8
+foreach ($needle in @(
+  'name = "sf6-calculation-executor"',
+  'name = "sympy"',
+  'version = "1.14.0"'
+)) {
+  if ($uvLockText -notmatch [regex]::Escape($needle)) {
+    Add-Issue ([ref]$issues) "packages/calculation-executor/uv.lock missing required text: $needle"
+  }
+}
+
+$readmeText = Get-Content -LiteralPath $readmePath -Raw -Encoding UTF8
+foreach ($needle in @(
+  'SymPy is the initial default maintainer-local symbolic math backend dependency',
+  'not SF6 authority',
+  'not SF6 combo damage formula',
+  'SF6 rounding rule'
+)) {
+  if ($readmeText -notmatch [regex]::Escape($needle)) {
+    Add-Issue ([ref]$issues) "packages/calculation-executor/README.md missing required boundary text: $needle"
+  }
 }
 
 $pythonCommand = Get-Command python -ErrorAction SilentlyContinue

--- a/tools/agent-skills/.gitignore
+++ b/tools/agent-skills/.gitignore
@@ -1,0 +1,4 @@
+
+# APM dependencies
+.agents/
+apm_modules/

--- a/tools/agent-skills/apm.lock.yaml
+++ b/tools/agent-skills/apm.lock.yaml
@@ -1,0 +1,14 @@
+lockfile_version: '1'
+generated_at: '2026-05-17T20:41:06.494227+00:00'
+apm_version: 0.13.0
+dependencies:
+- repo_url: K-Dense-AI/scientific-agent-skills
+  host: github.com
+  resolved_commit: 75c41d78a2503e687d0dc8d349c6d6081d9fc27c
+  resolved_ref: v2.38.0
+  virtual_path: scientific-skills/sympy
+  is_virtual: true
+  package_type: claude_skill
+  deployed_files:
+  - .agents/skills/sympy
+  content_hash: sha256:d939548507d34d2fe3b4be9db169d8366a9e942d15e34a6c508fb7b337d30c61

--- a/tools/agent-skills/apm.yml
+++ b/tools/agent-skills/apm.yml
@@ -4,6 +4,8 @@ description: Maintainer-only external Agent Skill dependency manifest for privat
 targets:
   - agent-skills
 dependencies:
-  apm: []
+  apm:
+    # renovate: datasource=git-tags depName=K-Dense-AI/scientific-agent-skills
+    - K-Dense-AI/scientific-agent-skills/scientific-skills/sympy#v2.38.0
 devDependencies:
   apm: []


### PR DESCRIPTION
## Summary

Closes #271.
Part of #197 Phase 5.

This PR records the initial calculation backend decision for private maintainer workflows:

- Selects SymPy as the initial maintainer-local symbolic math backend.
- Pins `sympy==1.14.0` package-locally under `packages/calculation-executor` with `uv.lock`.
- Adds only the K-Dense SymPy Agent Skill subset to `tools/agent-skills/apm.yml` and records `apm.lock.yaml` with `virtual_path: scientific-skills/sympy`.
- Explicitly defers SageMath, MCP servers, statistics skills, and broad scientific skill bundles.
- Keeps SF6 official values, formulas, rounding rules, system mechanics, current facts, and public answer behavior outside repo calculation authority.

## Hermes / Boundary Notes

- Hermes was used as primary draft analyst for the backend selection recommendation.
- Hermes output was primary draft input only and is not canonical evidence.
- Provider Codex was not used by Hermes.
- No Hermes memory, sessions, local skills, raw transcripts, logs, caches, credentials, or profile state are committed.
- Local APM/uv installed directories are ignored and not committed.

## Validation

- `uv run --project packages/calculation-executor python -c "import sympy; print(sympy.__version__)"` -> `1.14.0`
- `uvx --from apm-cli apm install --only apm --target agent-skills --frozen`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-agent-toolchain.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-calculation-executor.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-v2-contracts.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 -Lane read-only`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1`
- `git diff --check`
- `git diff --check origin/main...HEAD`

## Intentionally Not Done

- No SageMath adoption.
- No MCP server adoption.
- No statistics skill adoption.
- No broad K-Dense skill bundle adoption.
- No public `sf6-agent` behavior changes.
- No generated frame-current or generated knowledge changes are intentionally included.