### PR TITLE
[post-v2.6] Document Hermes delegation command discipline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,15 @@
 - Current operation prioritizes personal/private Codex-operated Hermes-first workflows; `skills/sf6-agent/` is deferred until later scoped work decides whether to remove, relocate, or reactivate it.
 - See `docs/architecture/hermes-v2.1-roadmap.md`, `docs/architecture/codex-hermes-bridge-policy.md`, and `workflows/codex-to-hermes-delegation.md`.
 
+## Hermes Delegation Command Discipline
+
+- Before using Hermes for in-scope analysis, review `workflows/codex-to-hermes-delegation.md`, the repo Hermes CLI capability reference, local `hermes chat --help`, and official Hermes CLI docs when command behavior or limits matter.
+- Do not reuse smoke-test or probe settings such as `--max-turns 1` for real analysis.
+- Give Hermes enough turn budget and wall-clock time for the task. Prefer the documented default or a larger explicit `--max-turns` for repo-wide audits, and resume the same session if the first run does not complete.
+- If Hermes hits a limit, tool denial, transient provider failure, or context issue, continue with `--resume` / `--continue` or split the delegation into bounded follow-up prompts before declaring Codex fallback.
+- Record Codex fallback only after a properly budgeted Hermes attempt, any reasonable resume/retry path, and the blocker have been verified.
+- Treat cost saving as secondary to accurate Hermes-first analysis when the issue requires Hermes primary analysis.
+
 ## Project Status Protocol
 
 - Before answering project status, resuming previous work, editing files, or updating progress docs, verify the current baseline.

--- a/workflows/codex-to-hermes-delegation.md
+++ b/workflows/codex-to-hermes-delegation.md
@@ -45,6 +45,30 @@ improvements without changing canonical surfaces directly.
 Codex-only analysis for these tasks is fallback behavior. Record the fallback
 reason when Hermes delegation is not attempted or cannot complete.
 
+## Command Discipline
+
+Codex is responsible for operating Hermes with a command shape that fits the
+task. Before a real Hermes-first delegation, Codex should verify current command
+behavior from the repo Hermes CLI capability reference, local `hermes chat
+--help`, and official Hermes CLI documentation when limits, resume behavior, or
+toolset behavior matter.
+
+Do not reuse connectivity-smoke settings such as `--max-turns 1` for primary
+analysis. For repo-wide audits, architecture reviews, source-surface audits, or
+other broad read-only tasks, use the documented default turn budget or a larger
+explicit budget, allow enough wall-clock time, and keep the session id so the
+same delegation can be resumed if needed.
+
+If Hermes stops because it hit a turn limit, encountered a denied nonessential
+tool command, failed transiently, or ran out of context, Codex should first
+resume or continue the same session, or split the remaining work into bounded
+follow-up prompts. Codex fallback is valid only after a properly budgeted
+attempt and reasonable resume/retry path have been tried or shown unsafe or
+out-of-scope.
+
+Cost control must not be the reason to under-budget Hermes primary analysis
+when the target issue calls for Hermes-first work.
+
 ## Forbidden Delegation Tasks
 
 Do not delegate tasks that would allow Hermes to bypass repo authority or issue


### PR DESCRIPTION
## Summary

- Add Hermes delegation command discipline to `AGENTS.md`.
- Expand `workflows/codex-to-hermes-delegation.md` with budgeting, resume, retry, and fallback rules.

## Why

This preserves the lesson from #286: real Hermes-first analysis must not reuse smoke-test settings such as `--max-turns 1`, and Codex fallback should only be recorded after a properly budgeted attempt plus reasonable resume/retry handling.

## Changed surfaces

- `AGENTS.md`
- `workflows/codex-to-hermes-delegation.md`

## Boundary notes

- Docs-only change.
- No Hermes profile, local memory, external skill/APM, gateway, MCP, Kanban, cron, public adapter behavior, generated output, runtime asset, current-fact authority, or distribution surface changes.

## Validation

- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/validation/run-all.ps1 -Lane read-only` passed.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.

## Issue mapping

- Refs #286.
