### PR TITLE
[v2.6] Harden Hermes freshness review boundaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,12 @@ mise.local.lock
 data/normalized/
 *.zip
 .dist/
+.hermes/
+.env
+.env.*
+!.env.EXAMPLE
+*.transcript
+*-transcript.txt
+*-doctor-output.txt
+*-profile-output.txt
+*-command-output.txt

--- a/docs/architecture/agent-toolchain-freshness.md
+++ b/docs/architecture/agent-toolchain-freshness.md
@@ -73,6 +73,35 @@ Hermes CLI freshness is managed through the root `flake.nix` and the reviewed
 `hermes --version` and `hermes update` output is fallback operator evidence
 only.
 
+## Freshness Continuation
+
+The v2.6 freshness loop continues through reviewed policy and reviewed pins:
+
+- `flake.nix` declares the Hermes Agent input.
+- `flake.lock` records the reviewed pin.
+- Renovate Nix flake PRs are the normal update surface.
+- `nix run .#hermes -- --version` is the preferred local inspection command
+  because it uses the reviewed flake input.
+- fallback local `hermes --version`, `hermes doctor`, and `hermes update`
+  output remains operator diagnostic output only.
+
+Do not promote local Hermes CLI output to canonical data. In particular, do not
+commit exact local installed versions, commit-behind counts, local paths,
+doctor transcripts, provider diagnostics, Python/OpenAI SDK versions, update
+output, logs, caches, credentials, auth output, or command transcripts.
+
+## Model And Reasoning Expectations
+
+`gpt-5.5` / `codex 5.5` and `xhigh` / extra-high reasoning are maintainer
+profile policy expectations recorded in `data/toolchain/maintainer-agent-toolchain.json`.
+They are not copied local profile output, not local proof, and are not proof
+that any maintainer machine currently matches the policy.
+
+If a local Hermes CLI or provider surface does not expose reasoning effort in a
+profile listing, treat the missing display as a local manual-review gap. Do not
+paste the profile listing into repo artifacts. Fix local profile state locally,
+or open a reviewed policy PR if the repo expectation itself needs to change.
+
 ## Verification
 
 `tests/validation/validate-agent-toolchain.ps1` verifies the contract, policy

--- a/docs/architecture/hermes-maintainer-profile-policy.md
+++ b/docs/architecture/hermes-maintainer-profile-policy.md
@@ -269,6 +269,24 @@ hermes profile show sf6ingest
 These commands may help confirm local model and reasoning setup, but they do
 not produce canonical repo data.
 
+## Freshness Review Is Not Profile Export
+
+Hermes CLI freshness and maintainer profile conformance are reviewed through
+repo policy, the Nix flake input, Renovate Nix flake PRs, and local operator
+checks. They are not reviewed by committing exported profile config or command
+transcripts.
+
+`gpt-5.5` / `codex 5.5` and `xhigh` / extra-high reasoning remain policy
+expectations for `sf6ingest`. They are policy expectations, not local proof.
+If a local profile listing does not show reasoning effort, do not treat the
+missing display as a canonical mismatch; verify locally and keep any raw output
+outside the repo.
+
+Do not paste or commit exact local Hermes versions, commit-behind counts,
+profile listings, config paths, local profile paths, `hermes doctor` output,
+provider diagnostics, Python/OpenAI SDK versions, logs, caches, credentials,
+device codes, auth output, or local update transcripts.
+
 ## Boundaries
 
 - Do not require Hermes for public `sf6-agent` users.

--- a/tests/validation/validate-agent-toolchain.ps1
+++ b/tests/validation/validate-agent-toolchain.ps1
@@ -159,6 +159,7 @@ function Get-JsonStringValues {
 
 $issues = @()
 $requiredFiles = @(
+  '.gitignore',
   '.github/renovate.json',
   'docs/architecture/agent-toolchain-freshness.md',
   'docs/architecture/agent-skill-dependency-policy.md',
@@ -226,6 +227,25 @@ $forbiddenManifestFields = @(
 foreach ($relativePath in $requiredFiles) {
   if (-not (Test-Path -LiteralPath (Join-Path $repoRoot $relativePath) -PathType Leaf)) {
     $issues += "Missing agent toolchain file: $relativePath"
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot '.gitignore') -PathType Leaf) {
+  $rootGitignore = Read-Text '.gitignore'
+  foreach ($needle in @(
+    '.hermes/',
+    '.env',
+    '.env.*',
+    '!.env.EXAMPLE',
+    '*.transcript',
+    '*-transcript.txt',
+    '*-doctor-output.txt',
+    '*-profile-output.txt',
+    '*-command-output.txt'
+  )) {
+    if ($rootGitignore -notmatch [regex]::Escape($needle)) {
+      $issues += ".gitignore missing Hermes local-state/output ignore: $needle"
+    }
   }
 }
 
@@ -730,6 +750,19 @@ if (Test-Path -LiteralPath (Join-Path $repoRoot 'docs/architecture/hermes-mainta
       $issues += "docs/architecture/hermes-maintainer-profile-policy.md missing skill allowlist policy text: $needle"
     }
   }
+
+  foreach ($needle in @(
+    'Freshness Review Is Not Profile Export',
+    'policy expectations',
+    'not local proof',
+    'profile listings',
+    'hermes doctor',
+    'device codes'
+  )) {
+    if ($profilePolicyText -notmatch [regex]::Escape($needle)) {
+      $issues += "docs/architecture/hermes-maintainer-profile-policy.md missing freshness boundary text: $needle"
+    }
+  }
 }
 
 if (Test-Path -LiteralPath (Join-Path $repoRoot 'workflows/hermes-ingest-profile-setup.md') -PathType Leaf) {
@@ -817,6 +850,48 @@ if (Test-Path -LiteralPath (Join-Path $repoRoot 'docs/architecture/hermes-curato
   }
 }
 
+if (Test-Path -LiteralPath (Join-Path $repoRoot 'docs/architecture/agent-toolchain-freshness.md') -PathType Leaf) {
+  $freshnessPolicy = Read-Text 'docs/architecture/agent-toolchain-freshness.md'
+  foreach ($needle in @(
+    'Freshness Continuation',
+    'flake.lock',
+    'Renovate Nix flake PRs',
+    'policy expectations',
+    'not local proof',
+    'gpt-5.5',
+    'xhigh',
+    'command transcripts',
+    'doctor transcripts',
+    'commit-behind counts'
+  )) {
+    if ($freshnessPolicy -notmatch [regex]::Escape($needle)) {
+      $issues += "docs/architecture/agent-toolchain-freshness.md missing freshness boundary text: $needle"
+    }
+  }
+}
+
+if (Test-Path -LiteralPath (Join-Path $repoRoot 'workflows/check-agent-toolchain-freshness.md') -PathType Leaf) {
+  $freshnessWorkflow = Read-Text 'workflows/check-agent-toolchain-freshness.md'
+  foreach ($needle in @(
+    'Canonical Hermes CLI Freshness Route',
+    'Renovate Nix flake PRs',
+    'operator diagnostics',
+    'local profile state',
+    'policy expectations',
+    'not copied local profile state',
+    'gpt-5.5',
+    'xhigh',
+    'command transcripts',
+    'doctor transcripts',
+    'profile listings',
+    'device codes'
+  )) {
+    if ($freshnessWorkflow -notmatch [regex]::Escape($needle)) {
+      $issues += "workflows/check-agent-toolchain-freshness.md missing freshness boundary text: $needle"
+    }
+  }
+}
+
 if (Test-Path -LiteralPath (Join-Path $repoRoot $manifestPath) -PathType Leaf) {
   $manifestRaw = Get-Content -LiteralPath (Join-Path $repoRoot $manifestPath) -Raw -Encoding UTF8
   $manifest = $manifestRaw | ConvertFrom-Json
@@ -853,7 +928,15 @@ if (Test-Path -LiteralPath (Join-Path $repoRoot $manifestPath) -PathType Leaf) {
       'Project: [A-Za-z]:\\',
       'Python: \d+\.\d+',
       'OpenAI SDK: \d+\.\d+',
-      'Update available:'
+      'Update available:',
+      'Active profile:',
+      'Profile path:',
+      'Config path:',
+      'HERMES_HOME=',
+      'auth\.json',
+      'state\.db',
+      'device code',
+      'Doctor report:'
     )) {
       if ([string]$stringValue -match $localOutputPattern) {
         $issues += "$manifestPath contains local command output or installed-version-like value: $stringValue"
@@ -1249,6 +1332,10 @@ if (-not (Test-Path -LiteralPath $toolchainRoot -PathType Container)) {
       $name -like '*session*' -or
       $name -like '*cache*' -or
       $name -like '*log*' -or
+      $name -like '*transcript*' -or
+      $name -like '*profile-output*' -or
+      $name -like '*doctor-output*' -or
+      $name -like '*command-output*' -or
       $relativePathLower -like '*/.env' -or
       $relativePathLower -like '*/.env.*' -or
       $relativePathLower -like '*/.envrc' -or
@@ -1257,7 +1344,11 @@ if (-not (Test-Path -LiteralPath $toolchainRoot -PathType Container)) {
       $relativePathLower -like '*credential*' -or
       $relativePathLower -like '*session*' -or
       $relativePathLower -like '*cache*' -or
-      $relativePathLower -like '*log*'
+      $relativePathLower -like '*log*' -or
+      $relativePathLower -like '*transcript*' -or
+      $relativePathLower -like '*profile-output*' -or
+      $relativePathLower -like '*doctor-output*' -or
+      $relativePathLower -like '*command-output*'
     ) {
       $issues += "Forbidden toolchain local-state or secret-like file: $relativePath"
     }

--- a/workflows/check-agent-toolchain-freshness.md
+++ b/workflows/check-agent-toolchain-freshness.md
@@ -41,13 +41,28 @@ The repo-managed expectation is:
 - skill selection is profile-specific policy, not committed runtime skill state
 - local Hermes commands are fallback observations, not canonical repo data
 
-When reviewing Hermes CLI freshness, prefer the Nix path:
+## Canonical Hermes CLI Freshness Route
+
+Hermes CLI freshness is reviewed through repo-managed pins and dependency PRs,
+not by committing local command output.
+
+Primary route:
+
+- Renovate Nix flake PRs update the `hermes-agent` input.
+- Review `flake.nix`, `flake.lock`, the Renovate PR diff, and CI output.
+- Merge only after the reviewed pin and validation are acceptable.
+
+Manual Nix review, when a maintainer needs to inspect the pin locally:
 
 ```bash
 nix flake update hermes-agent
 nix run .#hermes -- --version
 nix flake metadata
 ```
+
+The command output is local operator evidence only. Do not paste exact version
+strings, resolved local store paths, commit-behind counts, or Nix command
+transcripts into repo artifacts.
 
 If local Nix is unavailable, do not treat that as proof that the policy is
 wrong. Use fallback local Hermes checks only as operator diagnostics:
@@ -65,12 +80,38 @@ hermes --version
 hermes doctor
 ```
 
+Fallback output is not the canonical version pin. A PR may summarize that local
+freshness was reviewed, but it must not include exact local installed versions,
+commit-behind counts, doctor transcripts, local paths, provider diagnostics,
+Python/OpenAI SDK versions, update output, logs, caches, credentials, or auth
+output.
+
+## Profile Expectation Review
+
+`sf6ingest` profile checks are local review signals. They may help confirm that
+a maintainer's machine is aligned with the repo policy, but they are not proof
+of canonical repo state.
+
 Profile checks are separate from CLI pinning:
 
 ```bash
 hermes profile list
 hermes profile show sf6ingest
 ```
+
+Expected profile policy:
+
+- model: `gpt-5.5`
+- accepted model alias: `codex 5.5`
+- reasoning: `xhigh` / extra-high when the provider and Hermes CLI expose it
+- reasoning requirement mode: required when supported
+
+These values are policy expectations from
+`data/toolchain/maintainer-agent-toolchain.json`, not copied local profile
+state, and not local profile state. If local profile output does not expose
+reasoning effort, treat that as a manual local review gap rather than a repo
+policy mismatch. Fix local profile state locally, or open a separate policy PR
+if the repo expectation itself must change.
 
 Skill selection checks are also local review signals only:
 
@@ -85,6 +126,21 @@ canonical policy data. Do not paste local skill enablement output, local skill
 paths, or exported skill configuration into canonical policy data. A PR body
 may summarize that local freshness and skill selection were reviewed, but local
 output remains non-canonical.
+
+Safe PR wording:
+
+- OK: "Reviewed Hermes CLI freshness policy; canonical update path remains
+  Renovate Nix flake PRs. Local profile output was not committed."
+- OK: "The `sf6ingest` model and reasoning expectations remain `gpt-5.5` and
+  `xhigh` as repo policy. No local profile dump is included."
+- Not OK: exact `hermes --version` output, commit-behind counts, full
+  `hermes doctor` output, `hermes profile list` output, profile paths,
+  config paths, command transcripts, logs, caches, credentials, tokens, device
+  codes, or auth output.
+
+If a PR uses the phrase "not copied local profile state", it must mean exactly
+that no local profile state was copied into the repo artifact.
+Device codes are auth output and must not be pasted into repo artifacts.
 
 ## Boundaries
 


### PR DESCRIPTION
Closes #281

## Summary

- Clarify the canonical Hermes CLI freshness route through `flake.nix`, `flake.lock`, and Renovate Nix flake PRs.
- Document that local Hermes CLI/profile output is operator diagnostic evidence only, not canonical repo data or local proof of policy conformance.
- Add root ignore rules for Hermes local state, env files, transcripts, and command output files.
- Extend `validate-agent-toolchain.ps1` to enforce freshness boundary anchors and reject local output / transcript-like toolchain artifacts.

## Hermes Use

- Used the configured `sf6ingest` Hermes profile for primary draft analysis and waited for completion.
- Hermes raw transcript, memory, sessions, local skills, local profile state, logs, caches, credentials, auth output, and command transcripts were not committed.
- No exact local Hermes version, commit-behind count, profile dump, doctor output, or provider diagnostics are included.

## Validation

- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-agent-toolchain.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-doc-links.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/validate-v2-contracts.ps1`
- `git diff --check`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1`

## Intentionally Not Done

- Did not update `flake.lock` or local Hermes installation state.
- Did not commit local profile config, memory, sessions, logs, caches, credentials, command transcripts, or raw Hermes output.
- Did not change public `sf6-agent` behavior, current facts, generated references, frame-current assets, normalization assets, or `.dist`.