### PR TITLE
[v2.6] Add calculation backend handoff instructions

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -27,6 +27,7 @@ When `source_refs.path` points to a migrated legacy file, `source_revision` iden
 ## Human-Readable Contracts
 
 - `calculation-executor-trace.md`: boundary for calculation tools as executors and trace generators only.
+- `calculation-backend-handoff.schema.json`: schema for maintainer-only backend handoff instructions that stay outside SF6 formula authority.
 - `combo-notation.md`: notation rules for `evals/fixtures/combo-damage/*.yaml`.
 - `evidence-gate.md`: answer evidence authority boundaries for current facts, review claims, observations, and Hermes state.
 - `frame-current-runtime-assets.md`: runtime asset boundary for generated frame-current payloads.

--- a/contracts/calculation-backend-handoff.schema.json
+++ b/contracts/calculation-backend-handoff.schema.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sf6-knowledge-agent-kit.local/calculation-backend-handoff.schema.json",
+  "title": "Calculation Backend Handoff",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "handoff_id",
+    "handoff_schema_version",
+    "tracking_issue",
+    "backend_ref",
+    "backend_role",
+    "selected_dependency_ref",
+    "authority_status",
+    "public_answer_allowed",
+    "generated_reference_allowed",
+    "accepted_current_fact_authority",
+    "request_scope",
+    "calculation_intent",
+    "input_values",
+    "input_reference_refs",
+    "input_status",
+    "calculation_instruction",
+    "calculation_instruction_status",
+    "rounding_instruction",
+    "rounding_instruction_status",
+    "expected_trace_contract_ref",
+    "blocked_status_if_missing",
+    "uncertainty_or_hold_reasons",
+    "forbidden_uses",
+    "created_by",
+    "created_at"
+  ],
+  "properties": {
+    "handoff_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*$"
+    },
+    "handoff_schema_version": {
+      "const": "sf6-calculation-backend-handoff/v1"
+    },
+    "tracking_issue": {
+      "type": "string",
+      "pattern": "^#[0-9]+$"
+    },
+    "backend_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "backend_role": {
+      "enum": [
+        "trusted_external_symbolic_backend",
+        "maintainer_local_symbolic_backend"
+      ]
+    },
+    "selected_dependency_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "authority_status": {
+      "const": "operator_instruction_only"
+    },
+    "public_answer_allowed": {
+      "const": false
+    },
+    "generated_reference_allowed": {
+      "const": false
+    },
+    "accepted_current_fact_authority": {
+      "const": false
+    },
+    "request_scope": {
+      "type": "string",
+      "minLength": 1
+    },
+    "calculation_intent": {
+      "enum": [
+        "hypothetical_arithmetic_check",
+        "external_backend_instruction_check",
+        "damage_hidden_eval_candidate_check",
+        "frame_window_arithmetic",
+        "punish_window_arithmetic",
+        "oki_timing_arithmetic"
+      ]
+    },
+    "input_values": {
+      "type": "object"
+    },
+    "input_reference_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "input_status": {
+      "enum": [
+        "referenced",
+        "review_only",
+        "hypothetical",
+        "mixed",
+        "hold"
+      ]
+    },
+    "calculation_instruction": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "calculation_instruction_status": {
+      "enum": [
+        "external_backend_candidate",
+        "review_only",
+        "hypothetical",
+        "not_applicable",
+        "hold"
+      ]
+    },
+    "rounding_instruction": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "rounding_instruction_status": {
+      "enum": [
+        "external_backend_candidate",
+        "review_only",
+        "hypothetical",
+        "not_applicable",
+        "hold"
+      ]
+    },
+    "expected_trace_contract_ref": {
+      "const": "contracts/calculation-executor-trace.md"
+    },
+    "blocked_status_if_missing": {
+      "type": "array",
+      "items": {
+        "enum": [
+          "blocked_missing_input_reference",
+          "blocked_missing_calculation_instruction",
+          "blocked_missing_rounding_instruction",
+          "blocked_ambiguous_route",
+          "blocked_public_answer_boundary"
+        ]
+      },
+      "uniqueItems": true
+    },
+    "uncertainty_or_hold_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "forbidden_uses": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "created_by": {
+      "type": "string",
+      "minLength": 1
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/docs/architecture/calculation-backend-policy.md
+++ b/docs/architecture/calculation-backend-policy.md
@@ -87,6 +87,10 @@ Calculation outputs remain trace candidates. If an input, route mapping,
 formula-like instruction, or rounding instruction is missing or uncertain, the
 trace must remain hold / blocked rather than public answer authority.
 
+For reviewed maintainer handoff instruction artifacts, use
+`workflows/calculation-backend-handoff.md` and
+`contracts/calculation-backend-handoff.schema.json`.
+
 ## Not Committed
 
 Do not commit:

--- a/tests/fixtures/calculation-backend-handoff/hold-missing-instruction.json
+++ b/tests/fixtures/calculation-backend-handoff/hold-missing-instruction.json
@@ -1,0 +1,37 @@
+{
+  "handoff_id": "hold-missing-instruction",
+  "handoff_schema_version": "sf6-calculation-backend-handoff/v1",
+  "tracking_issue": "#273",
+  "backend_ref": "SymPy",
+  "backend_role": "maintainer_local_symbolic_backend",
+  "selected_dependency_ref": "tools/agent-skills/apm.lock.yaml#scientific-skills/sympy",
+  "authority_status": "operator_instruction_only",
+  "public_answer_allowed": false,
+  "generated_reference_allowed": false,
+  "accepted_current_fact_authority": false,
+  "request_scope": "Hold a maintainer calculation request when no reviewed backend instruction exists.",
+  "calculation_intent": "external_backend_instruction_check",
+  "input_values": {},
+  "input_reference_refs": [],
+  "input_status": "hold",
+  "calculation_instruction": null,
+  "calculation_instruction_status": "hold",
+  "rounding_instruction": null,
+  "rounding_instruction_status": "not_applicable",
+  "expected_trace_contract_ref": "contracts/calculation-executor-trace.md",
+  "blocked_status_if_missing": [
+    "blocked_missing_calculation_instruction"
+  ],
+  "uncertainty_or_hold_reasons": [
+    "No reviewed calculation instruction is available."
+  ],
+  "forbidden_uses": [
+    "not_formula_authority",
+    "not_rounding_authority",
+    "not_current_fact_authority",
+    "not_public_answer_behavior",
+    "must_not_feed_generated_references"
+  ],
+  "created_by": "fixture",
+  "created_at": "2026-05-18T00:00:00Z"
+}

--- a/tests/fixtures/calculation-backend-handoff/hold-missing-rounding-instruction.json
+++ b/tests/fixtures/calculation-backend-handoff/hold-missing-rounding-instruction.json
@@ -1,0 +1,40 @@
+{
+  "handoff_id": "hold-missing-rounding-instruction",
+  "handoff_schema_version": "sf6-calculation-backend-handoff/v1",
+  "tracking_issue": "#273",
+  "backend_ref": "SymPy",
+  "backend_role": "maintainer_local_symbolic_backend",
+  "selected_dependency_ref": "tools/agent-skills/apm.lock.yaml#scientific-skills/sympy",
+  "authority_status": "operator_instruction_only",
+  "public_answer_allowed": false,
+  "generated_reference_allowed": false,
+  "accepted_current_fact_authority": false,
+  "request_scope": "Hold a rounding-sensitive maintainer arithmetic request when no reviewed rounding instruction exists.",
+  "calculation_intent": "external_backend_instruction_check",
+  "input_values": {
+    "x": "hypothetical_symbol",
+    "y": "hypothetical_symbol"
+  },
+  "input_reference_refs": [],
+  "input_status": "hypothetical",
+  "calculation_instruction": "Use only the explicitly supplied hypothetical symbols x and y. Do not infer any SF6 mechanic.",
+  "calculation_instruction_status": "hypothetical",
+  "rounding_instruction": null,
+  "rounding_instruction_status": "hold",
+  "expected_trace_contract_ref": "contracts/calculation-executor-trace.md",
+  "blocked_status_if_missing": [
+    "blocked_missing_rounding_instruction"
+  ],
+  "uncertainty_or_hold_reasons": [
+    "Rounding behavior matters but no reviewed rounding instruction is available."
+  ],
+  "forbidden_uses": [
+    "not_formula_authority",
+    "not_rounding_authority",
+    "not_current_fact_authority",
+    "not_public_answer_behavior",
+    "must_not_feed_generated_references"
+  ],
+  "created_by": "fixture",
+  "created_at": "2026-05-18T00:00:00Z"
+}

--- a/tests/fixtures/calculation-backend-handoff/hypothetical-symbolic-check.json
+++ b/tests/fixtures/calculation-backend-handoff/hypothetical-symbolic-check.json
@@ -1,0 +1,38 @@
+{
+  "handoff_id": "hypothetical-symbolic-check",
+  "handoff_schema_version": "sf6-calculation-backend-handoff/v1",
+  "tracking_issue": "#273",
+  "backend_ref": "SymPy",
+  "backend_role": "maintainer_local_symbolic_backend",
+  "selected_dependency_ref": "tools/agent-skills/apm.lock.yaml#scientific-skills/sympy",
+  "authority_status": "operator_instruction_only",
+  "public_answer_allowed": false,
+  "generated_reference_allowed": false,
+  "accepted_current_fact_authority": false,
+  "request_scope": "Check an abstract symbolic expression without SF6 current values.",
+  "calculation_intent": "hypothetical_arithmetic_check",
+  "input_values": {
+    "x": "hypothetical_symbol",
+    "y": "hypothetical_symbol"
+  },
+  "input_reference_refs": [],
+  "input_status": "hypothetical",
+  "calculation_instruction": "Use SymPy symbols x and y to simplify the abstract expression (x + y) - y. Treat the result as hypothetical arithmetic only.",
+  "calculation_instruction_status": "hypothetical",
+  "rounding_instruction": null,
+  "rounding_instruction_status": "not_applicable",
+  "expected_trace_contract_ref": "contracts/calculation-executor-trace.md",
+  "blocked_status_if_missing": [],
+  "uncertainty_or_hold_reasons": [
+    "This fixture is hypothetical and does not contain SF6 current facts."
+  ],
+  "forbidden_uses": [
+    "not_formula_authority",
+    "not_rounding_authority",
+    "not_current_fact_authority",
+    "not_public_answer_behavior",
+    "must_not_feed_generated_references"
+  ],
+  "created_by": "fixture",
+  "created_at": "2026-05-18T00:00:00Z"
+}

--- a/tests/validation/run-all.ps1
+++ b/tests/validation/run-all.ps1
@@ -61,6 +61,7 @@ $readOnlyValidationScripts = @(
   'tests/validation/validate-deferred-distribution-retirement-plan.ps1',
   'tests/validation/validate-answer-orchestration-contracts.ps1',
   'tests/validation/validate-answer-smoke-fixtures.ps1',
+  'tests/validation/validate-calculation-backend-handoff.ps1',
   'tests/validation/validate-calculation-executor.ps1',
   'tests/validation/validate-normalization-aliases.ps1',
   'tests/validation/validate-normalization-runtime-assets.ps1',

--- a/tests/validation/schema-validation-manifest.json
+++ b/tests/validation/schema-validation-manifest.json
@@ -69,6 +69,14 @@
         "tests/fixtures/eval-score-reports/*.json"
       ],
       "notes": "Structural score report shape only; validate-eval-score-reports.ps1 remains semantic authority."
+    },
+    {
+      "id": "calculation_backend_handoffs",
+      "schema_path": "contracts/calculation-backend-handoff.schema.json",
+      "document_globs": [
+        "tests/fixtures/calculation-backend-handoff/*.json"
+      ],
+      "notes": "Structural calculation backend handoff shape only; validate-calculation-backend-handoff.ps1 remains semantic authority."
     }
   ]
 }

--- a/tests/validation/validate-calculation-backend-handoff.ps1
+++ b/tests/validation/validate-calculation-backend-handoff.ps1
@@ -1,0 +1,201 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$workflowPath = Join-Path $repoRoot 'workflows/calculation-backend-handoff.md'
+$schemaPath = Join-Path $repoRoot 'contracts/calculation-backend-handoff.schema.json'
+$fixtureRoot = Join-Path $repoRoot 'tests/fixtures/calculation-backend-handoff'
+
+function Add-Issue {
+  param(
+    [Parameter(Mandatory = $true)][ref]$Issues,
+    [Parameter(Mandatory = $true)][string]$Message
+  )
+  $Issues.Value += $Message
+}
+
+function Assert-Property {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  if (-not ($Object.PSObject.Properties.Name -contains $Name)) {
+    Add-Issue $Issues "$Context missing field: $Name"
+  }
+}
+
+$issues = @()
+
+if (-not (Test-Path -LiteralPath $workflowPath -PathType Leaf)) {
+  throw 'Missing calculation backend handoff workflow'
+}
+if (-not (Test-Path -LiteralPath $schemaPath -PathType Leaf)) {
+  throw 'Missing calculation backend handoff schema'
+}
+if (-not (Test-Path -LiteralPath $fixtureRoot -PathType Container)) {
+  throw 'Missing calculation backend handoff fixtures'
+}
+
+$workflowText = Get-Content -LiteralPath $workflowPath -Raw -Encoding UTF8
+foreach ($needle in @(
+  'operator instruction dependency',
+  'operator_instruction_only',
+  'not_formula_authority',
+  'not_rounding_authority',
+  'not_current_fact_authority',
+  'not_public_answer_behavior',
+  'must_not_feed_generated_references',
+  'contracts/calculation-executor-trace.md',
+  'Do not include real combo damage numbers',
+  'Do not commit Hermes memory'
+)) {
+  if ($workflowText -notmatch [regex]::Escape($needle)) {
+    Add-Issue ([ref]$issues) "workflows/calculation-backend-handoff.md missing boundary text: $needle"
+  }
+}
+
+$schemaText = Get-Content -LiteralPath $schemaPath -Raw -Encoding UTF8
+$schema = $schemaText | ConvertFrom-Json
+foreach ($field in @('$schema', '$id', 'title', 'required', 'properties')) {
+  Assert-Property $schema $field 'contracts/calculation-backend-handoff.schema.json' ([ref]$issues)
+}
+foreach ($needle in @(
+  'sf6-calculation-backend-handoff/v1',
+  'operator_instruction_only',
+  '"public_answer_allowed"',
+  '"const": false',
+  'blocked_missing_calculation_instruction',
+  'blocked_missing_rounding_instruction'
+)) {
+  if ($schemaText -notmatch [regex]::Escape($needle)) {
+    Add-Issue ([ref]$issues) "contracts/calculation-backend-handoff.schema.json missing required text: $needle"
+  }
+}
+
+$fixtureFiles = @(Get-ChildItem -LiteralPath $fixtureRoot -File -Filter '*.json' | Sort-Object Name)
+if ($fixtureFiles.Count -lt 3) {
+  Add-Issue ([ref]$issues) 'Expected at least three calculation backend handoff fixtures'
+}
+
+$requiredForbiddenUses = @(
+  'not_formula_authority',
+  'not_rounding_authority',
+  'not_current_fact_authority',
+  'not_public_answer_behavior',
+  'must_not_feed_generated_references'
+)
+$forbiddenText = @(
+  'accepted_formula',
+  'official_formula',
+  '"formula_authority": true',
+  '"rounding_authority": true',
+  '"current_fact_authority": true',
+  '"authority_status": "formula_authority"',
+  '"authority_status": "rounding_authority"',
+  '"authority_status": "current_fact_authority"',
+  '"public_answer_allowed": true',
+  '"generated_reference_allowed": true',
+  '"accepted_current_fact_authority": true',
+  'Hermes memory',
+  'raw transcript',
+  'credential',
+  'secret',
+  'token',
+  'provider output',
+  'local skill path'
+)
+
+foreach ($fixtureFile in $fixtureFiles) {
+  $relativePath = $fixtureFile.FullName.Substring($repoRoot.Length + 1).Replace('\', '/')
+  $rawText = Get-Content -LiteralPath $fixtureFile.FullName -Raw -Encoding UTF8
+
+  foreach ($forbidden in $forbiddenText) {
+    if ($rawText -match [regex]::Escape($forbidden)) {
+      Add-Issue ([ref]$issues) "$relativePath contains forbidden authority or local-state text: $forbidden"
+    }
+  }
+
+  try {
+    $fixture = $rawText | ConvertFrom-Json
+  } catch {
+    Add-Issue ([ref]$issues) "$relativePath is not valid JSON"
+    continue
+  }
+
+  foreach ($field in @(
+    'handoff_id',
+    'handoff_schema_version',
+    'tracking_issue',
+    'backend_ref',
+    'backend_role',
+    'selected_dependency_ref',
+    'authority_status',
+    'public_answer_allowed',
+    'generated_reference_allowed',
+    'accepted_current_fact_authority',
+    'request_scope',
+    'calculation_intent',
+    'input_values',
+    'input_reference_refs',
+    'input_status',
+    'calculation_instruction',
+    'calculation_instruction_status',
+    'rounding_instruction',
+    'rounding_instruction_status',
+    'expected_trace_contract_ref',
+    'blocked_status_if_missing',
+    'uncertainty_or_hold_reasons',
+    'forbidden_uses',
+    'created_by',
+    'created_at'
+  )) {
+    Assert-Property $fixture $field $relativePath ([ref]$issues)
+  }
+
+  if ($fixture.handoff_schema_version -ne 'sf6-calculation-backend-handoff/v1') {
+    Add-Issue ([ref]$issues) "$relativePath has wrong handoff_schema_version"
+  }
+  if ($fixture.authority_status -ne 'operator_instruction_only') {
+    Add-Issue ([ref]$issues) "$relativePath must use authority_status operator_instruction_only"
+  }
+  if ($fixture.public_answer_allowed -ne $false) {
+    Add-Issue ([ref]$issues) "$relativePath must not allow public answers"
+  }
+  if ($fixture.generated_reference_allowed -ne $false) {
+    Add-Issue ([ref]$issues) "$relativePath must not feed generated references"
+  }
+  if ($fixture.accepted_current_fact_authority -ne $false) {
+    Add-Issue ([ref]$issues) "$relativePath must not be accepted current-fact authority"
+  }
+  if ($fixture.expected_trace_contract_ref -ne 'contracts/calculation-executor-trace.md') {
+    Add-Issue ([ref]$issues) "$relativePath must point to calculation executor trace contract"
+  }
+
+  foreach ($requiredUse in $requiredForbiddenUses) {
+    if (@($fixture.forbidden_uses) -notcontains $requiredUse) {
+      Add-Issue ([ref]$issues) "$relativePath missing forbidden_uses entry: $requiredUse"
+    }
+  }
+
+  if ($fixture.calculation_instruction_status -eq 'hold' -and @($fixture.blocked_status_if_missing) -notcontains 'blocked_missing_calculation_instruction') {
+    Add-Issue ([ref]$issues) "$relativePath hold calculation instruction must block missing calculation instruction"
+  }
+  if ($fixture.rounding_instruction_status -eq 'hold' -and $null -eq $fixture.rounding_instruction -and @($fixture.blocked_status_if_missing) -notcontains 'blocked_missing_rounding_instruction') {
+    Add-Issue ([ref]$issues) "$relativePath hold rounding instruction must block missing rounding instruction"
+  }
+  if ($fixture.calculation_instruction_status -eq 'not_applicable' -and $null -ne $fixture.calculation_instruction) {
+    Add-Issue ([ref]$issues) "$relativePath not_applicable calculation instruction must be null"
+  }
+  if ($fixture.rounding_instruction_status -eq 'not_applicable' -and $null -ne $fixture.rounding_instruction) {
+    Add-Issue ([ref]$issues) "$relativePath not_applicable rounding instruction must be null"
+  }
+}
+
+if ($issues.Count -gt 0) {
+  throw ($issues -join '; ')
+}
+
+Write-Host 'Calculation backend handoff OK'

--- a/tests/validation/validate-v2-contracts.ps1
+++ b/tests/validation/validate-v2-contracts.ps1
@@ -13,6 +13,7 @@ $requiredJsonSchemas = @(
   'contracts/answer-intent.schema.json',
   'contracts/evidence-card.schema.json',
   'contracts/answer-plan.schema.json',
+  'contracts/calculation-backend-handoff.schema.json',
   'contracts/calculation-trace.schema.json',
   'contracts/normalization-aliases.schema.json',
   'contracts/agent-toolchain.schema.json',

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -13,6 +13,7 @@ Workflow docs are readable by humans and agents without requiring a skill runtim
 - [Hermes ingest profile setup](hermes-ingest-profile-setup.md)
 - [Media scratch cache policy](media-scratch-cache-policy.md)
 - [System mechanics fact workflow](system-mechanics-fact-workflow.md)
+- [Calculation backend handoff](calculation-backend-handoff.md)
 - [Update frame data](update-frame-data.md)
 - [Ingest article](ingest-article.md)
 - [Review claims](review-claims.md)

--- a/workflows/calculation-backend-handoff.md
+++ b/workflows/calculation-backend-handoff.md
@@ -1,0 +1,142 @@
+# Calculation Backend Handoff Workflow
+
+この workflow は、SF6 固有に見える計算要求を、repo-owned formula や
+rounding authority にせず、review 済み maintainer handoff instruction として
+選定 backend へ渡すための手順です。
+
+v2.6 の初期既定 backend は SymPy です。SymPy と pinned K-Dense SymPy Agent
+Skill は executor / operator instruction dependency であり、SF6 公式値、
+式、丸め規則、current facts、public answer behavior を提供しません。
+
+## When To Use
+
+Use this workflow when a maintainer needs arithmetic, symbolic checking, or
+trace preparation for one of these requests:
+
+- review-only arithmetic consistency checks;
+- hypothetical symbolic examples;
+- frame-window, punish-window, or oki timing arithmetic where all inputs and
+  instructions are explicitly supplied;
+- damage-hidden eval experiments that must stay non-authoritative.
+
+Do not use this workflow to define accepted SF6 formulas, rounding rules,
+current system mechanics, or public answer behavior.
+
+## Handoff Flow
+
+```text
+maintainer request
+  -> calculation backend handoff artifact
+  -> selected backend/operator instruction
+  -> calculation trace candidate
+  -> hold/review boundary
+```
+
+The handoff artifact is pre-execution context. It tells the selected backend
+what it may compute and when it must hold. The handoff is not calculation
+truth.
+
+## Required Boundary
+
+Every handoff must state:
+
+- `authority_status: operator_instruction_only`
+- `public_answer_allowed: false`
+- `generated_reference_allowed: false`
+- `accepted_current_fact_authority: false`
+
+Every handoff must include forbidden-use text equivalent to:
+
+- `not_formula_authority`
+- `not_rounding_authority`
+- `not_current_fact_authority`
+- `not_public_answer_behavior`
+- `must_not_feed_generated_references`
+
+## Handoff Template
+
+```json
+{
+  "handoff_id": "example-hold-missing-instruction",
+  "handoff_schema_version": "sf6-calculation-backend-handoff/v1",
+  "tracking_issue": "#273",
+  "backend_ref": "SymPy",
+  "backend_role": "maintainer_local_symbolic_backend",
+  "selected_dependency_ref": "tools/agent-skills/apm.lock.yaml#scientific-skills/sympy",
+  "authority_status": "operator_instruction_only",
+  "public_answer_allowed": false,
+  "generated_reference_allowed": false,
+  "accepted_current_fact_authority": false,
+  "request_scope": "Review-only maintainer calculation handoff.",
+  "calculation_intent": "external_backend_instruction_check",
+  "input_values": {},
+  "input_reference_refs": [],
+  "input_status": "hold",
+  "calculation_instruction": null,
+  "calculation_instruction_status": "hold",
+  "rounding_instruction": null,
+  "rounding_instruction_status": "hold",
+  "expected_trace_contract_ref": "contracts/calculation-executor-trace.md",
+  "blocked_status_if_missing": [
+    "blocked_missing_calculation_instruction",
+    "blocked_missing_rounding_instruction"
+  ],
+  "uncertainty_or_hold_reasons": [
+    "No reviewed calculation instruction is available.",
+    "No reviewed rounding instruction is available."
+  ],
+  "forbidden_uses": [
+    "not_formula_authority",
+    "not_rounding_authority",
+    "not_current_fact_authority",
+    "not_public_answer_behavior",
+    "must_not_feed_generated_references"
+  ],
+  "created_by": "maintainer",
+  "created_at": "2026-05-18T00:00:00Z"
+}
+```
+
+## Hold Rules
+
+Use hold / blocked behavior when:
+
+- the calculation instruction is missing or ambiguous;
+- rounding, floor, ceiling, truncation, minimum guarantee, or tie behavior
+  matters but no reviewed rounding instruction exists;
+- route mapping, action mapping, hit mapping, timing, or move identity is
+  unresolved;
+- the request asks the backend to infer official SF6 formula or current truth;
+- the request would support a public current-fact answer.
+
+The matching calculation trace should use the statuses from
+`contracts/calculation-executor-trace.md`, such as
+`blocked_missing_calculation_instruction`,
+`blocked_missing_rounding_instruction`, `blocked_ambiguous_route`, or
+`blocked_public_answer_boundary`.
+
+## Safe Examples
+
+Safe handoff examples use only:
+
+- empty hold cases;
+- abstract symbols such as `x`, `y`, and `z`;
+- generic arithmetic that is not labeled as SF6 current truth;
+- review-only instructions that explicitly preserve hold behavior.
+
+Do not include real combo damage numbers, scaling percentages, minimum
+guarantee values, route-level formulas, current patch exceptions, or
+character/move-specific formula examples.
+
+## Artifact Locations
+
+- schema: `contracts/calculation-backend-handoff.schema.json`
+- safe fixtures: `tests/fixtures/calculation-backend-handoff/`
+- semantic validator: `tests/validation/validate-calculation-backend-handoff.ps1`
+- downstream trace contract: `contracts/calculation-executor-trace.md`
+
+## Not Committed
+
+Do not commit Hermes memory, sessions, local skills, raw transcripts, Curator
+output, checkpoints, logs, caches, credentials, provider output, `.env`, or
+`auth.json` as part of a handoff.

--- a/workflows/system-mechanics-fact-workflow.md
+++ b/workflows/system-mechanics-fact-workflow.md
@@ -144,6 +144,11 @@ guess.
 
 See `contracts/calculation-executor-trace.md`.
 
+When a maintainer needs to hand a calculation request to the selected backend,
+use `workflows/calculation-backend-handoff.md`. That handoff is operator
+instruction only and must not become accepted formula, rounding, current-fact,
+or public answer authority.
+
 ## Future contract decision
 
 A future architecture decision may reopen system-mechanics modeling, but v2.6 does not create an accepted SF6 formula or rounding authority surface.


### PR DESCRIPTION
Closes #273.

## Summary
- Add a calculation backend handoff workflow for SF6-looking calculation requests that must stay operator-instruction-only.
- Add a JSON schema, safe fixtures, schema-manifest coverage, and a semantic validator.
- Cross-link the policy and system mechanics workflow so SymPy/SageMath-style backends stay executors, not repo authority.

## Hermes / Boundary Notes
- Hermes was used as the primary draft analyst for this roadmap item.
- Hermes output was treated as primary draft input only, then converted into reviewed repo artifacts.
- Provider Codex was not used by Hermes for this task.
- No Hermes memory, sessions, local skills, raw transcript, Curator output, checkpoints, logs, caches, credentials, current facts, official_raw, generated references, frame-current assets, normalization assets, or public sf6-agent behavior were committed or changed.

## Validation
- `tests/validation/validate-calculation-backend-handoff.ps1`
- `tests/validation/validate-json-schema-manifest.ps1`
- `tests/validation/validate-v2-contracts.ps1`
- `tests/validation/validate-calculation-executor.ps1`
- `tests/validation/validate-doc-links.ps1`
- `tests/validation/run-all.ps1`
- `git diff --cached --check`
- `git diff --check origin/main...HEAD`

## Intentionally Not Done
- Did not define accepted SF6 formulas, official values, or rounding rules.
- Did not add a public answer calculator.
- Did not add SageMath or MCP runtime integration.
- Did not change generated/runtime/current-fact surfaces.
