### PR TITLE
[v2.6] Add Hermes delegation sanitized trace contract

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -31,6 +31,7 @@ When `source_refs.path` points to a migrated legacy file, `source_revision` iden
 - `combo-notation.md`: notation rules for `evals/fixtures/combo-damage/*.yaml`.
 - `evidence-gate.md`: answer evidence authority boundaries for current facts, review claims, observations, and Hermes state.
 - `frame-current-runtime-assets.md`: runtime asset boundary for generated frame-current payloads.
+- `hermes-delegation-sanitized-trace.md`: boundary for recording sanitized Codex app / Hermes / provider Codex delegation metadata without local state or raw output.
 - `video-observation.md`: timestamped video observation artifact contract.
 - `web-research-policy.md`: web source ranking, freshness, and current-fact conflict policy.
 

--- a/contracts/hermes-delegation-sanitized-trace.md
+++ b/contracts/hermes-delegation-sanitized-trace.md
@@ -1,0 +1,67 @@
+# Hermes Delegation Sanitized Trace Contract
+
+この contract は、Codex app -> Hermes -> optional provider Codex の
+delegation / handoff を、repo に残せる sanitized metadata として記録する
+ための境界を定義します。
+
+Sanitized trace は orchestration metadata only として扱う。
+
+Sanitized trace は、Hermes-first orchestration がどの issue scope で行われ、
+どの role boundary と validator boundary で repo artifact に変換されたかを
+示す review artifact です。Hermes output、provider output、local state、
+raw command output、または SF6 gameplay fact の証拠ではありません。
+
+## Authority Boundary
+
+Sanitized traces may record:
+
+- `analysis_mode` が `hermes_primary` か `codex_fallback` か。
+- Codex app が `hermes_operator` / `boundary_auditor` /
+  `artifact_converter` / `validator_executor` として動いたこと。
+- Hermes が primary draft input を返したこと、または fallback reason が
+  記録されたこと。
+- provider Codex を使った場合に、executor-only の task/output summary が
+  used / rejected として整理されたこと。
+- どの repo artifact に変換されたか、どの validator が必要だったか。
+- raw/local/private state を commit していないという sanitization assertion。
+
+Sanitized traces must not record:
+
+- raw Hermes transcript
+- raw provider output
+- raw command output or tool logs
+- Hermes memory, sessions, local skills, Curator output, Kanban state,
+  checkpoints, logs, caches, profile state, `.env`, or `auth.json`
+- credentials, secrets, tokens, API keys, OAuth material, or private URLs
+- screenshots, videos, audio, binary media, or local browser/cache artifacts
+- SF6 current facts, official values, formulas, rounding rules, or analysis
+  correctness claims
+
+## Required Behavior
+
+- `schema_version` must be `hermes-delegation-sanitized-trace/v1`.
+- `analysis_mode: hermes_primary` requires Hermes primary analyst role and
+  Codex app operator/auditor role.
+- `analysis_mode: codex_fallback` requires `fallback.occurred: true` and a
+  non-empty fallback reason.
+- provider Codex, when used, must remain a bounded executor and must not be
+  recorded as final authority.
+- `post_delegation_review.hermes_output_is_draft_input` must be true.
+- `post_delegation_review.canonical_promotion_allowed` must be false.
+- `validators.live_hermes_required` must be false.
+- All `sanitization_assertions` must remain false for unsafe content.
+
+## Relationship To Delegation Workflow
+
+`workflows/codex-to-hermes-delegation.md` defines request and response shape.
+This contract defines the sanitized trace that may be committed after that
+workflow is used. A trace is acceptable only after Codex has reviewed Hermes
+draft output against issue scope, converted supported material into repo
+artifacts, and run the relevant validators.
+
+## Validation
+
+- JSON shape: `contracts/hermes-delegation-sanitized-trace.schema.json`
+- Fixtures: `tests/fixtures/hermes-delegation-sanitized-trace/`
+- Semantic validator:
+  `tests/validation/validate-hermes-delegation-sanitized-traces.ps1`

--- a/contracts/hermes-delegation-sanitized-trace.schema.json
+++ b/contracts/hermes-delegation-sanitized-trace.schema.json
@@ -1,0 +1,526 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sf6-knowledge-agent-kit.local/hermes-delegation-sanitized-trace.schema.json",
+  "title": "Hermes Delegation Sanitized Trace",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "trace_id",
+    "trace_kind",
+    "tracking_issue",
+    "target_issue",
+    "analysis_mode",
+    "created_at",
+    "created_from",
+    "delegation_summary",
+    "role_summary",
+    "sanitized_inputs",
+    "sanitized_hermes_result",
+    "provider_codex_summary",
+    "fallback",
+    "post_delegation_review",
+    "artifact_conversion",
+    "validators",
+    "expected_boundary_outcome",
+    "sanitization_assertions"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "hermes-delegation-sanitized-trace/v1"
+    },
+    "trace_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*$"
+    },
+    "trace_kind": {
+      "enum": [
+        "hermes_primary_delegation",
+        "provider_executor_summary",
+        "codex_fallback",
+        "post_delegation_review"
+      ]
+    },
+    "tracking_issue": {
+      "type": "string",
+      "pattern": "^#[0-9]+$"
+    },
+    "target_issue": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^#[0-9]+$"
+    },
+    "analysis_mode": {
+      "enum": [
+        "hermes_primary",
+        "codex_fallback"
+      ]
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "created_from": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_kind",
+        "source_refs"
+      ],
+      "properties": {
+        "source_kind": {
+          "enum": [
+            "repo_artifact",
+            "issue_scope",
+            "pr_body",
+            "maintainer_handoff",
+            "dry_run_fixture"
+          ]
+        },
+        "source_refs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "delegation_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target_scope_summary",
+        "requested_artifact_type",
+        "allowed_outputs",
+        "forbidden_outputs",
+        "authority_boundaries"
+      ],
+      "properties": {
+        "target_scope_summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "requested_artifact_type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "allowed_outputs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "forbidden_outputs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "authority_boundaries": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "role_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "codex_app_role",
+        "hermes_role",
+        "provider_codex_role"
+      ],
+      "properties": {
+        "codex_app_role": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "hermes_role": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "provider_codex_role": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "sanitized_inputs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "input_kind",
+          "ref",
+          "summary",
+          "canonicality"
+        ],
+        "properties": {
+          "input_kind": {
+            "type": "string",
+            "minLength": 1
+          },
+          "ref": {
+            "type": "string",
+            "minLength": 1
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1
+          },
+          "canonicality": {
+            "enum": [
+              "canonical",
+              "review_input",
+              "non_canonical"
+            ]
+          }
+        }
+      }
+    },
+    "sanitized_hermes_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "result_status",
+        "summary",
+        "proposed_artifacts",
+        "source_refs",
+        "evidence_candidate_notes",
+        "uncertainty_or_hold_reasons",
+        "boundary_notes",
+        "follow_up_recommendations"
+      ],
+      "properties": {
+        "result_status": {
+          "enum": [
+            "draft_received",
+            "hold",
+            "fallback_required",
+            "rejected"
+          ]
+        },
+        "summary": {
+          "type": "string"
+        },
+        "proposed_artifacts": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "source_refs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "evidence_candidate_notes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "uncertainty_or_hold_reasons": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "boundary_notes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "follow_up_recommendations": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "provider_codex_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "used",
+        "task_kinds",
+        "outputs_used",
+        "outputs_rejected",
+        "remained_executor"
+      ],
+      "properties": {
+        "used": {
+          "type": "boolean"
+        },
+        "task_kinds": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "outputs_used": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "outputs_rejected": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "remained_executor": {
+          "type": "boolean"
+        }
+      }
+    },
+    "fallback": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "occurred",
+        "reason",
+        "recorded_in"
+      ],
+      "properties": {
+        "occurred": {
+          "type": "boolean"
+        },
+        "reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "recorded_in": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "post_delegation_review": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "hermes_output_is_draft_input",
+        "canonical_promotion_allowed",
+        "requires_codex_review",
+        "requires_validators",
+        "provider_codex_final_authority",
+        "local_state_committed",
+        "raw_transcript_committed",
+        "credentials_committed",
+        "provider_raw_output_committed"
+      ],
+      "properties": {
+        "hermes_output_is_draft_input": {
+          "const": true
+        },
+        "canonical_promotion_allowed": {
+          "const": false
+        },
+        "requires_codex_review": {
+          "const": true
+        },
+        "requires_validators": {
+          "const": true
+        },
+        "provider_codex_final_authority": {
+          "const": false
+        },
+        "local_state_committed": {
+          "const": false
+        },
+        "raw_transcript_committed": {
+          "const": false
+        },
+        "credentials_committed": {
+          "const": false
+        },
+        "provider_raw_output_committed": {
+          "const": false
+        }
+      }
+    },
+    "artifact_conversion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "converted_to_repo_artifact",
+        "artifact_refs",
+        "conversion_notes",
+        "not_promoted_reason"
+      ],
+      "properties": {
+        "converted_to_repo_artifact": {
+          "type": "boolean"
+        },
+        "artifact_refs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "conversion_notes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "not_promoted_reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "validators": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "required",
+        "reported",
+        "skipped",
+        "live_hermes_required"
+      ],
+      "properties": {
+        "required": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "reported": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "skipped": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "validator",
+              "reason"
+            ],
+            "properties": {
+              "validator": {
+                "type": "string",
+                "minLength": 1
+              },
+              "reason": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        },
+        "live_hermes_required": {
+          "const": false
+        }
+      }
+    },
+    "expected_boundary_outcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "reason"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "accept_trace",
+            "reject_trace",
+            "hold",
+            "metadata_only"
+          ]
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "sanitization_assertions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contains_raw_transcript",
+        "contains_local_state",
+        "contains_credentials",
+        "contains_provider_raw_output",
+        "contains_tool_raw_log",
+        "contains_binary_asset_path",
+        "requires_live_hermes",
+        "requires_live_provider_execution"
+      ],
+      "properties": {
+        "contains_raw_transcript": {
+          "const": false
+        },
+        "contains_local_state": {
+          "const": false
+        },
+        "contains_credentials": {
+          "const": false
+        },
+        "contains_provider_raw_output": {
+          "const": false
+        },
+        "contains_tool_raw_log": {
+          "const": false
+        },
+        "contains_binary_asset_path": {
+          "const": false
+        },
+        "requires_live_hermes": {
+          "const": false
+        },
+        "requires_live_provider_execution": {
+          "const": false
+        }
+      }
+    }
+  }
+}

--- a/docs/architecture/codex-hermes-bridge-policy.md
+++ b/docs/architecture/codex-hermes-bridge-policy.md
@@ -63,6 +63,12 @@ Hermes output is non-canonical, but for delegated analysis tasks it is the
 primary draft input. Codex must review that draft against repo boundaries and
 convert only in-scope, supported material into repo artifacts.
 
+If the delegation itself needs to be recorded as a reusable repo artifact,
+use the sanitized trace contract in
+`contracts/hermes-delegation-sanitized-trace.md`. That trace is orchestration
+and handoff metadata only; it is not SF6 fact authority, analysis correctness
+evidence, raw Hermes output, or provider raw output.
+
 Codex-only analysis for Hermes-first work is fallback behavior. It is allowed
 only when Hermes is unavailable or unconfigured, the required Hermes capability
 is unavailable or unverified, the target issue explicitly requests Codex-only

--- a/tests/fixtures/hermes-delegation-sanitized-trace/invalid/binary-media-path.json
+++ b/tests/fixtures/hermes-delegation-sanitized-trace/invalid/binary-media-path.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "hermes-delegation-sanitized-trace/v1",
+  "trace_id": "binary-media-path",
+  "trace_kind": "post_delegation_review",
+  "tracking_issue": "#197",
+  "target_issue": "#275",
+  "analysis_mode": "hermes_primary",
+  "created_at": "2026-05-18T00:00:00Z",
+  "unsafe_example": "scratch/example.mp4"
+}

--- a/tests/fixtures/hermes-delegation-sanitized-trace/invalid/live-hermes-required.json
+++ b/tests/fixtures/hermes-delegation-sanitized-trace/invalid/live-hermes-required.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "hermes-delegation-sanitized-trace/v1",
+  "trace_id": "live-hermes-required",
+  "trace_kind": "hermes_primary_delegation",
+  "tracking_issue": "#197",
+  "target_issue": "#275",
+  "analysis_mode": "hermes_primary",
+  "created_at": "2026-05-18T00:00:00Z",
+  "validators": {
+    "required": [],
+    "reported": [],
+    "skipped": [],
+    "live_hermes_required": true
+  },
+  "sanitization_assertions": {
+    "contains_raw_transcript": false,
+    "contains_local_state": false,
+    "contains_credentials": false,
+    "contains_provider_raw_output": false,
+    "contains_tool_raw_log": false,
+    "contains_binary_asset_path": false,
+    "requires_live_hermes": true,
+    "requires_live_provider_execution": false
+  }
+}

--- a/tests/fixtures/hermes-delegation-sanitized-trace/invalid/local-state-path.json
+++ b/tests/fixtures/hermes-delegation-sanitized-trace/invalid/local-state-path.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "hermes-delegation-sanitized-trace/v1",
+  "trace_id": "local-state-path",
+  "trace_kind": "post_delegation_review",
+  "tracking_issue": "#197",
+  "target_issue": "#275",
+  "analysis_mode": "hermes_primary",
+  "created_at": "2026-05-18T00:00:00Z",
+  "unsafe_example": "~/.hermes/sessions/example.json and ~/.hermes/checkpoints/example"
+}

--- a/tests/fixtures/hermes-delegation-sanitized-trace/invalid/provider-raw-output.json
+++ b/tests/fixtures/hermes-delegation-sanitized-trace/invalid/provider-raw-output.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "hermes-delegation-sanitized-trace/v1",
+  "trace_id": "provider-raw-output",
+  "trace_kind": "provider_executor_summary",
+  "tracking_issue": "#197",
+  "target_issue": "#275",
+  "analysis_mode": "hermes_primary",
+  "created_at": "2026-05-18T00:00:00Z",
+  "unsafe_example": "provider raw output placeholder; BEGIN LOG placeholder; END LOG placeholder"
+}

--- a/tests/fixtures/hermes-delegation-sanitized-trace/invalid/raw-transcript-marker.json
+++ b/tests/fixtures/hermes-delegation-sanitized-trace/invalid/raw-transcript-marker.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "hermes-delegation-sanitized-trace/v1",
+  "trace_id": "raw-transcript-marker",
+  "trace_kind": "post_delegation_review",
+  "tracking_issue": "#197",
+  "target_issue": "#275",
+  "analysis_mode": "hermes_primary",
+  "created_at": "2026-05-18T00:00:00Z",
+  "unsafe_example": "RAW TRANSCRIPT marker only; assistant: placeholder; user: placeholder; tool_call placeholder"
+}

--- a/tests/fixtures/hermes-delegation-sanitized-trace/valid/codex-fallback-recorded.json
+++ b/tests/fixtures/hermes-delegation-sanitized-trace/valid/codex-fallback-recorded.json
@@ -1,0 +1,122 @@
+{
+  "schema_version": "hermes-delegation-sanitized-trace/v1",
+  "trace_id": "codex-fallback-recorded",
+  "trace_kind": "codex_fallback",
+  "tracking_issue": "#197",
+  "target_issue": "#275",
+  "analysis_mode": "codex_fallback",
+  "created_at": "2026-05-18T00:00:00Z",
+  "created_from": {
+    "source_kind": "dry_run_fixture",
+    "source_refs": [
+      "workflows/codex-to-hermes-delegation.md"
+    ]
+  },
+  "delegation_summary": {
+    "target_scope_summary": "Record that Hermes delegation could not complete and fallback was used.",
+    "requested_artifact_type": "fallback trace fixture",
+    "allowed_outputs": [
+      "fallback reason",
+      "review boundary",
+      "validator summary"
+    ],
+    "forbidden_outputs": [
+      "claiming Hermes-first completion",
+      "unrecorded fallback",
+      "canonical promotion without review"
+    ],
+    "authority_boundaries": [
+      "Codex fallback requires a recorded reason.",
+      "Fallback does not claim Hermes primary analysis."
+    ]
+  },
+  "role_summary": {
+    "codex_app_role": [
+      "hermes_operator",
+      "boundary_auditor",
+      "artifact_converter",
+      "validator_executor"
+    ],
+    "hermes_role": [],
+    "provider_codex_role": []
+  },
+  "sanitized_inputs": [
+    {
+      "input_kind": "workflow",
+      "ref": "workflows/codex-to-hermes-delegation.md",
+      "summary": "Fallback reason requirement.",
+      "canonicality": "canonical"
+    }
+  ],
+  "sanitized_hermes_result": {
+    "result_status": "fallback_required",
+    "summary": "Hermes delegation did not complete for this fixture.",
+    "proposed_artifacts": [],
+    "source_refs": [],
+    "evidence_candidate_notes": [],
+    "uncertainty_or_hold_reasons": [
+      "Hermes unavailable or unconfigured."
+    ],
+    "boundary_notes": [
+      "This trace does not claim Hermes primary analysis."
+    ],
+    "follow_up_recommendations": [
+      "Retry Hermes when the configured profile is available."
+    ]
+  },
+  "provider_codex_summary": {
+    "used": false,
+    "task_kinds": [],
+    "outputs_used": [],
+    "outputs_rejected": [],
+    "remained_executor": true
+  },
+  "fallback": {
+    "occurred": true,
+    "reason": "Hermes unavailable or unconfigured in this dry-run fixture.",
+    "recorded_in": "#275"
+  },
+  "post_delegation_review": {
+    "hermes_output_is_draft_input": true,
+    "canonical_promotion_allowed": false,
+    "requires_codex_review": true,
+    "requires_validators": true,
+    "provider_codex_final_authority": false,
+    "local_state_committed": false,
+    "raw_transcript_committed": false,
+    "credentials_committed": false,
+    "provider_raw_output_committed": false
+  },
+  "artifact_conversion": {
+    "converted_to_repo_artifact": true,
+    "artifact_refs": [
+      "tests/fixtures/hermes-delegation-sanitized-trace/valid/codex-fallback-recorded.json"
+    ],
+    "conversion_notes": [
+      "Fallback was recorded explicitly."
+    ],
+    "not_promoted_reason": null
+  },
+  "validators": {
+    "required": [
+      "tests/validation/validate-hermes-delegation-sanitized-traces.ps1"
+    ],
+    "reported": [],
+    "skipped": [],
+    "live_hermes_required": false
+  },
+  "expected_boundary_outcome": {
+    "status": "metadata_only",
+    "reason": "The fixture records fallback metadata and does not claim Hermes-first completion."
+  },
+  "sanitization_assertions": {
+    "contains_raw_transcript": false,
+    "contains_local_state": false,
+    "contains_credentials": false,
+    "contains_provider_raw_output": false,
+    "contains_tool_raw_log": false,
+    "contains_binary_asset_path": false,
+    "requires_live_hermes": false,
+    "requires_live_provider_execution": false
+  }
+}

--- a/tests/fixtures/hermes-delegation-sanitized-trace/valid/hermes-primary-delegation.json
+++ b/tests/fixtures/hermes-delegation-sanitized-trace/valid/hermes-primary-delegation.json
@@ -1,0 +1,139 @@
+{
+  "schema_version": "hermes-delegation-sanitized-trace/v1",
+  "trace_id": "hermes-primary-delegation",
+  "trace_kind": "hermes_primary_delegation",
+  "tracking_issue": "#197",
+  "target_issue": "#275",
+  "analysis_mode": "hermes_primary",
+  "created_at": "2026-05-18T00:00:00Z",
+  "created_from": {
+    "source_kind": "dry_run_fixture",
+    "source_refs": [
+      "workflows/codex-to-hermes-delegation.md",
+      "docs/architecture/codex-hermes-bridge-policy.md"
+    ]
+  },
+  "delegation_summary": {
+    "target_scope_summary": "Define sanitized trace metadata for Hermes-first delegation without storing private Hermes state.",
+    "requested_artifact_type": "contract fixture",
+    "allowed_outputs": [
+      "sanitized delegation summary",
+      "role boundary summary",
+      "validator summary"
+    ],
+    "forbidden_outputs": [
+      "private Hermes state",
+      "provider final authority",
+      "current fact changes",
+      "public adapter behavior changes"
+    ],
+    "authority_boundaries": [
+      "Hermes output is primary draft input only.",
+      "Repo artifacts become reusable only after review and validation.",
+      "This trace records orchestration metadata only."
+    ]
+  },
+  "role_summary": {
+    "codex_app_role": [
+      "hermes_operator",
+      "boundary_auditor",
+      "artifact_converter",
+      "validator_executor"
+    ],
+    "hermes_role": [
+      "primary_analyst",
+      "orchestrator"
+    ],
+    "provider_codex_role": []
+  },
+  "sanitized_inputs": [
+    {
+      "input_kind": "workflow",
+      "ref": "workflows/codex-to-hermes-delegation.md",
+      "summary": "Reviewed request and response shape for Codex-to-Hermes delegation.",
+      "canonicality": "canonical"
+    }
+  ],
+  "sanitized_hermes_result": {
+    "result_status": "draft_received",
+    "summary": "Hermes proposed a contract, fixtures, and validator for sanitized delegation traces.",
+    "proposed_artifacts": [
+      "contracts/hermes-delegation-sanitized-trace.md",
+      "contracts/hermes-delegation-sanitized-trace.schema.json",
+      "tests/validation/validate-hermes-delegation-sanitized-traces.ps1"
+    ],
+    "source_refs": [
+      "AGENTS.md",
+      "workflows/codex-to-hermes-delegation.md"
+    ],
+    "evidence_candidate_notes": [
+      "The trace is handoff metadata only.",
+      "The trace does not prove SF6 facts or analysis correctness."
+    ],
+    "uncertainty_or_hold_reasons": [
+      "Live Hermes capability remains maintainer-environment dependent."
+    ],
+    "boundary_notes": [
+      "No current facts are changed.",
+      "No public adapter behavior is changed."
+    ],
+    "follow_up_recommendations": [
+      "Use the validator when adding future sanitized traces."
+    ]
+  },
+  "provider_codex_summary": {
+    "used": false,
+    "task_kinds": [],
+    "outputs_used": [],
+    "outputs_rejected": [],
+    "remained_executor": true
+  },
+  "fallback": {
+    "occurred": false,
+    "reason": null,
+    "recorded_in": null
+  },
+  "post_delegation_review": {
+    "hermes_output_is_draft_input": true,
+    "canonical_promotion_allowed": false,
+    "requires_codex_review": true,
+    "requires_validators": true,
+    "provider_codex_final_authority": false,
+    "local_state_committed": false,
+    "raw_transcript_committed": false,
+    "credentials_committed": false,
+    "provider_raw_output_committed": false
+  },
+  "artifact_conversion": {
+    "converted_to_repo_artifact": true,
+    "artifact_refs": [
+      "contracts/hermes-delegation-sanitized-trace.md"
+    ],
+    "conversion_notes": [
+      "Only a sanitized summary was converted."
+    ],
+    "not_promoted_reason": null
+  },
+  "validators": {
+    "required": [
+      "tests/validation/validate-hermes-delegation-sanitized-traces.ps1"
+    ],
+    "reported": [],
+    "skipped": [],
+    "live_hermes_required": false
+  },
+  "expected_boundary_outcome": {
+    "status": "accept_trace",
+    "reason": "The fixture records only sanitized orchestration metadata."
+  },
+  "sanitization_assertions": {
+    "contains_raw_transcript": false,
+    "contains_local_state": false,
+    "contains_credentials": false,
+    "contains_provider_raw_output": false,
+    "contains_tool_raw_log": false,
+    "contains_binary_asset_path": false,
+    "requires_live_hermes": false,
+    "requires_live_provider_execution": false
+  }
+}

--- a/tests/fixtures/hermes-delegation-sanitized-trace/valid/provider-executor-summary.json
+++ b/tests/fixtures/hermes-delegation-sanitized-trace/valid/provider-executor-summary.json
@@ -1,0 +1,147 @@
+{
+  "schema_version": "hermes-delegation-sanitized-trace/v1",
+  "trace_id": "provider-executor-summary",
+  "trace_kind": "provider_executor_summary",
+  "tracking_issue": "#197",
+  "target_issue": "#275",
+  "analysis_mode": "hermes_primary",
+  "created_at": "2026-05-18T00:00:00Z",
+  "created_from": {
+    "source_kind": "dry_run_fixture",
+    "source_refs": [
+      "workflows/codex-to-hermes-delegation.md"
+    ]
+  },
+  "delegation_summary": {
+    "target_scope_summary": "Record provider Codex as bounded executor under Hermes orchestration.",
+    "requested_artifact_type": "provider executor summary fixture",
+    "allowed_outputs": [
+      "file inventory label",
+      "diff skeleton label",
+      "validator invocation label"
+    ],
+    "forbidden_outputs": [
+      "provider final judgment",
+      "provider raw details",
+      "canonical promotion without review"
+    ],
+    "authority_boundaries": [
+      "Provider Codex remains executor.",
+      "Hermes remains integrator for the delegated draft.",
+      "Codex app performs final boundary audit before commit."
+    ]
+  },
+  "role_summary": {
+    "codex_app_role": [
+      "hermes_operator",
+      "boundary_auditor",
+      "artifact_converter",
+      "validator_executor"
+    ],
+    "hermes_role": [
+      "primary_analyst",
+      "orchestrator"
+    ],
+    "provider_codex_role": [
+      "executor",
+      "file_reader",
+      "diff_skeleton_builder",
+      "validator_runner"
+    ]
+  },
+  "sanitized_inputs": [
+    {
+      "input_kind": "repo_artifact",
+      "ref": "tests/fixtures/codex-hermes-delegation/hermes-first-orchestration-loop.json",
+      "summary": "Dry-run role separation fixture.",
+      "canonicality": "review_input"
+    }
+  ],
+  "sanitized_hermes_result": {
+    "result_status": "draft_received",
+    "summary": "Hermes may integrate provider executor labels without accepting provider authority.",
+    "proposed_artifacts": [
+      "sanitized provider summary"
+    ],
+    "source_refs": [
+      "workflows/codex-to-hermes-delegation.md"
+    ],
+    "evidence_candidate_notes": [
+      "Provider executor labels are not evidence by themselves."
+    ],
+    "uncertainty_or_hold_reasons": [
+      "Future traces must summarize used and rejected provider outputs."
+    ],
+    "boundary_notes": [
+      "Provider output remains under Hermes orchestration.",
+      "Provider output does not become final authority."
+    ],
+    "follow_up_recommendations": [
+      "Keep provider summaries short and label-based."
+    ]
+  },
+  "provider_codex_summary": {
+    "used": true,
+    "task_kinds": [
+      "file_inventory",
+      "diff_skeleton",
+      "validator_invocation_summary"
+    ],
+    "outputs_used": [
+      "file_inventory",
+      "validator_invocation_summary"
+    ],
+    "outputs_rejected": [
+      "final_architecture_judgment"
+    ],
+    "remained_executor": true
+  },
+  "fallback": {
+    "occurred": false,
+    "reason": null,
+    "recorded_in": null
+  },
+  "post_delegation_review": {
+    "hermes_output_is_draft_input": true,
+    "canonical_promotion_allowed": false,
+    "requires_codex_review": true,
+    "requires_validators": true,
+    "provider_codex_final_authority": false,
+    "local_state_committed": false,
+    "raw_transcript_committed": false,
+    "credentials_committed": false,
+    "provider_raw_output_committed": false
+  },
+  "artifact_conversion": {
+    "converted_to_repo_artifact": true,
+    "artifact_refs": [
+      "tests/fixtures/hermes-delegation-sanitized-trace/valid/provider-executor-summary.json"
+    ],
+    "conversion_notes": [
+      "Provider details are represented as labels only."
+    ],
+    "not_promoted_reason": null
+  },
+  "validators": {
+    "required": [
+      "tests/validation/validate-hermes-delegation-sanitized-traces.ps1"
+    ],
+    "reported": [],
+    "skipped": [],
+    "live_hermes_required": false
+  },
+  "expected_boundary_outcome": {
+    "status": "accept_trace",
+    "reason": "Provider Codex remained a bounded executor and no unsafe content is recorded."
+  },
+  "sanitization_assertions": {
+    "contains_raw_transcript": false,
+    "contains_local_state": false,
+    "contains_credentials": false,
+    "contains_provider_raw_output": false,
+    "contains_tool_raw_log": false,
+    "contains_binary_asset_path": false,
+    "requires_live_hermes": false,
+    "requires_live_provider_execution": false
+  }
+}

--- a/tests/validation/run-all.ps1
+++ b/tests/validation/run-all.ps1
@@ -49,6 +49,7 @@ $readOnlyValidationScripts = @(
   'tests/validation/validate-hermes-pack.ps1',
   'tests/validation/validate-codex-hermes-pack.ps1',
   'tests/validation/validate-codex-hermes-delegation-fixtures.ps1',
+  'tests/validation/validate-hermes-delegation-sanitized-traces.ps1',
   'tests/validation/validate-v2-contracts.ps1',
   'tests/validation/validate-json-schema-manifest.ps1',
   'tests/validation/validate-agent-toolchain.ps1',

--- a/tests/validation/schema-validation-manifest.json
+++ b/tests/validation/schema-validation-manifest.json
@@ -77,6 +77,14 @@
         "tests/fixtures/calculation-backend-handoff/*.json"
       ],
       "notes": "Structural calculation backend handoff shape only; validate-calculation-backend-handoff.ps1 remains semantic authority."
+    },
+    {
+      "id": "hermes_delegation_sanitized_traces",
+      "schema_path": "contracts/hermes-delegation-sanitized-trace.schema.json",
+      "document_globs": [
+        "tests/fixtures/hermes-delegation-sanitized-trace/valid/*.json"
+      ],
+      "notes": "Structural sanitized trace shape only; validate-hermes-delegation-sanitized-traces.ps1 remains semantic authority and validates invalid rejection fixtures."
     }
   ]
 }

--- a/tests/validation/validate-hermes-delegation-sanitized-traces.ps1
+++ b/tests/validation/validate-hermes-delegation-sanitized-traces.ps1
@@ -1,0 +1,340 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$contractDocPath = Join-Path $repoRoot 'contracts/hermes-delegation-sanitized-trace.md'
+$schemaPath = Join-Path $repoRoot 'contracts/hermes-delegation-sanitized-trace.schema.json'
+$fixtureRoot = Join-Path $repoRoot 'tests/fixtures/hermes-delegation-sanitized-trace'
+$validFixtureRoot = Join-Path $fixtureRoot 'valid'
+$invalidFixtureRoot = Join-Path $fixtureRoot 'invalid'
+
+function Add-Issue {
+  param(
+    [Parameter(Mandatory = $true)][ref]$Issues,
+    [Parameter(Mandatory = $true)][string]$Message
+  )
+  $Issues.Value += $Message
+}
+
+function Test-Property {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name
+  )
+  return $null -ne $Object.PSObject.Properties[$Name]
+}
+
+function Assert-Property {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  if (-not (Test-Property $Object $Name)) {
+    Add-Issue $Issues "$Context missing property: $Name"
+  }
+}
+
+function Assert-BooleanValue {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][bool]$Expected,
+    [Parameter(Mandatory = $true)][string]$Context,
+    [Parameter(Mandatory = $true)][ref]$Issues
+  )
+
+  if (-not (Test-Property $Object $Name)) {
+    Add-Issue $Issues "$Context missing property: $Name"
+    return
+  }
+
+  $value = $Object.$Name
+  if ($value -isnot [bool]) {
+    Add-Issue $Issues "$Context.$Name must be a boolean"
+    return
+  }
+
+  if ($value -ne $Expected) {
+    Add-Issue $Issues "$Context.$Name must be $Expected"
+  }
+}
+
+function Test-ArrayContains {
+  param(
+    [Parameter(Mandatory = $true)][object]$Object,
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][string]$Expected
+  )
+
+  if (-not (Test-Property $Object $Name)) {
+    return $false
+  }
+  return @($Object.$Name) -contains $Expected
+}
+
+function Get-TraceIssues {
+  param(
+    [Parameter(Mandatory = $true)][System.IO.FileInfo]$File
+  )
+
+  $issues = @()
+  $relativePath = $File.FullName.Substring($repoRoot.Length + 1).Replace('\', '/')
+  $raw = Get-Content -LiteralPath $File.FullName -Raw -Encoding UTF8
+
+  foreach ($marker in @(
+    'RAW TRANSCRIPT',
+    'assistant:',
+    'user:',
+    'tool_call',
+    'tool_result',
+    'BEGIN LOG',
+    'END LOG',
+    'memory snapshot',
+    'provider raw output'
+  )) {
+    if ($raw -match [regex]::Escape($marker)) {
+      $issues += "$relativePath contains unsafe marker: $marker"
+    }
+  }
+
+  foreach ($pattern in @(
+    '"live_hermes_required"\s*:\s*true',
+    '"requires_live_hermes"\s*:\s*true',
+    '"requires_live_provider_execution"\s*:\s*true',
+    '"requires_live_web_research"\s*:\s*true',
+    '"requires_live_video_analysis"\s*:\s*true',
+    '(?i)live Hermes execution is required'
+  )) {
+    if ($raw -match $pattern) {
+      $issues += "$relativePath requires live execution outside CI-safe scope: $pattern"
+    }
+  }
+
+  foreach ($pattern in @(
+    '(?i)(^|[\\/])\.env($|[\\/])',
+    '(?i)\.hermes[\\/](sessions|memories|skills|logs|checkpoints|state\.db)',
+    '(?i)(^|[\\/])sessions[\\/]',
+    '(?i)(^|[\\/])memory[\\/]',
+    '(?i)(^|[\\/])checkpoints[\\/]',
+    '(?i)(^|[\\/])logs[\\/]',
+    '(?i)(^|[\\/])caches[\\/]',
+    '(?i)\bcurator\b',
+    '(?i)\bkanban\b',
+    '(?i)[A-Za-z0-9_\-./\\]*(secret|token|credential)[A-Za-z0-9_\-./\\]*[\\/]'
+  )) {
+    if ($raw -match $pattern) {
+      $issues += "$relativePath contains local state or secret path-like pattern: $pattern"
+    }
+  }
+
+  foreach ($pattern in @(
+    '(?i)\.(png|jpg|jpeg|gif|webp|mp4|mov|avi|mkv)\b'
+  )) {
+    if ($raw -match $pattern) {
+      $issues += "$relativePath contains binary/media path-like text: $pattern"
+    }
+  }
+
+  $activeStoragePattern = '(?im)^\s*(?:[-*+]\s+|\d+[.)]\s+)?(commit|store|save|persist|include|write|add)\b.*\b(sessions?|memory|local skills?|curator|checkpoints?|kanban state|logs?|caches?|credentials?|secrets?|tokens?|provider raw output|tool logs?)\b'
+  foreach ($line in ($raw -split "`r?`n")) {
+    if ($line -match $activeStoragePattern -and $line -notmatch '(?i)\b(do not|must not|forbid|forbidden|not|no|reject|rejection|without)\b') {
+      $issues += "Potential active local-state storage instruction in ${relativePath}: $line"
+    }
+  }
+
+  try {
+    $trace = $raw | ConvertFrom-Json
+  } catch {
+    $issues += "$relativePath is not valid JSON"
+    return $issues
+  }
+
+  foreach ($field in @(
+    'schema_version',
+    'trace_id',
+    'trace_kind',
+    'tracking_issue',
+    'target_issue',
+    'analysis_mode',
+    'created_at',
+    'created_from',
+    'delegation_summary',
+    'role_summary',
+    'sanitized_inputs',
+    'sanitized_hermes_result',
+    'provider_codex_summary',
+    'fallback',
+    'post_delegation_review',
+    'artifact_conversion',
+    'validators',
+    'expected_boundary_outcome',
+    'sanitization_assertions'
+  )) {
+    Assert-Property $trace $field $relativePath ([ref]$issues)
+  }
+
+  if ((Test-Property $trace 'schema_version') -and [string]$trace.schema_version -ne 'hermes-delegation-sanitized-trace/v1') {
+    $issues += "$relativePath must use schema_version hermes-delegation-sanitized-trace/v1"
+  }
+  if ((Test-Property $trace 'trace_id') -and [string]$trace.trace_id -notmatch '^[a-z0-9][a-z0-9-]*$') {
+    $issues += "$relativePath trace_id must be kebab-case"
+  }
+  if ((Test-Property $trace 'analysis_mode') -and @('hermes_primary', 'codex_fallback') -notcontains [string]$trace.analysis_mode) {
+    $issues += "$relativePath has invalid analysis_mode: $($trace.analysis_mode)"
+  }
+
+  if (Test-Property $trace 'role_summary') {
+    foreach ($role in @('hermes_operator', 'boundary_auditor', 'artifact_converter', 'validator_executor')) {
+      if (-not (Test-ArrayContains $trace.role_summary 'codex_app_role' $role)) {
+        $issues += "$relativePath role_summary.codex_app_role missing: $role"
+      }
+    }
+
+    if ((Test-Property $trace 'analysis_mode') -and [string]$trace.analysis_mode -eq 'hermes_primary') {
+      foreach ($role in @('primary_analyst', 'orchestrator')) {
+        if (-not (Test-ArrayContains $trace.role_summary 'hermes_role' $role)) {
+          $issues += "$relativePath hermes_primary trace missing Hermes role: $role"
+        }
+      }
+    }
+  }
+
+  if (Test-Property $trace 'provider_codex_summary') {
+    if ((Test-Property $trace.provider_codex_summary 'used') -and $trace.provider_codex_summary.used -eq $true) {
+      Assert-BooleanValue $trace.provider_codex_summary 'remained_executor' $true "$relativePath provider_codex_summary" ([ref]$issues)
+      if ((Test-Property $trace 'post_delegation_review') -and (Test-Property $trace.post_delegation_review 'provider_codex_final_authority') -and $trace.post_delegation_review.provider_codex_final_authority -ne $false) {
+        $issues += "$relativePath provider Codex must not become final authority"
+      }
+    }
+  }
+
+  if (Test-Property $trace 'fallback') {
+    if ((Test-Property $trace 'analysis_mode') -and [string]$trace.analysis_mode -eq 'codex_fallback') {
+      Assert-BooleanValue $trace.fallback 'occurred' $true "$relativePath fallback" ([ref]$issues)
+      if (-not (Test-Property $trace.fallback 'reason') -or [string]::IsNullOrWhiteSpace([string]$trace.fallback.reason)) {
+        $issues += "$relativePath codex_fallback must record a non-empty fallback reason"
+      }
+      if ((Test-Property $trace 'sanitized_hermes_result') -and (Test-Property $trace.sanitized_hermes_result 'result_status') -and [string]$trace.sanitized_hermes_result.result_status -ne 'fallback_required') {
+        $issues += "$relativePath codex_fallback must not claim Hermes-first completion"
+      }
+    } elseif ((Test-Property $trace.fallback 'occurred') -and $trace.fallback.occurred -eq $true) {
+      $issues += "$relativePath fallback.occurred true requires analysis_mode codex_fallback"
+    }
+  }
+
+  if (Test-Property $trace 'post_delegation_review') {
+    Assert-BooleanValue $trace.post_delegation_review 'hermes_output_is_draft_input' $true "$relativePath post_delegation_review" ([ref]$issues)
+    Assert-BooleanValue $trace.post_delegation_review 'canonical_promotion_allowed' $false "$relativePath post_delegation_review" ([ref]$issues)
+    Assert-BooleanValue $trace.post_delegation_review 'requires_codex_review' $true "$relativePath post_delegation_review" ([ref]$issues)
+    Assert-BooleanValue $trace.post_delegation_review 'requires_validators' $true "$relativePath post_delegation_review" ([ref]$issues)
+    Assert-BooleanValue $trace.post_delegation_review 'provider_codex_final_authority' $false "$relativePath post_delegation_review" ([ref]$issues)
+    Assert-BooleanValue $trace.post_delegation_review 'local_state_committed' $false "$relativePath post_delegation_review" ([ref]$issues)
+    Assert-BooleanValue $trace.post_delegation_review 'raw_transcript_committed' $false "$relativePath post_delegation_review" ([ref]$issues)
+    Assert-BooleanValue $trace.post_delegation_review 'credentials_committed' $false "$relativePath post_delegation_review" ([ref]$issues)
+    Assert-BooleanValue $trace.post_delegation_review 'provider_raw_output_committed' $false "$relativePath post_delegation_review" ([ref]$issues)
+  }
+
+  if (Test-Property $trace 'validators') {
+    Assert-BooleanValue $trace.validators 'live_hermes_required' $false "$relativePath validators" ([ref]$issues)
+  }
+
+  if (Test-Property $trace 'sanitization_assertions') {
+    foreach ($field in @(
+      'contains_raw_transcript',
+      'contains_local_state',
+      'contains_credentials',
+      'contains_provider_raw_output',
+      'contains_tool_raw_log',
+      'contains_binary_asset_path',
+      'requires_live_hermes',
+      'requires_live_provider_execution'
+    )) {
+      Assert-BooleanValue $trace.sanitization_assertions $field $false "$relativePath sanitization_assertions" ([ref]$issues)
+    }
+  }
+
+  return $issues
+}
+
+$issues = @()
+
+foreach ($requiredPath in @($contractDocPath, $schemaPath, $validFixtureRoot, $invalidFixtureRoot)) {
+  if (-not (Test-Path -LiteralPath $requiredPath)) {
+    $issues += "Missing required path: $requiredPath"
+  }
+}
+
+if ($issues.Count -eq 0) {
+  $contractText = Get-Content -LiteralPath $contractDocPath -Raw -Encoding UTF8
+  foreach ($needle in @(
+    'Hermes Delegation Sanitized Trace Contract',
+    'orchestration metadata only',
+    'Hermes output',
+    'primary draft input',
+    'provider Codex',
+    'raw Hermes transcript',
+    'Sanitized traces must not record'
+  )) {
+    if ($contractText -notmatch [regex]::Escape($needle)) {
+      $issues += "contracts/hermes-delegation-sanitized-trace.md missing required text: $needle"
+    }
+  }
+
+  $schemaText = Get-Content -LiteralPath $schemaPath -Raw -Encoding UTF8
+  foreach ($needle in @(
+    'hermes-delegation-sanitized-trace/v1',
+    'hermes_primary_delegation',
+    'provider_executor_summary',
+    'codex_fallback',
+    'post_delegation_review',
+    'live_hermes_required',
+    'sanitization_assertions'
+  )) {
+    if ($schemaText -notmatch [regex]::Escape($needle)) {
+      $issues += "contracts/hermes-delegation-sanitized-trace.schema.json missing required text: $needle"
+    }
+  }
+
+  $schemaObject = $schemaText | ConvertFrom-Json
+  foreach ($field in @('$schema', '$id', 'title', 'required', 'properties')) {
+    Assert-Property $schemaObject $field 'contracts/hermes-delegation-sanitized-trace.schema.json' ([ref]$issues)
+  }
+
+  $validFiles = @(Get-ChildItem -LiteralPath $validFixtureRoot -File -Filter '*.json' | Sort-Object Name)
+  $invalidFiles = @(Get-ChildItem -LiteralPath $invalidFixtureRoot -File -Filter '*.json' | Sort-Object Name)
+
+  foreach ($fileName in @('hermes-primary-delegation.json', 'provider-executor-summary.json', 'codex-fallback-recorded.json')) {
+    if (-not (Test-Path -LiteralPath (Join-Path $validFixtureRoot $fileName) -PathType Leaf)) {
+      $issues += "Missing valid sanitized trace fixture: $fileName"
+    }
+  }
+  foreach ($fileName in @('raw-transcript-marker.json', 'local-state-path.json', 'provider-raw-output.json', 'live-hermes-required.json', 'binary-media-path.json')) {
+    if (-not (Test-Path -LiteralPath (Join-Path $invalidFixtureRoot $fileName) -PathType Leaf)) {
+      $issues += "Missing invalid sanitized trace fixture: $fileName"
+    }
+  }
+
+  foreach ($file in $validFiles) {
+    $traceIssues = @(Get-TraceIssues -File $file)
+    if ($traceIssues.Count -gt 0) {
+      $issues += $traceIssues
+    }
+  }
+
+  foreach ($file in $invalidFiles) {
+    $traceIssues = @(Get-TraceIssues -File $file)
+    if ($traceIssues.Count -eq 0) {
+      $relativePath = $file.FullName.Substring($repoRoot.Length + 1).Replace('\', '/')
+      $issues += "$relativePath was expected to be rejected but produced no validation issues"
+    }
+  }
+}
+
+if ($issues.Count -gt 0) {
+  throw ($issues -join '; ')
+}
+
+Write-Host 'Hermes delegation sanitized traces OK'

--- a/tests/validation/validate-v2-contracts.ps1
+++ b/tests/validation/validate-v2-contracts.ps1
@@ -13,6 +13,7 @@ $requiredJsonSchemas = @(
   'contracts/answer-intent.schema.json',
   'contracts/evidence-card.schema.json',
   'contracts/answer-plan.schema.json',
+  'contracts/hermes-delegation-sanitized-trace.schema.json',
   'contracts/calculation-backend-handoff.schema.json',
   'contracts/calculation-trace.schema.json',
   'contracts/normalization-aliases.schema.json',
@@ -24,6 +25,7 @@ $requiredJsonSchemas = @(
 
 $requiredDocs = @(
   'contracts/frame-current-runtime-assets.md',
+  'contracts/hermes-delegation-sanitized-trace.md',
   'contracts/calculation-executor-trace.md',
   'contracts/video-observation.md',
   'contracts/evidence-gate.md',

--- a/workflows/codex-to-hermes-delegation.md
+++ b/workflows/codex-to-hermes-delegation.md
@@ -232,3 +232,9 @@ Use GitHub issues and PRs as primary progress state. Use PR bodies, issue
 comments, smoke reports, and reviewed docs as visible handoff surfaces. Do not
 rely on private model memory, Hermes memory, local sessions, local skills,
 Curator output, Kanban workers, or checkpoints as repo state.
+
+When a reusable record of a Hermes-first delegation is needed, use
+`contracts/hermes-delegation-sanitized-trace.md`. The sanitized trace may
+record orchestration and handoff metadata only. It must not include raw Hermes
+transcripts, local Hermes state, provider raw output, raw command output,
+credentials, binary media, or current-fact authority.


### PR DESCRIPTION
Closes #275.

## Summary
- Add a Hermes delegation sanitized trace contract and JSON schema.
- Add valid and invalid fixtures covering Hermes-primary, provider executor summary, Codex fallback, unsafe raw markers, local state paths, provider raw output, live-Hermes requirements, and binary media paths.
- Add a semantic validator and wire it into schema manifest, v2 contracts, and run-all.
- Cross-link the sanitized trace boundary from Codex-Hermes delegation and bridge policy docs.

## Hermes / Boundary Notes
- Hermes was used as primary draft analyst for this Phase 6 task.
- Hermes output was treated as primary draft input only and converted into reviewed repo artifacts.
- Provider Codex was not used by Hermes for this implementation.
- No Hermes memory, sessions, local skills, raw transcript, Curator output, Kanban state, checkpoints, logs, caches, credentials, local profile state, provider raw output, current facts, official_raw, generated references, frame-current assets, normalization assets, or public sf6-agent behavior were committed or changed.

## Validation
- `tests/validation/validate-hermes-delegation-sanitized-traces.ps1`
- `tests/validation/validate-json-schema-manifest.ps1`
- `tests/validation/validate-v2-contracts.ps1`
- `tests/validation/validate-codex-hermes-delegation-fixtures.ps1`
- `tests/validation/validate-doc-links.ps1`
- `tests/validation/run-all.ps1`
- `git diff --cached --check`
- `git diff --check origin/main...HEAD`

## Intentionally Not Done
- Did not add live Hermes execution to CI.
- Did not commit raw transcripts or local Hermes state.
- Did not change current facts, generated/runtime assets, or public adapter behavior.
