### PR TITLE
Record value-shape source review resolutions

### DIFF
--- a/data/source-reviews/20260521T025403Z-value-shape-blocked-source-review-summary.json
+++ b/data/source-reviews/20260521T025403Z-value-shape-blocked-source-review-summary.json
@@ -1,0 +1,125 @@
+{
+  "artifact_boundary": "source_review_summary_only",
+  "artifact_schema_version": "value_shape_source_review_summary/v1",
+  "authority_status": "review_decision_only_not_authority",
+  "input_disposition": "data/value-shape-dispositions/20260521T025403Z-value-shape-review-item-disposition-summary.json",
+  "resolution_counts": {
+    "parse_rule_required_before_schema": 2,
+    "schema_supports_raw_only": 1
+  },
+  "review_records": [
+    {
+      "affected_count": 3,
+      "decision": "source_confirmed_parse_rule_required",
+      "disposition_recommendation": "parse_rule_required_before_schema",
+      "examples": [
+        {
+          "raw_value": "30-34.35",
+          "raw_value_length": 8,
+          "raw_value_sha256": "sha256:e5b63d5b999e4db9832b8b739603d13d176c510a6750e710d92f5f824f98aafa"
+        },
+        {
+          "raw_value": "20-24.25",
+          "raw_value_length": 8,
+          "raw_value_sha256": "sha256:0ddb4eb80edb81f409403d27b86a55624336a29431c31d02ac520b2f7655d56e"
+        },
+        {
+          "raw_value": "23--33",
+          "raw_value_length": 6,
+          "raw_value_sha256": "sha256:b3f49b438e943f1d1fdf65ee8140af8175bef8ead3dafb7a553052caec70342a"
+        }
+      ],
+      "json_schema_redesign_blocked": true,
+      "next_execplan_needed": "deterministic parsed-value classifier policy",
+      "review_item_id": "value-shape:official--malformed_looking_source_value--u_fdb49a2113ba--u_c2b75204faf1",
+      "reviewer_notes": "The values are source-confirmed raw official active-frame strings. Preserve them exactly and require parser policy for dot and double-dash active-window notation before schema work.",
+      "source_header_path": [
+        "動作フレーム",
+        "持続"
+      ],
+      "source_name": "official",
+      "source_role": "authority_candidate",
+      "source_review_id": "source-review:official-active-malformed-looking",
+      "source_review_result": "resolved_for_disposition"
+    },
+    {
+      "affected_count": 2,
+      "decision": "source_confirmed_raw_only",
+      "disposition_recommendation": "schema_supports_raw_only",
+      "examples": [
+        {
+          "raw_value": "スクトゥム(当身派生版)※スクトゥム中に打撃を受ける",
+          "raw_value_length": 26,
+          "raw_value_sha256": "sha256:13ee294cec0579d7dca691d15d009ed3210cd70714a34009628ed8d8a803709b"
+        },
+        {
+          "raw_value": "OD スクトゥム(当身派生版)※ODスクトゥム中に打撃を受ける",
+          "raw_value_length": 31,
+          "raw_value_sha256": "sha256:7b5b27683ed35146a3d7c7c89e3e527656c6fb0d1c64c0cdd3e8b6bfa4916f25"
+        }
+      ],
+      "json_schema_redesign_blocked": false,
+      "next_execplan_needed": null,
+      "review_item_id": "value-shape:official--source_specific_expression--u_1aa6a6f86513",
+      "reviewer_notes": "The note-bearing move names are source-confirmed raw labels. First normalized export can keep the full source move label raw; a later identity split may be designed separately.",
+      "source_header_path": [
+        "技名"
+      ],
+      "source_name": "official",
+      "source_role": "authority_candidate",
+      "source_review_id": "source-review:official-note-bearing-move-name",
+      "source_review_result": "resolved_for_disposition"
+    },
+    {
+      "affected_count": 29,
+      "decision": "source_confirmed_supercombo_pair_parse_rule_required",
+      "disposition_recommendation": "parse_rule_required_before_schema",
+      "examples": [
+        {
+          "raw_value": "0.8 / 0.33",
+          "raw_value_length": 10,
+          "raw_value_sha256": "sha256:7f58b84d25ac365a9bf1193aecc8878e9c3da7528d1e1590a94fe56e02ee6220"
+        },
+        {
+          "raw_value": "0.85 / 0.38",
+          "raw_value_length": 11,
+          "raw_value_sha256": "sha256:a4bbe8d308b12b339d192bb091608cb1d07e529ff5209f12f8687afd26145995"
+        },
+        {
+          "raw_value": "0.9 / 0.43",
+          "raw_value_length": 10,
+          "raw_value_sha256": "sha256:3c0d946c34559b011f6cade7c871c22b0cc9fc39a1e8877437acde618809d1d4"
+        },
+        {
+          "raw_value": "1.02 / 0.49",
+          "raw_value_length": 11,
+          "raw_value_sha256": "sha256:ad96d0da5e0cfdcb8be8fb43a5432c9fff76c58542e3de324276e58c53a1cca1"
+        }
+      ],
+      "json_schema_redesign_blocked": true,
+      "next_execplan_needed": "SuperCombo mapping and pair-value parser policy update",
+      "proposed_components": [
+        "throw_range",
+        "hurtbox"
+      ],
+      "proposed_field_key": "supercombo_throw_range_hurtbox_pair",
+      "review_item_id": "value-shape:supercombo--unclassified_expression--character_vitals--throw_range_hurtbox",
+      "reviewer_notes": "The source label names an ordered paired value: Throw Range / Hurtbox. It remains SuperCombo enrichment only and needs a pair parser before schema use.",
+      "source_header_path": [
+        "Character Vitals",
+        "Throw Range / Hurtbox"
+      ],
+      "source_name": "supercombo",
+      "source_role": "enrichment_candidate",
+      "source_review_id": "source-review:supercombo-throw-range-hurtbox",
+      "source_review_result": "resolved_for_disposition"
+    }
+  ],
+  "run_id": "20260521T025403Z",
+  "source_boundary": {
+    "full_raw_rows_public_commit": "forbidden",
+    "local_artifacts_public_commit": "forbidden",
+    "raw_html_public_commit": "forbidden"
+  },
+  "total_review_records": 3
+}

--- a/docs/execplans/2026-05-23-value-shape-source-review-resolution.md
+++ b/docs/execplans/2026-05-23-value-shape-source-review-resolution.md
@@ -1,0 +1,50 @@
+# Value-Shape Source Review Resolution
+
+Status: Implementation complete; review pending.
+
+## Purpose
+
+Resolve the 3 `blocked_pending_source_review` value-shape items from the
+20260521T025403Z disposition artifact by recording source-review decisions.
+
+## Scope
+
+Create public Markdown/JSON source-review summaries and a validator. Do not
+change schema, parser, normalized export, retrieval, answer behavior, source
+acquisition, or authority status.
+
+## Decisions
+
+- Official active-frame malformed-looking values are source-confirmed raw
+  values and need parse-rule policy before schema work.
+- Official note-bearing move names are source-confirmed raw move labels and can
+  be represented raw-only until a later move-identity split is designed.
+- SuperCombo `Throw Range / Hurtbox` is a source-native paired value. It can be
+  mapped as SuperCombo-specific enrichment with later pair parsing, not as
+  official numeric authority.
+
+## Files
+
+- `docs/source-reviews/20260521T025403Z-value-shape-blocked-source-review.md`
+- `data/source-reviews/20260521T025403Z-value-shape-blocked-source-review-summary.json`
+- `tests/validation/validate_value_shape_source_review.py`
+- `docs/execplans/2026-05-23-value-shape-source-review-resolution.md`
+
+## Validation
+
+```bash
+git diff --check
+git diff --cached --check
+PYTHONPATH=src uv run --locked python tests/validation/validate_value_shape_source_review.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_value_shape_disposition.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
+git status --short --branch
+```
+
+PLAN deviations: none.
+
+## Remaining Risks
+
+- The disposition and SuperCombo mapping artifacts still need a follow-up
+  update to consume these source-review resolutions.
+- Parser/classifier and enum policies remain unimplemented.

--- a/docs/source-reviews/20260521T025403Z-value-shape-blocked-source-review.md
+++ b/docs/source-reviews/20260521T025403Z-value-shape-blocked-source-review.md
@@ -1,0 +1,25 @@
+# Value-Shape Blocked Source Review
+
+This is a source-review summary only. It does not implement schema, parser,
+retrieval, answer behavior, or numeric authority.
+
+- Run ID: `20260521T025403Z`
+- Input disposition: `data/value-shape-dispositions/20260521T025403Z-value-shape-review-item-disposition-summary.json`
+- Review records: `3`
+
+## Decisions
+
+| Review item | Source | Source header path | Recommendation | Notes |
+| --- | --- | --- | --- | --- |
+| `value-shape:official--malformed_looking_source_value--u_fdb49a2113ba--u_c2b75204faf1` | `official` | `動作フレーム > 持続` | `parse_rule_required_before_schema` | Values such as `30-34.35`, `20-24.25`, and `23--33` are source-confirmed raw official active-frame strings. Preserve exactly; parser policy must decide dot and double-dash active-window notation. |
+| `value-shape:official--source_specific_expression--u_1aa6a6f86513` | `official` | `技名` | `schema_supports_raw_only` | Note-bearing move names are source-confirmed raw labels. First normalized export can keep the full source move label raw. |
+| `value-shape:supercombo--unclassified_expression--character_vitals--throw_range_hurtbox` | `supercombo` | `Character Vitals > Throw Range / Hurtbox` | `parse_rule_required_before_schema` | Source label names an ordered paired value: `Throw Range / Hurtbox`. Proposed components are `throw_range` and `hurtbox`; SuperCombo remains enrichment only. |
+
+## Boundary Notes
+
+- Official remains authority candidate only.
+- SuperCombo remains enrichment/cross-reference/candidate only.
+- No current-fact authority is added.
+- No full raw rows, raw HTML, screenshots, local paths, cookies, browser
+  profiles, traces, debug dumps, answer logs, training logs, or private data are
+  included.

--- a/tests/validation/validate_value_shape_source_review.py
+++ b/tests/validation/validate_value_shape_source_review.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+JSON_PATH = ROOT / "data/source-reviews/20260521T025403Z-value-shape-blocked-source-review-summary.json"
+MD_PATH = ROOT / "docs/source-reviews/20260521T025403Z-value-shape-blocked-source-review.md"
+EXPECTED_IDS = {
+    "value-shape:official--malformed_looking_source_value--u_fdb49a2113ba--u_c2b75204faf1",
+    "value-shape:official--source_specific_expression--u_1aa6a6f86513",
+    "value-shape:supercombo--unclassified_expression--character_vitals--throw_range_hurtbox",
+}
+DISPOSITIONS = {
+    "parse_rule_required_before_schema",
+    "schema_supports_raw_only",
+}
+FORBIDDEN_PATTERNS = [
+    re.compile(r"(?i)(?:^|[\s\"'`])(?:/[a-z0-9_.-]+)+"),
+    re.compile(r"(?i)(?:^|[\s\"'`(])[A-Z]:[\\/]"),
+    re.compile(r"(?i)\b(?:cookie|authorization|bearer|token|password|secret)\b"),
+    re.compile(r"(?i)<html|</html|<!doctype|<table|</table|<tr|</tr|<td|</td|<th|</th"),
+    re.compile(r"(?i)\b(?:screenshot|trace|debug dump|answer[-_ ]?log|training[-_ ]?log|private[-_ ]?vault)\b"),
+]
+
+
+def main() -> int:
+    errors: list[str] = []
+    if not JSON_PATH.exists():
+        errors.append(f"Missing {JSON_PATH.relative_to(ROOT)}")
+    if not MD_PATH.exists():
+        errors.append(f"Missing {MD_PATH.relative_to(ROOT)}")
+    if errors:
+        return _finish(errors)
+
+    payload = json.loads(JSON_PATH.read_text(encoding="utf-8"))
+    if payload.get("artifact_schema_version") != "value_shape_source_review_summary/v1":
+        errors.append("unexpected artifact_schema_version")
+    if payload.get("run_id") != "20260521T025403Z":
+        errors.append("unexpected run_id")
+    if payload.get("artifact_boundary") != "source_review_summary_only":
+        errors.append("artifact_boundary must be source_review_summary_only")
+    if payload.get("authority_status") != "review_decision_only_not_authority":
+        errors.append("authority_status must be review_decision_only_not_authority")
+
+    records = payload.get("review_records", [])
+    ids = {record.get("review_item_id") for record in records}
+    if len(records) != 3 or payload.get("total_review_records") != 3:
+        errors.append("source review must contain exactly 3 records")
+    if ids != EXPECTED_IDS:
+        errors.append("source review records do not match blocked disposition IDs")
+
+    for index, record in enumerate(records):
+        if record.get("source_review_result") != "resolved_for_disposition":
+            errors.append(f"review_records[{index}] must be resolved_for_disposition")
+        if record.get("disposition_recommendation") not in DISPOSITIONS:
+            errors.append(f"review_records[{index}] has invalid disposition recommendation")
+        if record.get("source_name") == "official" and record.get("source_role") != "authority_candidate":
+            errors.append(f"review_records[{index}] official role must remain authority_candidate")
+        if record.get("source_name") == "supercombo" and record.get("source_role") != "enrichment_candidate":
+            errors.append(f"review_records[{index}] SuperCombo role must remain enrichment_candidate")
+        if "parsed_value" in record or "current_fact_authority" in json.dumps(record, ensure_ascii=False):
+            errors.append(f"review_records[{index}] must not include parsed values or authority promotion")
+
+    for path in (JSON_PATH, MD_PATH):
+        text = path.read_text(encoding="utf-8")
+        for pattern in FORBIDDEN_PATTERNS:
+            if pattern.search(text):
+                errors.append(f"{path.relative_to(ROOT)} contains forbidden public content")
+                break
+        for literal in [".local/", ".venv/", ".agents/", "/tmp", "page.html", "official_table_rows.raw.json", "supercombo_tables.raw.json"]:
+            if literal in text:
+                errors.append(f"{path.relative_to(ROOT)} contains forbidden literal: {literal}")
+    return _finish(errors)
+
+
+def _finish(errors: list[str]) -> int:
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("Value-shape source review validation OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- record source-review resolutions for the 3 blocked value-shape disposition items
- add Markdown + JSON source-review summaries and a validator
- do not change schema/parser/retrieval/answer behavior or authority status

## Validation
- git diff --check
- git diff --cached --check
- PYTHONPATH=src uv run --locked python -m unittest discover -s tests
- PYTHONPATH=src uv run --locked python tests/validation/validate_value_shape_source_review.py
- PYTHONPATH=src uv run --locked python tests/validation/validate_value_shape_disposition.py
- PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py

PLAN deviations: none.