### PR TITLE
[v2.6] Refactor Hermes packs as thin pointers

### DIFF
--- a/packs/README.md
+++ b/packs/README.md
@@ -2,4 +2,7 @@
 
 Optional environment-specific packs live here.
 
-Packs can improve maintainer ergonomics, but they are not canonical source surfaces.
+Packs can improve maintainer ergonomics, but they are not canonical source
+surfaces or canonical procedure authority. Keep packs as thin pointers,
+templates, and checklists that point back to `AGENTS.md`, `workflows/`,
+`docs/architecture/`, `contracts/`, and `tests/validation/`.

--- a/packs/codex-hermes-sf6/guards/article-video-boundary.md
+++ b/packs/codex-hermes-sf6/guards/article-video-boundary.md
@@ -1,5 +1,9 @@
 # Article And Video Boundary
 
+This guard is a repo-local reminder only. Canonical authority remains in
+`AGENTS.md`, `workflows/`, `docs/architecture/`, `contracts/`,
+`tests/validation/`, and reviewed repo artifacts.
+
 Article sources provide candidate claims and review input only until reviewed
 and promoted through an accepted repo path.
 

--- a/packs/codex-hermes-sf6/guards/calculation-executor-boundary.md
+++ b/packs/codex-hermes-sf6/guards/calculation-executor-boundary.md
@@ -1,5 +1,9 @@
 # Calculation Executor Boundary
 
+This guard is a repo-local reminder only. Canonical authority remains in
+`AGENTS.md`, `workflows/`, `docs/architecture/`, `contracts/`,
+`tests/validation/`, and reviewed repo artifacts.
+
 Calculation tools are executors only.
 
 They must not:
@@ -14,5 +18,5 @@ They must not:
 - feed generated references by default;
 - change public `sf6-agent` behavior.
 
-Use `packages/calculation-executor/sf6_calculation_executor.py` for deterministic
-arithmetic traces and keep `accepted_current_fact_authority: false`.
+Use the canonical calculation contracts, backend handoff workflow, package
+README, and validators for executable behavior.

--- a/packs/codex-hermes-sf6/guards/current-fact-boundary.md
+++ b/packs/codex-hermes-sf6/guards/current-fact-boundary.md
@@ -1,5 +1,9 @@
 # Current-Fact Boundary
 
+This guard is a repo-local reminder only. Canonical authority remains in
+`AGENTS.md`, `workflows/`, `docs/architecture/`, `contracts/`,
+`tests/validation/`, and reviewed repo artifacts.
+
 Exact current facts remain grounded in packaged/current-fact authorities:
 
 - `data/exports/`

--- a/packs/codex-hermes-sf6/guards/external-visual-asset-boundary.md
+++ b/packs/codex-hermes-sf6/guards/external-visual-asset-boundary.md
@@ -1,5 +1,9 @@
 # External Visual Asset Boundary
 
+This guard is a repo-local reminder only. Canonical authority remains in
+`AGENTS.md`, `workflows/`, `docs/architecture/`, `contracts/`,
+`tests/validation/`, and reviewed repo artifacts.
+
 Reviewed policy:
 
 - `docs/architecture/external-frame-atlas-policy.md`

--- a/packs/codex-hermes-sf6/guards/hermes-local-state-boundary.md
+++ b/packs/codex-hermes-sf6/guards/hermes-local-state-boundary.md
@@ -1,5 +1,9 @@
 # Hermes Local State Boundary
 
+This guard is a repo-local reminder only. Canonical authority remains in
+`AGENTS.md`, `workflows/`, `docs/architecture/`, `contracts/`,
+`tests/validation/`, and reviewed repo artifacts.
+
 Do not commit Hermes or Codex local state.
 
 Forbidden repo content includes:

--- a/packs/codex-hermes-sf6/guards/video-observation-boundary.md
+++ b/packs/codex-hermes-sf6/guards/video-observation-boundary.md
@@ -1,5 +1,9 @@
 # Video Observation Boundary
 
+This guard is a repo-local reminder only. Canonical authority remains in
+`AGENTS.md`, `workflows/`, `docs/architecture/`, `contracts/`,
+`tests/validation/`, and reviewed repo artifacts.
+
 Reviewed policy:
 
 - `docs/architecture/sf6-video-analysis-protocol.md`

--- a/packs/codex-hermes-sf6/resources/calculation-executor-playbook.md
+++ b/packs/codex-hermes-sf6/resources/calculation-executor-playbook.md
@@ -1,36 +1,27 @@
-# Calculation Executor Playbook
+# Calculation Executor Boundary Pointer
 
-This playbook is repo-local maintainer support only. It does not define public
-`sf6-agent` answer behavior.
+This pointer is repo-local maintainer support only. It does not define public
+`sf6-agent` answer behavior and does not define SF6 formula authority.
 
-Use the deterministic executor when Hermes, Codex, or provider Codex needs to
-avoid LLM arithmetic errors while preserving SF6 authority boundaries.
+Canonical calculation boundaries live in:
 
-## Command
+- `contracts/calculation-executor-trace.md`
+- `contracts/calculation-trace.schema.json`
+- `contracts/calculation-backend-handoff.schema.json`
+- `workflows/calculation-backend-handoff.md`
+- `packages/calculation-executor/README.md`
+- `tests/validation/validate-calculation-executor.ps1`
+- `tests/validation/validate-calculation-backend-handoff.ps1`
 
-```bash
-python packages/calculation-executor/sf6_calculation_executor.py \
-  --input tests/fixtures/calculation-executor/hypothetical-addition.json \
-  --pretty
-```
+Use this pack note only to remember the boundary:
 
-## Required boundary
+- calculation executors are trace generators only;
+- executor output is not SF6 authority, formula authority, rounding authority,
+  or current-fact authority;
+- exact SF6 values, formulas, and rounding rules are not repo authority;
+- backend instructions and traces must stay review-only or hold unless a
+  separate accepted authority path exists;
+- do not use calculation output to change public `sf6-agent` behavior.
 
-- The executor is a calculation executor and trace generator only.
-- The executor output is not SF6 authority, formula authority, or current-fact
-  authority.
-- Hermes may request arithmetic, but provider Codex should run the repo-owned
-  script rather than doing arithmetic in natural language.
-- Codex must audit the trace against `contracts/calculation-executor-trace.md`
-  and `contracts/calculation-trace.schema.json`.
-- Missing input provenance, formula instruction, rounding instruction, route,
-  or timing context must produce blocked or hold behavior.
-- Do not use the executor to discover SF6 facts, infer formulas, scrape data, or
-  make public answers.
-
-## First-tranche use
-
-Use the executor for generic arithmetic and hypothetical consistency checks
-only. Do not encode combo damage, scaling tables, minimum guarantees, frame
-advantage interpretation, punish-window logic, or meaty/oki timing rules until
-a later reviewed backend-instruction policy exists.
+Command examples and executable behavior belong to the package README, tests,
+and validators, not to this pack.

--- a/packs/codex-hermes-sf6/resources/codex-to-hermes-request-template.md
+++ b/packs/codex-hermes-sf6/resources/codex-to-hermes-request-template.md
@@ -1,11 +1,16 @@
 # Codex-To-Hermes Request Template
 
-Use this concise template when the target issue allows Hermes delegation.
+This is a fill-in template only. Canonical delegation procedure lives in
+`workflows/codex-to-hermes-delegation.md`, with boundary policy in
+`docs/architecture/codex-hermes-bridge-policy.md`.
+
 Hermes output is draft input only. For Hermes-first analysis, it is the
 primary draft input.
 
 ```yaml
 analysis_mode: hermes_primary
+task_id:
+tracking_issue:
 target_issue:
 target_scope_summary:
 codex_app_role:
@@ -27,32 +32,16 @@ validators_to_run:
 review_checklist:
 ```
 
-## Field Guidance
+## Minimal Field Notes
 
-- `target_issue`: the GitHub issue controlling scope and acceptance.
-- `target_scope_summary`: a short restatement of scope, non-goals, and
-  acceptance.
-- `analysis_mode`: usually `hermes_primary`; use `codex_fallback` only when
-  Hermes is unavailable, unconfigured, explicitly out of scope, or unsafe for
-  the material.
-- `codex_app_role`: Windows Codex app responsibilities. It operates Hermes,
-  audits boundaries, converts artifacts, runs validators, and reports to the
-  maintainer.
-- `hermes_role`: Hermes responsibilities. Hermes performs primary analysis,
-  orchestration, uncertainty integration, and self-improvement review.
-- `provider_codex_role`: provider Codex responsibilities when Hermes uses it.
-  Provider Codex is an executor, not the final analyst.
-- `source_material`: repo artifacts, links, notes, article/video references,
-  or other input. Source material is not automatically canonical.
-- `requested_artifact_type`: draft note, candidate observation, review
-  checklist, validator proposal, or other scoped draft.
-- `allowed_outputs`: what Hermes may produce as draft input.
-- `forbidden_outputs`: exact current facts, public answer behavior, raw
-  article/video dumps, local state, secrets, or out-of-scope artifacts.
-- `authority_boundaries`: current-fact, article, video, external visual atlas,
-  and public adapter boundaries that apply.
-- `validators_to_run`: repo validators Codex must run before commit.
-- `review_checklist`: checks Codex must perform before using the draft.
+- `target_issue`: issue controlling scope and acceptance.
+- `target_scope_summary`: one short scope / non-goal / acceptance restatement.
+- `source_material`: repo refs or source refs; not automatically canonical.
+- `forbidden_outputs`: include local state, raw transcript, secrets, exact
+  current facts, and public answer behavior unless explicitly in scope.
+- `authority_boundaries`: current-fact, article/video, visual-asset,
+  calculation, and public-adapter boundaries that apply.
+- `validators_to_run`: checks Codex must run before commit.
 
 Use this fallback shape only when Hermes-first analysis cannot be used:
 
@@ -64,5 +53,5 @@ hermes_delegation:
 debt: hermes_first_analysis_not_validated_for_this_workflow
 ```
 
-Reference `workflows/codex-to-hermes-delegation.md` for the canonical
-delegation workflow.
+Fallback rules, provider Codex boundaries, and post-delegation checks are
+defined by `workflows/codex-to-hermes-delegation.md`.

--- a/packs/codex-hermes-sf6/resources/hermes-response-review-checklist.md
+++ b/packs/codex-hermes-sf6/resources/hermes-response-review-checklist.md
@@ -1,22 +1,29 @@
-# Hermes Response Review Checklist
+# Hermes Response Pre-Conversion Checklist
 
-Use this checklist before converting Hermes output into repo artifacts.
+This checklist is a concise helper only. It does not replace
+`workflows/codex-to-hermes-delegation.md`. If there is a conflict, canonical
+workflows, architecture docs, contracts, validators, issue scope, and PR review
+win.
+
+Before converting Hermes output into repo artifacts, confirm:
 
 - Hermes output is draft input.
-- For Hermes-first analysis, Hermes output is the primary draft input.
-- Codex did not replace Hermes as primary analyst unless fallback is recorded.
+- Hermes-primary analysis happened, or `codex_fallback` has a recorded reason.
 - Provider Codex, if used by Hermes, remained a bounded executor.
-- Source refs are not canonical evidence by themselves.
-- Candidate claims or observations must identify uncertainty and review
-  status.
-- Exact current facts require current-fact authority surfaces.
-- Web, article, video, and external atlas inputs cannot override
+- Source refs and evidence candidate notes are not canonical evidence by
+  themselves.
+- Exact current facts remain grounded in current-fact authority surfaces.
+- Article, video, web, and external atlas inputs do not override
   `official_raw`.
+- Calculation executors remain trace generators and are not SF6 formula,
+  rounding, or current-fact authority.
 - Local Hermes memory, sessions, skills, Curator output, browser state, cron
-  state, Kanban state, checkpoints, logs, caches, and profile state are
-  non-canonical.
-- Validators and PR review remain required before merge.
-- Public `sf6-agent` behavior must not change unless the target issue
-  explicitly allows it.
+  state, Kanban state, checkpoints, logs, caches, profile state, raw
+  transcripts, provider raw output, credentials, secrets, and tokens are not
+  committed.
+- Public `sf6-agent` behavior is unchanged unless the target issue explicitly
+  allows it.
 - Generated surfaces, frame-current assets, normalization assets, `.dist`, and
-  historical smoke reports must remain unchanged unless explicitly in scope.
+  historical smoke reports are unchanged unless explicitly in scope.
+- Validators, diff checks, warnings, and intentionally not done items are
+  recorded before PR handoff.

--- a/packs/codex-hermes-sf6/skill/SKILL.md
+++ b/packs/codex-hermes-sf6/skill/SKILL.md
@@ -1,85 +1,63 @@
 ---
 name: codex-hermes-sf6
-description: Repo-local Codex playbook for safe Hermes delegation in the SF6 Knowledge Agent Kit.
+description: Repo-local Codex pointer pack for safe Hermes delegation in the SF6 Knowledge Agent Kit.
 ---
 
-# Codex-Hermes SF6 Playbook
+# Codex-Hermes SF6 Pack Pointer
 
-This is repo-local Codex skill/playbook source. It is maintainer support only,
-not public `sf6-agent` distribution, and it does not define public answer
-behavior.
+This is repo-local maintainer support only. It is a thin pointer, template,
+and checklist surface for Codex-operated Hermes work. It is not canonical
+procedure authority, not public `sf6-agent` distribution, and it does not
+define public answer behavior.
 
-## When To Use
+Validator anchor: this pack is not canonical procedure authority.
 
-Use this playbook when issue scope allows Hermes-first analysis or when Codex
-needs to delegate bounded draft or review work to Hermes, such as:
+## Canonical Procedure References
 
-- source analysis drafts
-- claim or observation draft shaping
-- architecture review or directory audit drafts
-- validator-pattern proposals
-- review checklist drafting
-- maintainer workflow improvement proposals
+Use the reviewed repo surfaces as authority:
 
-Codex remains the repo implementation entrypoint. When Hermes is configured
-and the task is in scope for Hermes-first analysis, Codex is the Hermes
-operator, boundary auditor, artifact converter, validator runner, and PR
-executor. Codex must not replace Hermes as the primary object-level analyst.
+- `AGENTS.md`
+- `workflows/maintainer-agent-session.md`
+- `workflows/codex-to-hermes-delegation.md`
+- `docs/architecture/codex-hermes-bridge-policy.md`
+- `docs/architecture/hermes-cli-capability-reference.md`
+- `docs/architecture/sf6-video-analysis-protocol.md`
+- `docs/architecture/external-frame-atlas-policy.md`
+- `contracts/hermes-delegation-sanitized-trace.md`
+- `contracts/calculation-executor-trace.md`
+- `workflows/calculation-backend-handoff.md`
 
-## When Not To Use
+If this pack conflicts with those sources, the canonical workflow, contract,
+validator, issue scope, and merged repo artifact win.
 
-Do not use this playbook to:
+## Use This Pack For
 
-- answer public SF6 user questions directly
-- change `skills/sf6-agent/`
-- promote exact current facts from Hermes output
-- override packaged `official_raw`
-- run live Hermes in CI
-- run live video analysis in CI
-- scrape, download, cache, or store external visual assets
-- rely on closed PR #71 or PR #83
+- Finding the Codex-to-Hermes request template.
+- Finding the Hermes response review checklist.
+- Finding short guard reminders for local state, current facts, article/video
+  material, visual assets, stale PRs, and calculation executors.
+- Remembering that Hermes output remains draft input and, for Hermes-first
+  analysis, the primary draft input.
 
-## Required Procedure
+## Do Not Use This Pack For
 
-1. Read the target issue and restate scope, non-goals, and acceptance.
-2. Follow `workflows/maintainer-agent-session.md`.
-3. Use `workflows/codex-to-hermes-delegation.md` for request and response
-   shape when Hermes-first analysis or delegation is appropriate.
-4. Check `docs/architecture/codex-hermes-bridge-policy.md` to confirm
-   Hermes-first delegation applies or to record a documented fallback reason.
-5. Check `docs/architecture/hermes-cli-capability-reference.md` for reviewed
-   Hermes capability status. Do not invent command requirements.
-6. For video work, check
-   `docs/architecture/sf6-video-analysis-protocol.md`.
-7. For external visual atlas work, check
-   `docs/architecture/external-frame-atlas-policy.md`.
-8. For calculation work, check `contracts/calculation-executor-trace.md`,
-   `packs/codex-hermes-sf6/resources/calculation-executor-playbook.md`, and
-   `packs/codex-hermes-sf6/guards/calculation-executor-boundary.md`.
-9. Convert useful Hermes output into reviewed repo artifacts only when the
-   target issue scope allows it.
-10. If Codex fallback analysis is used, record why Hermes-first delegation was
-   not attempted or could not complete.
-11. Run the relevant validators and record results before commit.
+- Public SF6 answers.
+- Public `skills/sf6-agent/` behavior changes.
+- Exact current-fact promotion from Hermes output.
+- `official_raw` overrides.
+- Hermes CLI command truth.
+- Live Hermes or live video analysis in CI.
+- Committing Hermes memory, sessions, local skills, Curator output, browser
+  state, cron state, Kanban state, checkpoints, local configs, logs, caches,
+  credentials, secrets, tokens, raw transcripts, or provider raw output.
+- Treating stale PR #71 and PR #83 as active source material.
 
-## Review Checklist
+## Pack Helpers
 
-- Hermes output remains draft input.
-- For Hermes-first analysis, Hermes output is the primary draft input.
-- Codex did not perform primary object-level analysis unless a fallback reason
-  is recorded.
-- Provider Codex, when used by Hermes, remained an executor and did not become
-  the final analyst.
-- Source references are review inputs, not canonical evidence by themselves.
-- Exact current facts remain grounded in current-fact authority surfaces.
-- Web, article, video, and external visual atlas inputs do not override
-  `official_raw`.
-- Calculation executors are trace generators only and do not become SF6,
-  formula, or current-fact authority.
-- Hermes memory, sessions, local skills, Curator output, browser state, cron
-  state, Kanban state, and checkpoints are non-canonical.
-- Stale PR #71 and PR #83 are closed historical debt, not active sources.
-- Validators and PR review remain required.
+- `resources/codex-to-hermes-request-template.md`: fill-in template only.
+- `resources/hermes-response-review-checklist.md`: pre-conversion checklist.
+- `resources/*`: pointer notes to reviewed policies and contracts.
+- `guards/*`: short boundary reminders only.
 
 ## Verification
 
@@ -87,7 +65,7 @@ For pack changes, run:
 
 ```powershell
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-codex-hermes-pack.ps1
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 -Lane read-only
 ```
 
 Also run:
@@ -96,16 +74,3 @@ Also run:
 git diff --check
 git diff --check origin/main...HEAD
 ```
-
-If PowerShell cannot see `git` during generated-surface checks, verify from a
-git-visible environment that generated references, `.dist`, frame-current
-assets, and normalization assets have no residual unintended diff.
-
-## Pitfalls
-
-- Do not copy the Hermes CLI command table into this pack.
-- Do not make Hermes local state into repo state.
-- Do not confuse video observations with current-fact authority.
-- Do not treat external GIF, image, or frame atlas assets as source-of-truth
-  data.
-- Do not add public adapter behavior to a maintainer playbook.

--- a/packs/hermes-sf6/README.md
+++ b/packs/hermes-sf6/README.md
@@ -1,30 +1,42 @@
 # Hermes SF6 Pack
 
-This pack is repo-local orchestration support for Hermes.
+This pack is repo-local orchestration support for Hermes. It is a thin pointer
+surface only.
 
-Hermes is the primary repo-local orchestration harness when a configured maintainer profile is available. Hermes is not a canonical knowledge surface, not canonical memory, and not required for public distribution. Hermes state is non-canonical. This pack is not public answer behavior and does not replace skills/sf6-agent. Canonical maintainer procedures live in [workflows](../../workflows/). Public agent behavior lives in the single `sf6-agent` adapter.
+It is not public answer behavior, does not replace skills/sf6-agent, and does
+not define canonical procedure authority. Canonical workflows, canonical
+contracts, architecture docs, validators, issue scope, and reviewed repo
+artifacts remain authoritative.
 
-When Hermes is unavailable, Codex, humans, or other agents may still follow the same canonical workflows as fallback executors.
+Validator anchor: this pack is not canonical procedure authority. Canonical
+workflows and canonical contracts remain authoritative.
+
+Hermes state is non-canonical. Do not commit Hermes memory, sessions, profile
+state, browser state, cron state, local managed skills, local config, secrets,
+raw transcripts, logs, caches, Kanban state, checkpoints, credentials, or
+tokens.
 
 ## Contents
 
-- `hermes.example.json`: example harness configuration shape.
-- `prompts/`: boundary guidance for future prompt wrappers.
+- `hermes.example.json`: example harness shape only.
+- `prompts/`: pointer guidance for future prompt wrappers.
 - `profiles/`: markdown profile guidance only; not executable profile config.
-- `guards/`: boundary guidance for future guard checks.
-- `reports/`: boundary guidance for future report templates.
+- `guards/`: pointer guidance for future guard checks.
+- `reports/`: pointer guidance for future report templates.
 
 ## Rules
 
-- Hermes wrappers must follow canonical workflows and canonical contracts.
-- Operational prompt bodies belong to later work after answer contracts and evidence gate policy.
-- Reusable output must be committed as repo artifacts, not stored in Hermes state.
-- Do not commit Hermes memory state.
-- Do not commit cron state.
-- Do not commit secrets.
-- Do not commit user session state.
-- Keep generated or local Hermes runtime files outside this pack.
+- Hermes wrappers must point back to canonical workflows and canonical
+  contracts.
+- Reusable output must be promoted through reviewed repo artifacts.
+- Operational prompt bodies belong to later work after answer contracts and
+  evidence gate policy.
+- Do not add executable profile config, local state, or public adapter behavior
+  to this pack.
 
 ## Usage
 
-Install or build the `sf6-agent` adapter using the canonical distribution docs under [docs/distribution/agents](../../docs/distribution/agents/). Use this pack only to point Hermes at the adapter and at [workflows](../../workflows/) for repo-local orchestration tasks.
+Use this pack only to orient Hermes maintainer operation back to canonical repo
+surfaces. For deferred public adapter work, follow the explicit target issue
+and the canonical distribution docs instead of treating this pack as
+distribution procedure.

--- a/packs/hermes-sf6/guards/README.md
+++ b/packs/hermes-sf6/guards/README.md
@@ -1,10 +1,11 @@
 # Hermes Guard Guidance
 
 This directory is repo-local orchestration support for future Hermes guard guidance.
+It is a thin pointer and checklist surface only.
 
 Files here are not public answer behavior. This directory does not replace skills/sf6-agent. Public SF6 answer behavior remains in the single `skills/sf6-agent/` adapter.
 
-Hermes guards must follow canonical workflows and canonical contracts. Reusable output must be committed as repo artifacts, not stored in Hermes state.
+Hermes guards must follow canonical workflows and canonical contracts. Reusable output must be committed as repo artifacts, not stored in Hermes state. This directory is not canonical procedure authority.
 
 Hermes memory, sessions, profile state, browser state, cron state, local managed skills, local config, secrets, and chat transcripts are non-canonical.
 

--- a/packs/hermes-sf6/profiles/README.md
+++ b/packs/hermes-sf6/profiles/README.md
@@ -1,10 +1,11 @@
 # Hermes Profile Guidance
 
 This directory is repo-local orchestration support for future Hermes profile guidance.
+It is a thin pointer surface only.
 
 Files here are not public answer behavior. This directory does not replace skills/sf6-agent. Public SF6 answer behavior remains in the single `skills/sf6-agent/` adapter.
 
-Hermes profile guidance must follow canonical workflows and canonical contracts. Reusable output must be committed as repo artifacts, not stored in Hermes state.
+Hermes profile guidance must follow canonical workflows and canonical contracts. Reusable output must be committed as repo artifacts, not stored in Hermes state. This directory is not canonical procedure authority.
 
 Hermes memory, sessions, profile state, browser state, cron state, local managed skills, local config, secrets, and chat transcripts are non-canonical.
 
@@ -16,17 +17,18 @@ Repo-local Hermes maintainer profiles should follow
 `data/toolchain/maintainer-agent-toolchain.json` and
 `docs/architecture/hermes-maintainer-profile-policy.md`.
 
-For SF6 maintainer work, profiles are expected to use `gpt-5.5` / `codex 5.5`
-with `xhigh` / extra-high reasoning where the provider and Hermes CLI expose
-that setting. If a profile listing does not show reasoning effort, verify it
-manually outside the repo and do not commit the observed local profile state or
-command output.
+Those canonical toolchain surfaces define the `gpt-5.5` / `codex 5.5` and
+`xhigh` / extra-high expectations for SF6 maintainer work. Local checks such
+as `hermes --version`, `hermes doctor`, and `hermes profile list` are local
+review signals only, not CI requirements. Do not commit the observed local
+profile state or command output.
+
+Validator anchor: local review signals only.
 
 Hermes CLI version freshness is primarily managed through the root `flake.nix`,
-the reviewed `flake.lock` pin, and Renovate Nix flake PRs.
-Fallback checks such as `hermes --version`, `hermes doctor`, and
-`hermes profile list` are local review signals only. The repo records policy
-and command expectations, not local installed versions or profile snapshots.
+the reviewed `flake.lock` pin, and Renovate Nix flake PRs. The repo records
+policy and command expectations, not local installed versions or profile
+snapshots.
 
 Profile skill selection should also follow the repo-managed policy in
 `data/toolchain/maintainer-agent-toolchain.json`. The policy records expected

--- a/packs/hermes-sf6/profiles/ingest-profile-guidance.md
+++ b/packs/hermes-sf6/profiles/ingest-profile-guidance.md
@@ -1,10 +1,11 @@
 # Ingest Profile Guidance
 
 This file is repo-local orchestration support for future Hermes ingest profile guidance.
+It is a thin pointer surface only.
 
 It is not public answer behavior and does not replace skills/sf6-agent. Public SF6 answer behavior remains in the single `skills/sf6-agent/` adapter.
 
-Hermes ingest guidance must follow canonical workflows and canonical contracts, including the relevant article, video, and source review workflows under `workflows/`.
+Hermes ingest guidance must follow canonical workflows and canonical contracts, including the relevant article, video, and source review workflows under `workflows/`. This file is not canonical procedure authority.
 
 Reusable output must be committed as repo artifacts, not stored in Hermes state. Source metadata, claims, observations, review notes, and smoke evidence belong in their canonical repository surfaces.
 
@@ -15,18 +16,13 @@ This is markdown guidance only, not executable profile config. Operational promp
 ## Model And Reasoning Expectation
 
 The `sf6ingest` profile should follow the repo maintainer profile policy in
-`data/toolchain/maintainer-agent-toolchain.json`.
-
-Expected setup:
-
-- model: `gpt-5.5`
-- accepted model alias: `codex 5.5`
-- reasoning effort: `xhigh` / extra-high where supported
-
-If Hermes does not expose reasoning effort in `hermes profile list`, verify the
-setting manually outside the repo. Do not commit Hermes profile config, profile
-state, command output, memory, sessions, logs, caches, credentials, or raw
-transcripts.
+`data/toolchain/maintainer-agent-toolchain.json` and
+`docs/architecture/hermes-maintainer-profile-policy.md`. Those canonical
+surfaces define the `gpt-5.5` / `codex 5.5` and `xhigh` / extra-high
+expectations. If Hermes does not expose reasoning effort in a local profile
+listing, verify the setting manually outside the repo. Do not commit Hermes
+profile config, profile state, command output, memory, sessions, logs, caches,
+credentials, or raw transcripts.
 
 ## Skill Selection Expectation
 

--- a/packs/hermes-sf6/prompts/README.md
+++ b/packs/hermes-sf6/prompts/README.md
@@ -1,10 +1,11 @@
 # Hermes Prompt Wrapper Guidance
 
 This directory is repo-local orchestration support for future Hermes prompt wrappers.
+It is a thin pointer surface only.
 
 Files here are not public answer behavior. This directory does not replace skills/sf6-agent. Public SF6 answer behavior remains in the single `skills/sf6-agent/` adapter.
 
-Hermes prompt wrappers must follow canonical workflows and canonical contracts. Reusable output must be committed as repo artifacts, not stored in Hermes state.
+Hermes prompt wrappers must follow canonical workflows and canonical contracts. Reusable output must be committed as repo artifacts, not stored in Hermes state. This directory is not canonical procedure authority.
 
 Hermes memory, sessions, profile state, browser state, cron state, local managed skills, local config, secrets, and chat transcripts are non-canonical.
 

--- a/packs/hermes-sf6/reports/README.md
+++ b/packs/hermes-sf6/reports/README.md
@@ -1,10 +1,11 @@
 # Hermes Report Guidance
 
 This directory is repo-local orchestration support for future Hermes report guidance.
+It is a thin pointer and checklist surface only.
 
 Files here are not public answer behavior. This directory does not replace skills/sf6-agent. Public SF6 answer behavior remains in the single `skills/sf6-agent/` adapter.
 
-Hermes report guidance must follow canonical workflows and canonical contracts. Reusable output must be committed as repo artifacts, not stored in Hermes state.
+Hermes report guidance must follow canonical workflows and canonical contracts. Reusable output must be committed as repo artifacts, not stored in Hermes state. This directory is not canonical procedure authority.
 
 Hermes memory, sessions, profile state, browser state, cron state, local managed skills, local config, secrets, and chat transcripts are non-canonical.
 

--- a/tests/validation/validate-codex-hermes-pack.ps1
+++ b/tests/validation/validate-codex-hermes-pack.ps1
@@ -75,6 +75,10 @@ if ($issues.Count -eq 0) {
 
   $requiredPhrases = @(
     'repo-local maintainer support only',
+    'thin pointer',
+    'template',
+    'checklist',
+    'not canonical procedure authority',
     'does not define public answer behavior',
     'workflows/maintainer-agent-session.md',
     'workflows/codex-to-hermes-delegation.md',
@@ -83,7 +87,7 @@ if ($issues.Count -eq 0) {
     'docs/architecture/sf6-video-analysis-protocol.md',
     'docs/architecture/external-frame-atlas-policy.md',
     'Hermes output remains draft input',
-    'Stale PR #71 and PR #83 are closed historical debt',
+    'stale PR #71 and PR #83',
     'official_raw'
   )
 
@@ -100,11 +104,26 @@ if ($issues.Count -eq 0) {
 
   $activePublicAnswerPatterns = @(
     '(?im)^\s*(this pack|the pack)\s+defines\s+public answer behavior',
-    '(?im)^\s*define\s+public answer behavior'
+    '(?im)^\s*this pack defines public answer behavior'
   )
   foreach ($pattern in $activePublicAnswerPatterns) {
     if ($combinedText -match $pattern) {
       $issues += 'Codex-Hermes pack appears to define public answer behavior.'
+    }
+  }
+
+  foreach ($pattern in @(
+    '(?im)^## Required Procedure$',
+    '(?im)^## Canonical Procedure$',
+    '(?i)\bthis pack is authoritative\b',
+    '(?i)\bmust follow this pack\b',
+    '(?i)\bthis pack defines canonical procedure\b',
+    '(?i)\bthis pack defines Hermes CLI command truth\b',
+    '(?i)\blive Hermes.*CI requirement\b',
+    '(?i)\blive video analysis.*CI requirement\b'
+  )) {
+    if ($combinedText -match $pattern) {
+      $issues += "Codex-Hermes pack duplicates or overclaims procedure authority: $pattern"
     }
   }
 

--- a/tests/validation/validate-hermes-pack.ps1
+++ b/tests/validation/validate-hermes-pack.ps1
@@ -44,10 +44,12 @@ $requiredFiles = @(
 
 $commonBoundaryPhrases = @(
   'repo-local orchestration support',
+  'thin pointer',
   'not public answer behavior',
   'does not replace skills/sf6-agent',
   'canonical workflows',
   'canonical contracts',
+  'not canonical procedure authority',
   'non-canonical',
   'repo artifacts'
 )
@@ -77,10 +79,8 @@ if ($issues.Count -eq 0) {
     'packs/hermes-sf6/profiles/ingest-profile-guidance.md'
   )) {
     Assert-TextContains $relativePath @(
-      'gpt-5.5',
-      'codex 5.5',
-      'xhigh',
-      'extra-high',
+      'data/toolchain/maintainer-agent-toolchain.json',
+      'docs/architecture/hermes-maintainer-profile-policy.md',
       'do not commit'
     ) ([ref]$issues)
   }
@@ -89,10 +89,8 @@ if ($issues.Count -eq 0) {
     'flake.nix',
     'flake.lock',
     'Renovate Nix flake PRs',
-    'hermes --version',
-    'hermes doctor',
-    'hermes profile list',
-    'local installed versions'
+    'local review signals only',
+    'not local installed versions'
   ) ([ref]$issues)
 
   foreach ($relativePath in @(
@@ -103,6 +101,19 @@ if ($issues.Count -eq 0) {
     'packs/hermes-sf6/reports/README.md'
   )) {
     Assert-TextContains $relativePath @('operational prompt bodies belong to later work') ([ref]$issues)
+  }
+
+  $combinedText = ($requiredFiles | ForEach-Object { Read-Text $_ }) -join "`n"
+  foreach ($pattern in @(
+    '(?i)\bthis pack is authoritative\b',
+    '(?i)\bmust follow this pack\b',
+    '(?i)\bthis directory defines canonical procedure\b',
+    '(?i)\blive Hermes.*CI requirement\b',
+    '(?i)\blive video analysis.*CI requirement\b'
+  )) {
+    if ($combinedText -match $pattern) {
+      $issues += "Hermes pack duplicates or overclaims procedure authority: $pattern"
+    }
   }
 }
 


### PR DESCRIPTION
Closes #277.

## Summary
- Refactor `packs/codex-hermes-sf6` into a thin pointer/template/checklist surface.
- Refactor `packs/hermes-sf6` guidance to point back to canonical workflows, contracts, architecture docs, validators, and toolchain policy.
- Update pack validators to enforce thin pointer boundaries while preserving local-state, public-adapter, stale-source, CLI-table, live-CI, and executable-profile-config guardrails.

## Hermes / Boundary Notes
- Hermes was used as primary draft analyst for this Phase 6 task and I waited for its response before editing.
- Hermes output was treated as primary draft input only and converted into reviewed repo artifacts.
- Provider Codex was not used by Hermes for this implementation.
- No Hermes memory, sessions, local skills, raw transcript, Curator output, Kanban state, checkpoints, logs, caches, credentials, local profile state, provider raw output, current facts, official_raw, generated references, frame-current assets, normalization assets, `.dist`, or public sf6-agent behavior were committed or changed.

## Validation
- `tests/validation/validate-codex-hermes-pack.ps1`
- `tests/validation/validate-hermes-pack.ps1`
- `tests/validation/validate-doc-links.ps1`
- `tests/validation/run-all.ps1 -Lane read-only`
- `tests/validation/run-all.ps1`
- `git diff --check`
- `git diff --check origin/main...HEAD`

## Intentionally Not Done
- Did not remove packs.
- Did not add public adapter behavior.
- Did not add live Hermes execution to CI.
- Did not change generated/runtime/current-fact surfaces.
