### PR TITLE
Plan Phase 1 retrieval contract roadmap

### DIFF
--- a/docs/execplans/2026-05-20-phase1-retrieval-contract.md
+++ b/docs/execplans/2026-05-20-phase1-retrieval-contract.md
@@ -1,0 +1,252 @@
+# Phase 1 Retrieval Contract
+
+Status: Draft; planning-only, not implemented.
+
+## Purpose
+
+Plan the smallest Phase 1 implementation slice that moves the clean-slate
+scaffold toward the retrieval contract in `docs/PLAN.md` without broad runtime
+work.
+
+This ExecPlan does not implement database, CLI, private vault, Discord, VLM,
+web, API, or vector-search behavior. It defines the next implementation slice
+only.
+
+## Scope
+
+Included in the next implementation slice:
+
+- Add an in-memory SQLite retrieval database built from public repo data at
+  command runtime.
+- Add an FTS5 prose/search table for searchable public text snippets.
+- Add structured numeric/current-fact tables sourced only from
+  `data/exports/*/official_raw.json`.
+- Add alias dictionary tables sourced only from `data/aliases/`.
+- Add metadata/evidence-boundary fields that can filter search and lookup
+  results.
+- Keep numeric/current-fact answers deterministic and grounded in structured
+  tables.
+- Keep JP as the initial active character while preserving
+  character-agnostic schema and query paths.
+- Add tests for retrieval DB construction, current-fact lookup, FTS search,
+  alias loading, metadata filters, and answer verification boundaries.
+
+Excluded from the next implementation slice:
+
+- Do not create a persistent SQLite file in the repository.
+- Do not write generated DB files in daily answer mode.
+- Do not implement private vault, private overlay DB, personal profiles,
+  personal logs, or private knowledge.
+- Do not implement Discord, VLM, video pipeline, web daily-answer mode, or API
+  fallback.
+- Do not add vector search or embeddings.
+- Do not add external package dependencies.
+- Do not create broad knowledge authoring, review workflow, or generated public
+  DB publishing behavior.
+- Do not restore deleted legacy runtime, validators, packages, workflows, or
+  schemas.
+
+## Acceptance Criteria
+
+- A retrieval module can build an in-memory SQLite database from public repo
+  data without writing files.
+- SQLite FTS5 is used for a first prose/search surface.
+- The FTS surface is explicitly non-authoritative for frame, damage, scaling,
+  punish, combo damage, patch delta, and current move facts.
+- Structured current-fact lookup uses tables populated from
+  `data/exports/*/official_raw.json` only.
+- CSV sidecars, `*_manual_review.*`, `supercombo_enrichment.*`, and
+  `derived_metrics.*` are not numeric-answer authority in this slice.
+- Alias loading reads `data/aliases/` and preserves English-compatible metadata
+  keys.
+- Metadata/evidence filters are represented as queryable columns, at minimum:
+  `source_role`, `evidence_basis`, `review_status`, `patch_sensitivity`,
+  `character_slug`, and `data_source`.
+- Numeric/current-fact answer preparation cannot use FTS text or model memory
+  as definitive evidence.
+- Daily answer commands remain read-only for the public repository.
+- Answer logs remain Git-outside only; this slice does not change log writing.
+- Tests prove that JP current facts still work without hardcoding JP as a
+  global assumption.
+
+## Files / Interfaces
+
+Expected implementation files:
+
+- `src/sf6_knowledge_coach/retrieval.py`
+- `src/sf6_knowledge_coach/current_facts.py`
+- `src/sf6_knowledge_coach/answering.py`
+- `src/sf6_knowledge_coach/cli.py`
+- `tests/test_retrieval.py`
+- `tests/test_cli.py`
+- `tests/validation/validate_clean_slate.py`
+- `README.md`
+- `docs/execplans/2026-05-20-phase1-retrieval-contract.md`
+
+Planned command behavior:
+
+```text
+sf6 search <query> [--character <slug>] [--limit <n>]
+sf6 current lookup --character <slug> --move <input> [--field <field>]
+sf6 answer prepare <query> [--log]
+sf6 answer verify <query>
+```
+
+The existing command names remain stable. Implementation may change their
+internal data source from raw JSON iteration to the retrieval DB API.
+
+No new `sf6 ask` command is included in this slice.
+
+## Retrieval Contract
+
+The next implementation should create a small retrieval boundary with these
+conceptual tables.
+
+```text
+current_moves
+  character_slug
+  move_id
+  move_name
+  input
+  field/value columns from official_raw.json
+  data_source = data/exports official_raw
+  source_role = current_fact_authority
+  evidence_basis = official
+  review_status = reviewed
+  patch_sensitivity = high
+
+search_documents
+  doc_id
+  title
+  body
+  character_slug nullable
+  source_role
+  evidence_basis
+  review_status
+  patch_sensitivity
+  data_source
+
+search_documents_fts
+  FTS5 index over title/body
+
+aliases
+  alias
+  normalized_key
+  normalized_value
+  source_path
+```
+
+The first FTS corpus may be intentionally narrow: generated public text
+snippets derived from current move metadata and safe public README-style
+descriptions. It must not be treated as authority for numeric answers.
+
+## Validation Commands
+
+Run from the repository root for this planning-only step:
+
+```bash
+git diff --check
+PYTHONPATH=src python tests/validation/validate_clean_slate.py
+git status --short --branch
+```
+
+Future implementation validation should include:
+
+```bash
+PYTHONPATH=src python -m unittest discover -s tests
+PYTHONPATH=src python tests/validation/validate_clean_slate.py
+PYTHONPATH=src python -m sf6_knowledge_coach.cli search "JP 5LP"
+PYTHONPATH=src python -m sf6_knowledge_coach.cli current lookup --character jp --move 5LP --field block_adv
+PYTHONPATH=src python -m sf6_knowledge_coach.cli answer prepare "JPの5LPはガードで何F？"
+PYTHONPATH=src python -m sf6_knowledge_coach.cli answer verify "JPの5LPはガードで何F？"
+git diff --check
+git diff --cached --check
+git status --short --branch
+```
+
+## Progress
+
+- [x] (2026-05-20 JST) Verified PR #298 was merged into `main` and `origin/main`
+  points to merge commit `214c74e33b7473a00cc3a4b51f1b4b42c8c2e474`.
+- [x] (2026-05-20 JST) Verified main branch CI passed for merge commit
+  `214c74e33b7473a00cc3a4b51f1b4b42c8c2e474`.
+- [x] (2026-05-20 JST) Created branch `plan/phase1-retrieval-contract` from
+  current `main`.
+- [x] (2026-05-20 JST) Reviewed `AGENTS.md`, `docs/PLAN.md`, current CLI,
+  current fact lookup, alias loading, tests, and retained data surfaces.
+- [x] (2026-05-20 JST) Confirmed local Python SQLite supports FTS5.
+- [x] (2026-05-20 JST) Drafted this planning-only ExecPlan.
+- [x] (2026-05-20 JST) Ran planning validation:
+  `git diff --check`,
+  `PYTHONPATH=src python tests/validation/validate_clean_slate.py`, and
+  `git status --short --branch`.
+- [ ] Review and approve the next implementation prompt before code changes.
+
+## Decision Log
+
+- Decision: The next slice uses in-memory SQLite, not a persisted DB file.
+  Rationale: This proves the retrieval contract while preserving daily answer
+  mode as read-only for the public repository and avoiding generated binary DB
+  review churn.
+  Date/Author: 2026-05-20 / Codex
+
+- Decision: Use Python standard library `sqlite3` and SQLite FTS5.
+  Rationale: The scaffold currently has no external dependencies, and local
+  verification showed the available Python SQLite build supports FTS5.
+  Date/Author: 2026-05-20 / Codex
+
+- Decision: `data/exports/*/official_raw.json` remains the only numeric/current
+  fact authority for this slice.
+  Rationale: `docs/PLAN.md` requires deterministic tools/tables for current
+  facts, and `AGENTS.md` forbids numeric answers from memory.
+  Date/Author: 2026-05-20 / Codex
+
+- Decision: FTS search may find current-fact related text but may not authorize
+  numeric answers.
+  Rationale: FTS is useful for discovery, but frame, damage, scaling, punish,
+  combo damage, patch delta, and current move facts require structured table
+  results.
+  Date/Author: 2026-05-20 / Codex
+
+- Decision: Do not implement private vault in this slice.
+  Rationale: The retrieval contract can advance using public surfaces only;
+  private overlay behavior needs a separate boundary-focused ExecPlan.
+  Date/Author: 2026-05-20 / Codex
+
+## Deviations
+
+- None.
+
+## Unresolved Decisions
+
+- Whether a later slice should create a persisted generated public SQLite DB,
+  and if so whether it belongs in Git, GitHub release artifacts, or a Git-outside
+  local cache.
+- Whether future reviewed prose knowledge should live under a new `knowledge/`
+  surface or another public source path after the clean-slate deletion.
+- How much metadata filtering should be exposed through CLI flags versus kept
+  internal to answer preparation.
+- Whether alias normalization should remain query-substring based or become a
+  table-driven tokenization pass.
+
+## Risks
+
+- In-memory DB construction may become slow as public data grows. This is
+  acceptable for the next slice but should be measured before broader use.
+- FTS5 availability must be verified in CI, even though it works locally.
+- Current `data/aliases/` seed coverage is small, so query normalization will
+  remain limited.
+- Search result ranking will be minimal in this slice.
+- The slice does not yet provide complete Phase 1 public knowledge retrieval;
+  it only establishes the retrieval contract boundary.
+
+## Completion Review Table
+
+| PLAN item | Planned implementation | Changed files | Validation command | Result | Deviation | Incomplete | Risk |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| SQLite + FTS prose/search | Add in-memory SQLite FTS5 search over narrow public text snippets. | Future `src/sf6_knowledge_coach/retrieval.py`; `src/sf6_knowledge_coach/cli.py`; tests | Future `sf6 search` smoke and unittest | Pending | None | Not implemented in this planning step | FTS ranking and corpus are intentionally small |
+| Structured numeric tables | Populate structured current-fact tables only from `official_raw.json`. | Future `retrieval.py`; `current_facts.py`; tests | Future current lookup and answer prepare smoke | Pending | None | Not implemented in this planning step | Must not accidentally use sidecars/manual review |
+| Alias dictionary | Load aliases from `data/aliases/` into queryable table/context resolution path. | Future `retrieval.py`; `aliases.py`; tests | Future context/search tests | Pending | None | Not implemented in this planning step | Alias coverage remains limited |
+| Evidence filters | Add filter columns for source role, evidence basis, review status, patch sensitivity, character, and data source. | Future `retrieval.py`; tests | Future metadata filter tests | Pending | None | Not implemented in this planning step | CLI exposure remains undecided |
+| Deterministic numeric answers | Keep numeric answers grounded in structured current-fact lookup, never FTS or model memory. | Future `answering.py`; `current_facts.py`; tests | Future answer verify smoke | Pending | None | Not implemented in this planning step | Boundary must remain covered by tests |
+| Public/private boundary | Keep daily mode read-only for repo data and keep answer logs Git-outside only. | Future tests only unless code needs boundary wiring | Unit tests and clean-slate validator | Pending | None | Private vault not implemented | Later private overlay needs separate ExecPlan |

--- a/docs/execplans/2026-05-20-phase1-retrieval-contract.md
+++ b/docs/execplans/2026-05-20-phase1-retrieval-contract.md
@@ -1,6 +1,6 @@
 # Phase 1 Retrieval Contract
 
-Status: Draft; planning-only, not implemented.
+Status: Paused; implementation is not stage-ready pending Phase 1 roadmap prerequisites.
 
 ## Purpose
 
@@ -8,9 +8,11 @@ Plan the smallest Phase 1 implementation slice that moves the clean-slate
 scaffold toward the retrieval contract in `docs/PLAN.md` without broad runtime
 work.
 
-This ExecPlan does not implement database, CLI, private vault, Discord, VLM,
-web, API, or vector-search behavior. It defines the next implementation slice
-only.
+This ExecPlan records the small attempted implementation slice for an in-memory
+SQLite retrieval boundary. Review found that retrieval should pause until
+current-fact acquisition inventory, value semantics, and schema redesign are
+planned and approved. It does not implement private vault, Discord, VLM, web,
+API, or vector-search behavior.
 
 ## Scope
 
@@ -71,7 +73,7 @@ Excluded from the next implementation slice:
 
 ## Files / Interfaces
 
-Expected implementation files:
+Implementation files:
 
 - `src/sf6_knowledge_coach/retrieval.py`
 - `src/sf6_knowledge_coach/current_facts.py`
@@ -180,7 +182,33 @@ git status --short --branch
   `git diff --check`,
   `PYTHONPATH=src python tests/validation/validate_clean_slate.py`, and
   `git status --short --branch`.
-- [ ] Review and approve the next implementation prompt before code changes.
+- [x] (2026-05-20 JST) Committed this ExecPlan before implementation with
+  message `Plan Phase 1 retrieval contract`.
+- [x] (2026-05-20 JST) Added `src/sf6_knowledge_coach/retrieval.py` with
+  in-memory SQLite tables for current facts, search documents, FTS5, and
+  aliases.
+- [x] (2026-05-20 JST) Routed `current lookup`, `search`, and numeric answer
+  preparation through the retrieval boundary without adding persistent DB
+  files.
+- [x] (2026-05-20 JST) Added tests for in-memory DB behavior, FTS discovery,
+  metadata filters, alias table loading, character-agnostic current fact
+  lookup, and numeric evidence verification.
+- [x] (2026-05-20 JST) Ran full implementation validation:
+  `PYTHONPATH=src python -m unittest discover -s tests`,
+  `PYTHONPATH=src python tests/validation/validate_clean_slate.py`,
+  `sf6 search`, `sf6 current lookup`, `sf6 answer prepare`, `sf6 answer
+  verify`, `git diff --check`, `git diff --cached --check`, and
+  `git status --short --branch`.
+- [x] (2026-05-20 JST) Mandatory review found the current unstaged retrieval
+  implementation is not stage-ready. The immediate bug is raw FTS operator
+  handling for search terms such as `OR`, `AND`, and `NOT`; the larger
+  prerequisite is deterministic current-fact acquisition inventory, value
+  semantics, and schema redesign.
+- [x] (2026-05-20 JST) Paused retrieval implementation. The current unstaged
+  retrieval changes must not be staged until prerequisite ExecPlans are
+  completed or explicitly accepted.
+- [x] (2026-05-20 JST) Created `docs/execplans/2026-05-20-phase1-roadmap.md`
+  to break Phase 1 into separately reviewable units.
 
 ## Decision Log
 
@@ -213,6 +241,35 @@ git status --short --branch
   private overlay behavior needs a separate boundary-focused ExecPlan.
   Date/Author: 2026-05-20 / Codex
 
+- Decision: Store official rows with missing `input` in `current_moves` with a
+  nullable input column rather than dropping them.
+  Rationale: Some `official_raw.json` records represent follow-up or automatic
+  move states without input notation. They remain official current-fact rows,
+  but command lookup by input naturally cannot select them.
+  Date/Author: 2026-05-20 / Codex
+
+- Decision: Keep alias-backed context resolution in `aliases.py` unchanged and
+  add the alias table to the retrieval DB for the next boundary.
+  Rationale: The approved slice allowed queryable alias tables, but broader
+  tokenization or normalization redesign remains unresolved.
+  Date/Author: 2026-05-20 / Codex
+
+- Decision: Pause the current retrieval implementation rather than fix the FTS
+  operator bug in isolation.
+  Rationale: Review found `sf6 search "OR"`, `sf6 search "AND"`, and
+  `sf6 search "NOT"` can traceback because raw user tokens are passed into the
+  SQLite FTS5 `MATCH` expression. That bug is real, but current-fact value
+  semantics and schema boundaries are a higher-priority prerequisite for making
+  retrieval and answer verification safe.
+  Date/Author: 2026-05-20 / Codex
+
+- Decision: Retrieval work resumes only after Phase 1 prerequisite ExecPlans
+  are completed or explicitly accepted.
+  Rationale: Current facts must preserve raw official/SuperCombo values,
+  classify observed value shapes, and define JSON Schemas before retrieval can
+  safely expose normalized/current-fact answer behavior.
+  Date/Author: 2026-05-20 / Codex
+
 ## Deviations
 
 - None.
@@ -222,12 +279,19 @@ git status --short --branch
 - Whether a later slice should create a persisted generated public SQLite DB,
   and if so whether it belongs in Git, GitHub release artifacts, or a Git-outside
   local cache.
+- How all-character official and SuperCombo raw snapshots should be acquired
+  and inventoried.
+- How observed current-fact value shapes should drive JSON Schema redesign.
+- Which parsed value classes can safely support deterministic arithmetic and
+  which must remain raw-only or manual-review-required.
+- How SuperCombo values should be represented as enrichment, cross-reference,
+  or candidate evidence without becoming daily-answer numeric authority.
 - Whether future reviewed prose knowledge should live under a new `knowledge/`
   surface or another public source path after the clean-slate deletion.
 - How much metadata filtering should be exposed through CLI flags versus kept
   internal to answer preparation.
-- Whether alias normalization should remain query-substring based or become a
-  table-driven tokenization pass.
+- Whether alias normalization should move from current query-substring behavior
+  to a table-driven tokenization pass.
 
 ## Risks
 
@@ -239,14 +303,21 @@ git status --short --branch
 - Search result ranking will be minimal in this slice.
 - The slice does not yet provide complete Phase 1 public knowledge retrieval;
   it only establishes the retrieval contract boundary.
+- Some official rows have no input notation; they are stored in the structured
+  table but cannot be selected through `current lookup --move` until a later
+  identifier-based lookup exists.
+- The current unstaged retrieval implementation has a known FTS operator bug and
+  is not stage-ready.
+- Retrieval may need to change after current-fact raw snapshot, value-shape, and
+  schema decisions are made.
 
 ## Completion Review Table
 
 | PLAN item | Planned implementation | Changed files | Validation command | Result | Deviation | Incomplete | Risk |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| SQLite + FTS prose/search | Add in-memory SQLite FTS5 search over narrow public text snippets. | Future `src/sf6_knowledge_coach/retrieval.py`; `src/sf6_knowledge_coach/cli.py`; tests | Future `sf6 search` smoke and unittest | Pending | None | Not implemented in this planning step | FTS ranking and corpus are intentionally small |
-| Structured numeric tables | Populate structured current-fact tables only from `official_raw.json`. | Future `retrieval.py`; `current_facts.py`; tests | Future current lookup and answer prepare smoke | Pending | None | Not implemented in this planning step | Must not accidentally use sidecars/manual review |
-| Alias dictionary | Load aliases from `data/aliases/` into queryable table/context resolution path. | Future `retrieval.py`; `aliases.py`; tests | Future context/search tests | Pending | None | Not implemented in this planning step | Alias coverage remains limited |
-| Evidence filters | Add filter columns for source role, evidence basis, review status, patch sensitivity, character, and data source. | Future `retrieval.py`; tests | Future metadata filter tests | Pending | None | Not implemented in this planning step | CLI exposure remains undecided |
-| Deterministic numeric answers | Keep numeric answers grounded in structured current-fact lookup, never FTS or model memory. | Future `answering.py`; `current_facts.py`; tests | Future answer verify smoke | Pending | None | Not implemented in this planning step | Boundary must remain covered by tests |
-| Public/private boundary | Keep daily mode read-only for repo data and keep answer logs Git-outside only. | Future tests only unless code needs boundary wiring | Unit tests and clean-slate validator | Pending | None | Private vault not implemented | Later private overlay needs separate ExecPlan |
+| SQLite + FTS prose/search | Added an attempted in-memory SQLite FTS5 search over narrow public metadata snippets. Review found raw FTS operator handling is unsafe. | `src/sf6_knowledge_coach/retrieval.py`; `src/sf6_knowledge_coach/cli.py`; `tests/test_retrieval.py`; `tests/test_cli.py` | `PYTHONPATH=src python -m sf6_knowledge_coach.cli search "JP 5LP"`; review repro with `OR`/`AND`/`NOT` | Paused | None | Not stage-ready | FTS operator handling must be fixed when retrieval resumes |
+| Structured numeric tables | Populated attempted structured current-fact table only from `official_raw.json`. | `retrieval.py`; `current_facts.py`; tests | Current lookup and answer prepare smoke | Paused | None | Needs value semantics/schema prerequisite | Inputless official rows require later identifier lookup |
+| Alias dictionary | Loaded aliases from `data/aliases/` into queryable table; existing context resolver remains file-backed. | `retrieval.py`; `tests/test_retrieval.py` | Alias table tests | Paused | None | Table-driven tokenization not implemented | Alias coverage remains limited |
+| Evidence filters | Added queryable source role, evidence basis, review status, patch sensitivity, character, and data source columns. | `retrieval.py`; tests | Metadata filter tests | Paused | None | CLI exposure remains minimal | CLI exposure remains undecided |
+| Deterministic numeric answers | Kept attempted numeric answers grounded in structured current-fact lookup and added verification guard for source role/data source. | `answering.py`; `current_facts.py`; tests | Answer verify smoke and unittest | Paused | None | Needs current-fact schema/value semantics | Boundary must remain covered by later tests |
+| Public/private boundary | Daily mode still reads public data and does not write generated DB files; answer log behavior remains Git-outside only. | `README.md`; tests | Unit tests and clean-slate validator | Pass | None | Private vault not implemented | Later private overlay needs separate ExecPlan |

--- a/docs/execplans/2026-05-20-phase1-roadmap.md
+++ b/docs/execplans/2026-05-20-phase1-roadmap.md
@@ -1,0 +1,538 @@
+# Phase 1 Roadmap
+
+Status: Finalized as planning roadmap; retrieval implementation remains paused.
+
+## Purpose
+
+Break Phase 1 into separately reviewable units so each unit can be approved
+before implementation. The current unstaged retrieval implementation is paused
+and must not be staged until prerequisite current-fact acquisition inventory,
+value semantics, and schema decisions are completed or explicitly accepted.
+
+This roadmap is a governance artifact. It does not implement fetching, schema,
+runtime, validator, private vault, Discord, VLM, web daily-answer mode, API
+fallback, vector search, persistent DB, or `sf6 ask` behavior.
+
+## Global Constraints
+
+- Official values may become `current_fact_authority` after deterministic
+  parsing and validation.
+- SuperCombo starts as enrichment, cross-reference, or candidate evidence only.
+- Raw source values must be preserved exactly.
+- Manual review, prose, FTS, and LLM memory are not numeric authority.
+- Daily answer mode remains read-only for public repo data.
+- No generated DB files are written to the repo unless a later ExecPlan
+  explicitly approves that surface.
+- Do not add private vault, Discord, VLM, web daily-answer mode, API fallback,
+  vector search, persistent DB, or `sf6 ask` in these units unless a later
+  ExecPlan changes the contract.
+- Each unit needs a mandatory review before the next unit begins.
+
+## Task Units
+
+### 1. Current-Fact Acquisition Inventory Planning
+
+Purpose: Define how the project will inventory official and SuperCombo
+current-fact sources before changing schemas or retrieval.
+
+Inputs:
+
+- `docs/PLAN.md`
+- Existing `data/exports/`
+- Existing `data/aliases/`
+- Current clean-slate CLI/tests
+
+Outputs/artifacts:
+
+- ExecPlan for source inventory
+- Source list and per-source acquisition questions
+- Field inventory template
+
+Authority/evidence rules:
+
+- This unit does not promote any new data to authority.
+- It records source roles only.
+
+Explicit exclusions:
+
+- No fetching implementation.
+- No schema implementation.
+- No runtime answer behavior changes.
+
+Validation commands:
+
+```bash
+git diff --check
+PYTHONPATH=src python tests/validation/validate_clean_slate.py
+git status --short --branch
+```
+
+Approval gate:
+
+- Reviewer approves source list, artifact boundaries, and inventory template.
+
+### 2. Official All-Character Raw Snapshot Acquisition
+
+Purpose: Acquire or refresh official all-character raw snapshots with exact raw
+values preserved.
+
+Inputs:
+
+- Approved acquisition inventory plan
+- Official source URLs or source descriptors
+- Existing `data/exports/` for comparison
+
+Outputs/artifacts:
+
+- Official raw snapshot artifacts
+- Acquisition metadata including fetch time, source URL, extractor, and source
+  version when available
+- Raw row manifest
+
+Authority/evidence rules:
+
+- Official raw rows may become current-fact authority only after schema and
+  validator gates.
+- Raw values are preserved exactly and are not rewritten by the acquisition
+  step.
+
+Explicit exclusions:
+
+- No SuperCombo acquisition.
+- No parsed value semantics.
+- No answer behavior change.
+
+Validation commands:
+
+```bash
+git diff --check
+PYTHONPATH=src python tests/validation/validate_clean_slate.py
+git status --short --branch
+```
+
+Approval gate:
+
+- Reviewer approves raw snapshot placement, manifest shape, and no-loss raw
+  preservation.
+
+### 3. SuperCombo All-Character Raw Snapshot Acquisition
+
+Purpose: Acquire or inventory SuperCombo all-character raw snapshots as
+cross-reference/enrichment evidence without making them numeric authority.
+
+Inputs:
+
+- Approved acquisition inventory plan
+- SuperCombo source URLs or source descriptors
+- Chosen acquisition approach, including Scrapling if selected
+
+Outputs/artifacts:
+
+- SuperCombo raw snapshot artifacts
+- Acquisition metadata
+- Raw row manifest
+
+Authority/evidence rules:
+
+- SuperCombo values are enrichment, cross-reference, or candidate evidence.
+- They are not daily-answer numeric authority in this unit.
+
+Explicit exclusions:
+
+- No promotion policy.
+- No answer behavior change.
+- No official/SuperCombo reconciliation logic.
+
+Validation commands:
+
+```bash
+git diff --check
+PYTHONPATH=src python tests/validation/validate_clean_slate.py
+git status --short --branch
+```
+
+Approval gate:
+
+- Reviewer approves source role separation and raw preservation.
+
+### 4. Value-Shape Inventory Across All Fields
+
+Purpose: Build a complete inventory of observed value representations across all
+characters, fields, and approved raw sources.
+
+Inputs:
+
+- Official raw snapshots
+- SuperCombo raw snapshots
+- Field inventory template
+
+Outputs/artifacts:
+
+- Value-shape inventory
+- Per-field observed shape counts
+- Examples for scalar, signed frame, parenthesized, plus-separated, multihit,
+  conditional, missing/blank, nonnumeric note, raw-only, and unparsed values
+
+Authority/evidence rules:
+
+- Inventory classifies observed shapes; it does not calculate official totals.
+- LLM interpretation is not an authority source.
+
+Explicit exclusions:
+
+- No parsed value implementation.
+- No normalized export.
+- No retrieval changes.
+
+Validation commands:
+
+```bash
+git diff --check
+PYTHONPATH=src python tests/validation/validate_clean_slate.py
+git status --short --branch
+```
+
+Approval gate:
+
+- Reviewer approves that inventory coverage is sufficient to design schemas.
+
+### 5. Current-Fact JSON Schema Redesign
+
+Purpose: Redesign current-fact schemas using the actual source and value-shape
+inventory.
+
+Inputs:
+
+- Value-shape inventory
+- Source snapshot manifests
+- PLAN authority rules
+
+Outputs/artifacts:
+
+- JSON Schemas for `source_snapshot`, `source_row`, `current_fact_record`,
+  `parsed_value`, and `value_shape_inventory`
+- Fixtures for each discovered shape class
+- Validator plan
+
+Authority/evidence rules:
+
+- `source_role`, `evidence_basis`, `review_status`, `patch_sensitivity`, and
+  raw/parsed boundaries are explicit schema fields.
+- `raw_value` is preserved even when `parsed_value` exists.
+
+Explicit exclusions:
+
+- No parser implementation.
+- No generated DB.
+- No retrieval changes.
+
+Validation commands:
+
+```bash
+git diff --check
+PYTHONPATH=src python tests/validation/validate_clean_slate.py
+git status --short --branch
+```
+
+Approval gate:
+
+- Reviewer approves schema boundaries and fixture coverage before parser work.
+
+### 6. Deterministic Parsed-Value Classifier
+
+Purpose: Implement deterministic classification for approved raw value shapes.
+
+Inputs:
+
+- Approved JSON Schemas
+- Value-shape fixtures
+- Official/SuperCombo raw snapshot examples
+
+Outputs/artifacts:
+
+- Parser/classifier implementation
+- Tests for scalar, signed frame, parenthesized, plus-separated, multihit,
+  conditional, missing/blank, nonnumeric note, raw-only, and unparsed values
+- Validator coverage for parser output
+
+Authority/evidence rules:
+
+- Parser may classify values and produce safe numeric scalars only for approved
+  shapes.
+- Parser must not infer totals from expressions unless the approved schema and
+  tests explicitly allow it.
+
+Explicit exclusions:
+
+- No LLM arithmetic.
+- No SuperCombo promotion.
+- No answer prose expansion.
+
+Validation commands:
+
+```bash
+PYTHONPATH=src python -m unittest discover -s tests
+PYTHONPATH=src python tests/validation/validate_clean_slate.py
+git diff --check
+git status --short --branch
+```
+
+Approval gate:
+
+- Reviewer approves parser boundaries and rejects any unapproved calculation.
+
+### 7. Normalized Current-Fact Export Design
+
+Purpose: Design normalized current-fact artifacts built from approved raw
+snapshots and parsed values.
+
+Inputs:
+
+- Approved schemas
+- Approved parser/classifier
+- Raw snapshots
+
+Outputs/artifacts:
+
+- Normalized export ExecPlan
+- Artifact placement decision
+- Validator requirements
+
+Authority/evidence rules:
+
+- Normalized official current facts can become current-fact authority only when
+  generated from approved official raw snapshots and parser outputs.
+- SuperCombo remains separate unless later promoted by explicit policy.
+
+Explicit exclusions:
+
+- No generated DB unless separately approved.
+- No private overlay.
+- No answer runtime changes.
+
+Validation commands:
+
+```bash
+git diff --check
+PYTHONPATH=src python tests/validation/validate_clean_slate.py
+git status --short --branch
+```
+
+Approval gate:
+
+- Reviewer approves artifact location, generated markers, and authority status.
+
+### 8. Retrieval DB Resume/Fix
+
+Purpose: Resume retrieval only after current-fact schema/value prerequisites are
+accepted, including the known FTS operator bug.
+
+Inputs:
+
+- Approved schemas or explicit acceptance to proceed without them
+- Normalized current-fact design or approved raw-source boundary
+- Paused retrieval implementation
+
+Outputs/artifacts:
+
+- Safe in-memory retrieval implementation
+- Fixed literal FTS query handling for terms such as `OR`, `AND`, and `NOT`
+- Retrieval tests for metadata filters and current-fact boundaries
+
+Authority/evidence rules:
+
+- FTS remains discovery-only.
+- Numeric/current-fact answers use structured authority tables, not FTS.
+
+Explicit exclusions:
+
+- No persistent DB.
+- No vector search.
+- No broad answer behavior rewrite.
+
+Validation commands:
+
+```bash
+PYTHONPATH=src python -m unittest discover -s tests
+PYTHONPATH=src python tests/validation/validate_clean_slate.py
+PYTHONPATH=src python -m sf6_knowledge_coach.cli search "JP 5LP"
+PYTHONPATH=src python -m sf6_knowledge_coach.cli search "OR"
+PYTHONPATH=src python -m sf6_knowledge_coach.cli search "AND"
+PYTHONPATH=src python -m sf6_knowledge_coach.cli search "NOT"
+git diff --check
+git status --short --branch
+```
+
+Approval gate:
+
+- Reviewer confirms retrieval is stage-ready and still non-authoritative for
+  numeric facts.
+
+### 9. Answer Behavior And Answer Verify Boundaries
+
+Purpose: Define and implement answer preparation/verification behavior for
+scalar, expression, raw-only, candidate, and unavailable values.
+
+Inputs:
+
+- Approved parser/classifier
+- Approved authority policy
+- Retrieval/current-fact implementation
+
+Outputs/artifacts:
+
+- Answer behavior tests
+- Verification rules for source role, raw/parsed value kind, and uncertainty
+- User-facing hold/uncertainty language for raw-only or candidate values
+
+Authority/evidence rules:
+
+- Deterministic official parsed values may answer directly when approved.
+- Raw-only expressions must preserve raw value and include uncertainty or
+  parsing limitation.
+- SuperCombo candidates must not be stated as definitive daily-answer facts.
+
+Explicit exclusions:
+
+- No API fallback.
+- No Discord adapter.
+- No private personalization.
+
+Validation commands:
+
+```bash
+PYTHONPATH=src python -m unittest discover -s tests
+PYTHONPATH=src python tests/validation/validate_clean_slate.py
+PYTHONPATH=src python -m sf6_knowledge_coach.cli answer prepare "JPの5LPはガードで何F？"
+PYTHONPATH=src python -m sf6_knowledge_coach.cli answer verify "JPの5LPはガードで何F？"
+git diff --check
+git status --short --branch
+```
+
+Approval gate:
+
+- Reviewer approves that answer behavior follows source authority and value
+  semantics.
+
+### 10. CI/Validator Expansion
+
+Purpose: Expand CI and validators only after schemas, parser, retrieval, and
+answer boundaries have approved tests.
+
+Inputs:
+
+- Approved tests and validators from prior units
+- Current `.github/workflows/ci.yml`
+- Clean-slate validator
+
+Outputs/artifacts:
+
+- CI/validator ExecPlan
+- Updated CI commands
+- Validation guard coverage for source snapshots, schemas, parser fixtures, and
+  answer boundaries
+
+Authority/evidence rules:
+
+- CI must reject private data, generated DB files not explicitly approved, and
+  numeric authority violations.
+
+Explicit exclusions:
+
+- No dependency installation unless separately approved.
+- No artifact upload of private or local state.
+- No legacy workflow restoration.
+
+Validation commands:
+
+```bash
+PYTHONPATH=src python -m unittest discover -s tests
+PYTHONPATH=src python tests/validation/validate_clean_slate.py
+git diff --check
+git status --short --branch
+```
+
+Approval gate:
+
+- Reviewer approves CI coverage before PR readiness.
+
+## Known Blocked Work
+
+- Current unstaged retrieval implementation is not stage-ready.
+- FTS operator bug must wait until retrieval resumes.
+- Retrieval DB authority boundaries depend on current-fact schema/value
+  semantics.
+- Answer verification for expression/raw-only values depends on parsed-value
+  classification.
+- Inputless official rows need an identifier-based lookup decision.
+- Alias tokenization and metadata filter CLI exposure remain unresolved.
+- In-memory DB performance must be measured after normalized artifacts and
+  retrieval scope are clearer.
+
+## Validation Commands
+
+Run from the repository root for this planning-only step:
+
+```bash
+git diff --check
+PYTHONPATH=src python tests/validation/validate_clean_slate.py
+git status --short --branch
+```
+
+## Progress
+
+- [x] (2026-05-20 JST) Recorded that the current retrieval implementation is
+  paused and not stage-ready.
+- [x] (2026-05-20 JST) Listed known Phase 1 blocked work from retrieval review
+  and current-fact value semantics discussion.
+- [x] (2026-05-20 JST) Broke Phase 1 into ten separately reviewable units with
+  per-unit approval gates.
+- [x] (2026-05-20 JST) Completed planning validation:
+  `git diff --check`,
+  `PYTHONPATH=src python tests/validation/validate_clean_slate.py`, and
+  `git status --short --branch`.
+- [x] (2026-05-20 JST) Final roadmap review completed; roadmap is ready to
+  stage as docs-only work while paused retrieval implementation remains
+  unstaged.
+
+## Decision Log
+
+- Decision: Split Phase 1 into separately reviewed units before continuing
+  retrieval implementation.
+  Rationale: Current-fact value semantics, source acquisition, and JSON Schema
+  boundaries are prerequisites for safe retrieval and answer behavior.
+  Date/Author: 2026-05-20 / Codex
+
+- Decision: Treat SuperCombo acquisition separately from official acquisition.
+  Rationale: A common acquisition technique such as Scrapling may be practical,
+  but source authority differs. Official values may become current-fact
+  authority; SuperCombo starts as enrichment/cross-reference/candidate.
+  Date/Author: 2026-05-20 / Codex
+
+- Decision: Do not fix the FTS operator bug until retrieval resumes.
+  Rationale: The bug is real, but fixing it alone would advance a retrieval
+  slice whose current-fact schema and value semantics are not yet approved.
+  Date/Author: 2026-05-20 / Codex
+
+## Deviations
+
+- None.
+
+## Risks
+
+- The roadmap may reveal that some current unstaged retrieval work needs to be
+  discarded or rewritten after schema decisions.
+- All-character acquisition may expose value shapes not listed here.
+- SuperCombo source structure may require source-specific extraction policy even
+  if acquisition tooling is shared.
+- Planning-only validators do not prove future source acquisition or parser
+  correctness.
+
+## Completion Review Table
+
+| PLAN item | Planned implementation | Changed files | Validation command | Result | Deviation | Incomplete | Risk |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| ExecPlan governance | Added a Phase 1 roadmap with separate approval gates before implementation units. | `docs/execplans/2026-05-20-phase1-roadmap.md` | `git diff --check`; clean-slate validator | Pass | None | None for roadmap docs | Roadmap may need adjustment after source inventory |
+| Numeric/current-fact safety | Made acquisition inventory, value-shape inventory, schema redesign, and parser classification prerequisites before retrieval/answers. | Roadmap only | Review of roadmap | Pass | None | No implementation in this step | Future parser must avoid unapproved arithmetic |
+| Source authority boundary | Separated official authority path from SuperCombo enrichment/candidate path. | Roadmap only | Review of roadmap | Pass | None | No source acquisition yet | Source-specific extraction may be needed |
+| Retrieval pause | Recorded that retrieval implementation is paused and the FTS operator bug waits for retrieval resume. | `docs/execplans/2026-05-20-phase1-retrieval-contract.md`; roadmap | Review of docs | Pass | None | Current unstaged code remains not stage-ready | Unstaged code must not be committed accidentally |


### PR DESCRIPTION
## Summary
- Adds a Phase 1 retrieval-contract ExecPlan.
- Records that the attempted retrieval implementation is paused and not stage-ready.
- Adds a Phase 1 roadmap that splits current-fact acquisition, source authority, value-shape inventory, schema redesign, parser work, retrieval resume, answer behavior, and CI expansion into separately reviewable units.

## Scope
Docs only:
- docs/execplans/2026-05-20-phase1-retrieval-contract.md
- docs/execplans/2026-05-20-phase1-roadmap.md

Paused runtime implementation files remain local and are not part of this PR.

## Validation
- git diff --check
- PYTHONPATH=src python tests/validation/validate_clean_slate.py

## Notes
- Draft PR only.
- Do not merge until reviewed.
- No runtime/schema/fetching changes are included.