### PR TITLE
Retire legacy alias fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ under [docs/execplans/](docs/execplans/).
 - `docs/PLAN.md`: clean-slate architecture contract.
 - `docs/execplans/`: scoped execution plans for implementation slices.
 - `data/exports/`: retained public current-fact seed data.
-- `data/aliases/`: retained query-normalization seed data.
 - `src/sf6_knowledge_coach/`: minimal deterministic local tools.
 - `tests/`: clean-slate tests and validation.
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -183,7 +183,9 @@ knowledge_item:
 
 - SQLite + FTS: prose/search 用。概念説明、レビュー済み知識、用語、戦術メモの検索に使う。
 - Structured numeric tables: frame、damage、scaling、punish、combo damage、patch delta、current move facts の正確値に使う。
-- Alias dictionary from `data/aliases/`: 日本語・英語・略称・表記揺れのquery normalizationに使う。
+- Alias dictionary: 日本語・英語・略称・表記揺れのquery normalizationに使う。旧
+  `data/aliases/` seed fixtureはclean-slate後の負債としてretireし、将来の
+  alias dictionary surfaceは別ExecPlanで新規設計する。
 - Metadata filters: evidence boundary、status、review state、patch sensitivity、source role、personal/public boundary の絞り込みに使う。
 
 数値回答は、prose FTSやLLM memoryではなく、deterministic tools/tables の結果を必須根拠にする。
@@ -327,7 +329,7 @@ Step 2: 30+短尺クリップ
 - 公開repoに実個人情報は置かない
 - 日常回答runtimeはCodex CLI中心
 - API課金前提の回答runtimeにはしない
-- 初期検索・取得はSQLite + FTS、structured numeric tables、`data/aliases/` alias dictionary、metadata filtersを組み合わせる
+- 初期検索・取得はSQLite + FTS、structured numeric tables、newly designed alias dictionary、metadata filtersを組み合わせる
 - 数値回答はdeterministic tools/tablesを必須根拠にし、prose FTSやLLM memoryから答えない
 - ベクトル検索は後続判断
 - 動画の元データと解析中間物はGit外

--- a/docs/execplans/2026-05-23-retire-legacy-alias-fixture.md
+++ b/docs/execplans/2026-05-23-retire-legacy-alias-fixture.md
@@ -1,0 +1,51 @@
+# Retire Legacy Alias Fixture
+
+Status: Implementation complete; review pending.
+
+## Purpose
+
+Retire the old `data/aliases/` fixture as legacy app data. Keep only the
+current lightweight fallback resolver until a new alias dictionary is designed.
+
+## Scope
+
+Change only PLAN/README wording, the alias fallback, tests, and clean-slate
+validation. Do not add new alias data, retrieval behavior, schema/parser work,
+or authority changes.
+
+## Changes
+
+- `docs/PLAN.md`: future alias dictionary remains planned, but no longer points
+  at retired `data/aliases/`.
+- `README.md`: removes stale retained-alias-surface wording.
+- `src/sf6_knowledge_coach/aliases.py`: removes legacy JSON fixture loading and
+  keeps fixture-free fallback resolution.
+- `src/sf6_knowledge_coach/paths.py`: removes the now-unused alias fixture path.
+- `tests/test_cli.py`: tests the JP block-advantage smoke path without alias
+  fixture data.
+- `tests/validation/validate_clean_slate.py`: stops requiring
+  `data/aliases/ja-query-fixtures.json`.
+
+## Validation
+
+```bash
+git diff --check
+git diff --cached --check
+PYTHONPATH=src uv run --locked python -m unittest tests.test_cli
+PYTHONPATH=src uv run --locked python -m unittest discover -s tests
+PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
+PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.cli answer prepare "JPの5LPはガードで何F？"
+git status --short --branch
+```
+
+## Decision
+
+Do not restore `data/aliases/`. The old fixture is data debt; future alias
+coverage needs a clean-slate ExecPlan.
+
+## Risks
+
+- Japanese query normalization remains intentionally narrow until that future
+  alias design lands.
+
+PLAN deviations: none.

--- a/src/sf6_knowledge_coach/aliases.py
+++ b/src/sf6_knowledge_coach/aliases.py
@@ -1,19 +1,17 @@
 from __future__ import annotations
 
-import json
 import re
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any
 
-from .paths import aliases_file, exports_dir
+from .paths import exports_dir
 
 
 FIELD_ALIASES = {
-    "startup": ["startup", "発生", "何f", "何F"],
     "block_adv": ["block", "on block", "ガード", "硬直差", "有利不利"],
     "hit_adv": ["hit", "ヒット"],
     "damage": ["damage", "ダメージ"],
+    "startup": ["startup", "発生", "何f", "何F"],
 }
 
 
@@ -33,14 +31,6 @@ class ResolvedContext:
         }
 
 
-def load_alias_entries(path: Path | None = None) -> list[dict[str, Any]]:
-    source = path or aliases_file()
-    if not source.exists():
-        return []
-    payload = json.loads(source.read_text(encoding="utf-8"))
-    return list(payload.get("entries", []))
-
-
 def available_character_slugs() -> set[str]:
     root = exports_dir()
     if not root.exists():
@@ -51,14 +41,6 @@ def available_character_slugs() -> set[str]:
 def resolve_query(query: str) -> ResolvedContext:
     lowered = query.casefold()
     resolved: dict[str, str] = {}
-
-    for entry in load_alias_entries():
-        aliases = entry.get("aliases", [])
-        if any(str(alias).casefold() in lowered for alias in aliases):
-            normalized = entry.get("normalized", {})
-            for key, value in normalized.items():
-                if isinstance(value, str):
-                    resolved[key] = value
 
     for slug in sorted(available_character_slugs(), key=len, reverse=True):
         if slug.casefold() in lowered:

--- a/src/sf6_knowledge_coach/paths.py
+++ b/src/sf6_knowledge_coach/paths.py
@@ -11,9 +11,5 @@ def data_dir() -> Path:
     return repo_root() / "data"
 
 
-def aliases_file() -> Path:
-    return data_dir() / "aliases" / "ja-query-fixtures.json"
-
-
 def exports_dir() -> Path:
     return data_dir() / "exports"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,10 +16,10 @@ from sf6_knowledge_coach.paths import repo_root
 
 
 class CleanSlateCliTests(unittest.TestCase):
-    def test_resolves_seed_alias_fixture(self) -> None:
-        context = resolve_query("リュウの屈中Pってガードで何F？")
-        self.assertEqual(context.character_slug, "ryu")
-        self.assertEqual(context.move_input, "2MP")
+    def test_resolves_current_fact_query_without_legacy_alias_fixture(self) -> None:
+        context = resolve_query("JPの5LPってガードで何F？")
+        self.assertEqual(context.character_slug, "jp")
+        self.assertEqual(context.move_input, "5LP")
         self.assertEqual(context.field, "block_adv")
 
     def test_current_fact_lookup_uses_official_raw(self) -> None:

--- a/tests/validation/validate_clean_slate.py
+++ b/tests/validation/validate_clean_slate.py
@@ -18,7 +18,6 @@ REQUIRED_PATHS = [
     "src/sf6_knowledge_coach/cli.py",
     "tests/test_cli.py",
     "tests/validation/validate_clean_slate.py",
-    "data/aliases/ja-query-fixtures.json",
     "data/exports/jp/official_raw.json",
 ]
 


### PR DESCRIPTION
## Summary
- retire the legacy data/aliases fixture as old-app data debt
- update PLAN/README/test/clean-slate validation to stop requiring data/aliases
- keep fixture-free JP block-advantage smoke resolution working via existing fallback cues

## Validation
- git diff --check
- git diff --cached --check
- PYTHONPATH=src uv run --locked python -m unittest tests.test_cli
- PYTHONPATH=src uv run --locked python -m unittest discover -s tests
- PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
- PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.cli answer prepare "JPの5LPはガードで何F？"

PLAN deviations: none.