### PR TITLE
Apply value-shape source review resolutions

### DIFF
--- a/data/field-mappings/20260521T025403Z-supercombo-canonical-field-mapping-summary.json
+++ b/data/field-mappings/20260521T025403Z-supercombo-canonical-field-mapping-summary.json
@@ -3,13 +3,13 @@
   "artifact_schema_version": "supercombo_field_mapping_summary/v1",
   "authority_status": "supercombo_not_numeric_authority",
   "input_inventory": "data/value-shape-inventories/20260521T025403Z-latest-source-value-shape-summary.json",
-  "json_schema_redesign_blocked_count": 1,
+  "json_schema_redesign_blocked_count": 0,
   "mapping_status_counts": {
-    "blocked_pending_human_review": 1,
+    "blocked_pending_human_review": 0,
     "enrichment_only_no_current_fact_mapping": 10,
     "maps_to_existing_official_field_key": 80,
     "out_of_scope_first_normalized_export": 38,
-    "supercombo_source_specific_field_key": 274
+    "supercombo_source_specific_field_key": 275
   },
   "mappings": [
     {
@@ -438,13 +438,13 @@
     {
       "affected_field_summary_count": 1,
       "display_label_ja": null,
-      "json_schema_redesign_blocked": true,
+      "json_schema_redesign_blocked": false,
       "mapping_id": "supercombo:character_vitals--throw_range_hurtbox",
-      "mapping_status": "blocked_pending_human_review",
+      "mapping_status": "supercombo_source_specific_field_key",
       "observation_count": 29,
       "official_field_key_target": null,
-      "proposed_field_key": null,
-      "rationale": "Combined throw range and hurtbox semantics require human review before mapping.",
+      "proposed_field_key": "supercombo_throw_range_hurtbox_pair",
+      "rationale": "Source review resolved this as an ordered SuperCombo throw range and hurtbox pair.",
       "review_item_count": 1,
       "run_id": "20260521T025403Z",
       "shape_classes": [

--- a/data/value-shape-dispositions/20260521T025403Z-value-shape-review-item-disposition-summary.json
+++ b/data/value-shape-dispositions/20260521T025403Z-value-shape-review-item-disposition-summary.json
@@ -3,10 +3,10 @@
   "artifact_schema_version": "value_shape_review_item_disposition_summary/v1",
   "authority_status": "disposition_only_not_authority",
   "disposition_counts": {
-    "blocked_pending_source_review": 3,
+    "blocked_pending_source_review": 0,
     "out_of_scope_first_normalized_export": 17,
-    "parse_rule_required_before_schema": 206,
-    "schema_supports_raw_only": 5,
+    "parse_rule_required_before_schema": 208,
+    "schema_supports_raw_only": 6,
     "source_specific_enum_required": 16
   },
   "dispositions": [
@@ -377,12 +377,12 @@
     {
       "affected_count": 3,
       "display_label_ja": "持続",
-      "disposition": "blocked_pending_source_review",
+      "disposition": "parse_rule_required_before_schema",
       "inventory_source_family": "official",
       "json_schema_redesign_blocked": true,
-      "next_execplan_needed": "source review for malformed official values",
+      "next_execplan_needed": "deterministic parsed-value classifier policy",
       "proposed_field_key": "active",
-      "rationale": "Malformed-looking official value must be checked against the source before schema work.",
+      "rationale": "Source review confirmed the official raw value; parser policy must handle malformed-looking notation before schema work.",
       "representative_examples": [
         {
           "raw_value": "30-34.35",
@@ -408,7 +408,7 @@
       ],
       "review_item_id": "value-shape:official--malformed_looking_source_value--u_fdb49a2113ba--u_c2b75204faf1",
       "review_kind": "malformed_looking_source_value",
-      "reviewer_notes": "Source-review blocker; do not infer numeric meaning.",
+      "reviewer_notes": "Source review resolved this item; do not infer numeric meaning before parser policy.",
       "run_id": "20260521T025403Z",
       "semantic_source_family": "timing",
       "shape_classes": [
@@ -683,12 +683,12 @@
     {
       "affected_count": 2,
       "display_label_ja": "技名",
-      "disposition": "blocked_pending_source_review",
+      "disposition": "schema_supports_raw_only",
       "inventory_source_family": "official",
-      "json_schema_redesign_blocked": true,
-      "next_execplan_needed": "source review for note-bearing move names",
+      "json_schema_redesign_blocked": false,
+      "next_execplan_needed": null,
       "proposed_field_key": "move_name",
-      "rationale": "Note-bearing official move-name variants require source/domain review before identity schema design.",
+      "rationale": "Source review confirmed note-bearing official move names can remain raw-only in the first schema.",
       "representative_examples": [
         {
           "raw_value": "スクトゥム(当身派生版)※スクトゥム中に打撃を受ける",
@@ -707,7 +707,7 @@
       ],
       "review_item_id": "value-shape:official--source_specific_expression--u_1aa6a6f86513",
       "review_kind": "source_specific_expression",
-      "reviewer_notes": "Move identity must not be normalized from a note-bearing source string by guesswork.",
+      "reviewer_notes": "Later move-identity splitting may be designed separately.",
       "run_id": "20260521T025403Z",
       "semantic_source_family": "identity",
       "shape_classes": [
@@ -1222,12 +1222,12 @@
     {
       "affected_count": 29,
       "display_label_ja": null,
-      "disposition": "blocked_pending_source_review",
+      "disposition": "parse_rule_required_before_schema",
       "inventory_source_family": "supercombo",
       "json_schema_redesign_blocked": true,
-      "next_execplan_needed": "SuperCombo field mapping human review",
-      "proposed_field_key": null,
-      "rationale": "The SuperCombo field mapping itself is blocked pending human review.",
+      "next_execplan_needed": "deterministic parsed-value classifier policy",
+      "proposed_field_key": "supercombo_throw_range_hurtbox_pair",
+      "rationale": "The SuperCombo field has special value shapes that need deterministic parse/classifier policy before schema use.",
       "representative_examples": [
         {
           "raw_value": "0.8 / 0.33",
@@ -1267,7 +1267,7 @@
       ],
       "review_item_id": "value-shape:supercombo--unclassified_expression--character_vitals--throw_range_hurtbox",
       "review_kind": "unclassified_expression",
-      "reviewer_notes": "Schema work must not consume this field until mapping is resolved or scoped out.",
+      "reviewer_notes": "Do not use these values as numeric authority.",
       "run_id": "20260521T025403Z",
       "semantic_source_family": "throw",
       "shape_classes": [
@@ -14103,7 +14103,7 @@
     "official": 16,
     "supercombo": 231
   },
-  "json_schema_redesign_blocked_count": 225,
+  "json_schema_redesign_blocked_count": 224,
   "json_schema_redesign_gate": {
     "blocked_until": [
       "all parse_rule_required_before_schema records get parser/classifier policy",

--- a/docs/execplans/2026-05-23-apply-value-shape-source-review-resolutions.md
+++ b/docs/execplans/2026-05-23-apply-value-shape-source-review-resolutions.md
@@ -1,0 +1,39 @@
+# Apply Value-Shape Source Review Resolutions
+
+Status: Implementation complete; review pending.
+
+## Purpose
+
+Consume the source-review decisions for the 3 previously blocked value-shape
+items and update the mapping/disposition artifacts.
+
+## Scope
+
+Update only SuperCombo field mapping, value-shape disposition generation,
+their generated public artifacts, tests, and relevant ExecPlan notes. Do not
+change schema, parser, normalized export, retrieval, answer behavior, source
+acquisition, or authority status.
+
+## Result
+
+- SuperCombo mapping `blocked_pending_human_review`: `1 -> 0`.
+- SuperCombo mapping `supercombo_source_specific_field_key`: `274 -> 275`.
+- Disposition `blocked_pending_source_review`: `3 -> 0`.
+- Disposition `parse_rule_required_before_schema`: `206 -> 208`.
+- Disposition `schema_supports_raw_only`: `5 -> 6`.
+- JSON Schema redesign remains blocked by parser/classifier and enum policy,
+  not source-review blockers.
+
+## Validation
+
+```bash
+git diff --check
+git diff --cached --check
+PYTHONPATH=src uv run --locked python -m unittest discover -s tests
+PYTHONPATH=src uv run --locked python tests/validation/validate_supercombo_field_mapping.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_value_shape_disposition.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_value_shape_source_review.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
+```
+
+PLAN deviations: none.

--- a/docs/execplans/2026-05-23-supercombo-field-mapping-artifacts.md
+++ b/docs/execplans/2026-05-23-supercombo-field-mapping-artifacts.md
@@ -446,16 +446,14 @@ git status --short --branch
   more error-prone than deterministic generation from reviewed policy tables.
   Date/Author: 2026-05-23 / Codex
 
-- Decision: Leave `Character Vitals > Throw Range / Hurtbox` as
-  `blocked_pending_human_review`.
-  Rationale: The combined source label mixes throw range and hurtbox semantics;
-  mapping it without human disposition would guess normalized meaning.
+- Decision: Map `Character Vitals > Throw Range / Hurtbox` as
+  `supercombo_throw_range_hurtbox_pair`.
+  Rationale: Source review resolved the source label as an ordered SuperCombo
+  enrichment pair. It remains non-authority and still needs pair parser policy.
   Date/Author: 2026-05-23 / Codex
 
 ## Unresolved Decisions
 
-- Reviewer disposition for the single blocked mapping:
-  `Character Vitals > Throw Range / Hurtbox`.
 - Whether any SuperCombo source-specific enrichment keys should be renamed in
   a later normalized schema ExecPlan.
 - Value-shape review item disposition for 231 SuperCombo review item groups and
@@ -474,8 +472,6 @@ git status --short --branch
   artifact keeps all official matches as cross-reference candidates only.
 - Too many out-of-scope mappings could reduce SuperCombo cross-reference
   value.
-- The one blocked mapping still blocks JSON Schema redesign unless resolved or
-  explicitly scoped out by review.
 - The mapping artifact may need follow-up review before value-shape
   disposition can fill `proposed_field_key` reliably.
 
@@ -483,7 +479,7 @@ git status --short --branch
 
 | PLAN item | Implementation | Changed files | Validation command | Result | Deviation | Incomplete | Risk |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Plan SuperCombo mapping artifacts | Implemented 403-record mapping artifacts | ExecPlan, generator, validator, tests, Markdown artifact, JSON artifact | `PYTHONPATH=src uv run --locked python tests/validation/validate_supercombo_field_mapping.py` | Pass | None | Mandatory review pending | One blocked mapping remains |
+| Plan SuperCombo mapping artifacts | Implemented 403-record mapping artifacts | ExecPlan, generator, validator, tests, Markdown artifact, JSON artifact | `PYTHONPATH=src uv run --locked python tests/validation/validate_supercombo_field_mapping.py` | Pass | None | Mandatory review pending | No blocked mapping remains |
 | Preserve mapping boundaries | Source-native labels, semantic `source_family`, `source_name: supercombo`, and non-authority roles are validated | `src/sf6_knowledge_coach/supercombo_field_mapping.py`, artifacts | `PYTHONPATH=src uv run --locked python -m unittest discover -s tests` | Pass, 35 tests | None | None | Reviewer must confirm policy choices |
 | Plan validation | Implemented coverage/status/privacy/source-boundary validator | `tests/validation/validate_supercombo_field_mapping.py` | `PYTHONPATH=src uv run --locked python tests/validation/validate_supercombo_field_mapping.py` | Pass | None | None | CI will run after PR |
 | Keep schema blocked | JSON Schema redesign remains blocked until mapping artifacts and value-shape disposition are reviewed | ExecPlan and artifacts | reviewer check | Pending | None | Value-shape disposition still pending | Schema work must wait |

--- a/docs/execplans/2026-05-23-value-shape-review-item-disposition.md
+++ b/docs/execplans/2026-05-23-value-shape-review-item-disposition.md
@@ -180,15 +180,15 @@ Implemented disposition summary:
 - total dispositions: 247
 - official dispositions: 16
 - SuperCombo dispositions: 231
-- `parse_rule_required_before_schema`: 206
+- `parse_rule_required_before_schema`: 208
 - `source_specific_enum_required`: 16
-- `schema_supports_raw_only`: 5
+- `schema_supports_raw_only`: 6
 - `out_of_scope_first_normalized_export`: 17
-- `blocked_pending_source_review`: 3
+- `blocked_pending_source_review`: 0
 - SuperCombo mapping dependencies: 231
-- JSON Schema redesign blocked records: 225
+- JSON Schema redesign blocked records: 224
 
-Blocked source-review items:
+Resolved source-review items:
 
 - official `動作フレーム > 持続` malformed-looking value group;
 - official `技名` note-bearing move-name variant group;
@@ -496,12 +496,12 @@ git status --short --branch
   dispositions would hide blockers.
   Date/Author: 2026-05-23 / Codex
 
-- Decision: Mark official malformed-looking `動作フレーム > 持続`, official
-  note-bearing `技名`, and SuperCombo `Character Vitals > Throw Range / Hurtbox`
-  as `blocked_pending_source_review`.
-  Rationale: These are the only groups that cannot safely proceed to schema or
-  classifier planning without additional source/domain review or completed
-  mapping clarification.
+- Decision: Consume source-review resolutions for official malformed-looking
+  `動作フレーム > 持続`, official note-bearing `技名`, and SuperCombo
+  `Character Vitals > Throw Range / Hurtbox`.
+  Rationale: Source review resolved those items enough for disposition:
+  active-frame notation and the SuperCombo pair need parser policy; note-bearing
+  move names can remain raw-only in the first schema.
   Date/Author: 2026-05-23 / Codex
 
 - Decision: Mark source-specific cancel/attribute/guard/defense categorical
@@ -525,13 +525,12 @@ git status --short --branch
 
 ## Unresolved Decisions
 
-- Exact parse/classifier rules for the 206
+- Exact parse/classifier rules for the 208
   `parse_rule_required_before_schema` groups.
 - Exact enum design for the 16 `source_specific_enum_required` groups.
-- Human review outcome for the 3 `blocked_pending_source_review` groups.
 - Whether any of the 17 `out_of_scope_first_normalized_export` groups should be
   pulled into a later normalized export.
-- Whether the 5 `schema_supports_raw_only` groups need additional display or
+- Whether the 6 `schema_supports_raw_only` groups need additional display or
   review-context schema fields.
 
 ## Deviations
@@ -548,14 +547,14 @@ git status --short --branch
   normalized export.
 - Long example context is summarized; reviewers may need to consult the
   source inventory or ignored local artifacts for full context.
-- JSON Schema redesign remains blocked because 225 disposition records still
-  require parse/classifier, enum, or source-review follow-up before schema work.
+- JSON Schema redesign remains blocked because 224 disposition records still
+  require parse/classifier or enum follow-up before schema work.
 
 ## Completion Review Table
 
 | PLAN item | Implementation | Changed files | Validation command | Result | Deviation | Incomplete | Risk |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Implement review item disposition | Generated 247 disposition records | `src/sf6_knowledge_coach/value_shape_disposition.py`, disposition artifacts | `PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.value_shape_disposition build` | Pass | None | Mandatory review pending | 225 records still block schema redesign |
+| Implement review item disposition | Generated 247 disposition records | `src/sf6_knowledge_coach/value_shape_disposition.py`, disposition artifacts | `PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.value_shape_disposition build` | Pass | None | Mandatory review pending | 224 records still block schema redesign |
 | Validate coverage and boundaries | Added validator and tests | `tests/test_value_shape_disposition.py`, `tests/validation/validate_value_shape_disposition.py` | `PYTHONPATH=src uv run --locked python tests/validation/validate_value_shape_disposition.py` | Pass | None | Mandatory review pending | None |
 | Preserve mapping dependency | SuperCombo 231 review items reference mapping IDs | disposition JSON/Markdown | validator | Pass | None | None | SuperCombo remains non-authority |
 | Preserve source boundaries | Uses `inventory_source_family`; official and SuperCombo remain separate | disposition JSON/Markdown | validator | Pass | None | None | None |

--- a/docs/field-mappings/20260521T025403Z-supercombo-canonical-field-mapping-review.md
+++ b/docs/field-mappings/20260521T025403Z-supercombo-canonical-field-mapping-review.md
@@ -7,16 +7,16 @@ SuperCombo numeric authority.
 - Run ID: `20260521T025403Z`
 - Input inventory: `data/value-shape-inventories/20260521T025403Z-latest-source-value-shape-summary.json`
 - Total SuperCombo field summaries: `403`
-- JSON Schema redesign blocked records: `1`
+- JSON Schema redesign blocked records: `0`
 - Value-shape disposition dependencies: `231`
 
 ## Mapping Status Counts
 
 - `maps_to_existing_official_field_key`: 80
-- `supercombo_source_specific_field_key`: 274
+- `supercombo_source_specific_field_key`: 275
 - `enrichment_only_no_current_fact_mapping`: 10
 - `out_of_scope_first_normalized_export`: 38
-- `blocked_pending_human_review`: 1
+- `blocked_pending_human_review`: 0
 
 ## Section Counts
 
@@ -54,7 +54,7 @@ SuperCombo numeric authority.
 | `Character Vitals > Jump Apex` | `supercombo_source_specific_field_key` | `mobility` | `enrichment_candidate` | `supercombo_jump_apex` | `` | 29 | 1 | Jump apex is SuperCombo-specific mobility enrichment. |
 | `Character Vitals > Jump Speed` | `supercombo_source_specific_field_key` | `mobility` | `enrichment_candidate` | `supercombo_jump_speed` | `` | 29 | 0 | Jump speed is SuperCombo-specific mobility enrichment. |
 | `Character Vitals > Portrait` | `out_of_scope_first_normalized_export` | `metadata` | `enrichment_candidate` | `` | `` | 29 | 0 | Portrait media is excluded from first normalized and enrichment outputs. |
-| `Character Vitals > Throw Range / Hurtbox` | `blocked_pending_human_review` | `throw` | `enrichment_candidate` | `` | `` | 29 | 1 | Combined throw range and hurtbox semantics require human review before mapping. |
+| `Character Vitals > Throw Range / Hurtbox` | `supercombo_source_specific_field_key` | `throw` | `enrichment_candidate` | `supercombo_throw_range_hurtbox_pair` | `` | 29 | 1 | Source review resolved this as an ordered SuperCombo throw range and hurtbox pair. |
 | `Command Normals > Active` | `maps_to_existing_official_field_key` | `timing` | `cross_reference_candidate` | `active` | `active` | 141 | 1 | SuperCombo Active is a cross-reference candidate for official active frames after review. |
 | `Command Normals > After DR Blk` | `supercombo_source_specific_field_key` | `advantage` | `enrichment_candidate` | `supercombo_after_drive_rush_block_advantage` | `` | 141 | 1 | Drive-rush block advantage is SuperCombo-specific enrichment. |
 | `Command Normals > After DR Hit` | `supercombo_source_specific_field_key` | `advantage` | `enrichment_candidate` | `supercombo_after_drive_rush_hit_advantage` | `` | 141 | 1 | Drive-rush hit advantage is SuperCombo-specific enrichment. |

--- a/docs/value-shape-dispositions/20260521T025403Z-value-shape-review-item-disposition.md
+++ b/docs/value-shape-dispositions/20260521T025403Z-value-shape-review-item-disposition.md
@@ -9,16 +9,16 @@ numeric authority.
 - Input inventory: `data/value-shape-inventories/20260521T025403Z-latest-source-value-shape-summary.json`
 - Input SuperCombo mapping: `data/field-mappings/20260521T025403Z-supercombo-canonical-field-mapping-summary.json`
 - Total review items: `247`
-- JSON Schema redesign blocked records: `225`
+- JSON Schema redesign blocked records: `224`
 - SuperCombo mapping dependencies: `231`
 
 ## Disposition Counts
 
-- `parse_rule_required_before_schema`: 206
-- `schema_supports_raw_only`: 5
+- `parse_rule_required_before_schema`: 208
+- `schema_supports_raw_only`: 6
 - `source_specific_enum_required`: 16
 - `out_of_scope_first_normalized_export`: 17
-- `blocked_pending_source_review`: 3
+- `blocked_pending_source_review`: 0
 
 ## Source Counts
 
@@ -35,12 +35,12 @@ numeric authority.
 | `value-shape:official--source_specific_expression--u_55d872f6091a` | `official` | `コンボ補正値` | `source_specific_expression` | `parse_rule_required_before_schema` | `combo_scaling` | `authority_candidate` | 55 | Official current-fact values with special shapes need deterministic parse rules before schema redesign. |
 | `value-shape:official--source_specific_expression--u_202a059d9b1b` | `official` | `ダメージ` | `source_specific_expression` | `parse_rule_required_before_schema` | `damage` | `authority_candidate` | 36 | Official current-fact values with special shapes need deterministic parse rules before schema redesign. |
 | `value-shape:official--source_specific_expression--u_80309c573b8b` | `official` | `備考` | `source_specific_expression` | `schema_supports_raw_only` | `remarks` | `authority_candidate` | 311 | Official remarks are source prose and should remain raw-only in the first schema. |
-| `value-shape:official--malformed_looking_source_value--u_fdb49a2113ba--u_c2b75204faf1` | `official` | `動作フレーム > 持続` | `malformed_looking_source_value` | `blocked_pending_source_review` | `active` | `authority_candidate` | 3 | Malformed-looking official value must be checked against the source before schema work. |
+| `value-shape:official--malformed_looking_source_value--u_fdb49a2113ba--u_c2b75204faf1` | `official` | `動作フレーム > 持続` | `malformed_looking_source_value` | `parse_rule_required_before_schema` | `active` | `authority_candidate` | 3 | Source review confirmed the official raw value; parser policy must handle malformed-looking notation before schema work. |
 | `value-shape:official--source_specific_expression--u_fdb49a2113ba--u_c2b75204faf1` | `official` | `動作フレーム > 持続` | `source_specific_expression` | `parse_rule_required_before_schema` | `active` | `authority_candidate` | 44 | Official current-fact values with special shapes need deterministic parse rules before schema redesign. |
 | `value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100` | `official` | `動作フレーム > 発生` | `source_specific_expression` | `parse_rule_required_before_schema` | `startup` | `authority_candidate` | 6 | Official current-fact values with special shapes need deterministic parse rules before schema redesign. |
 | `value-shape:official--source_specific_expression--u_fdb49a2113ba--u_4b3674d32cef` | `official` | `動作フレーム > 硬直` | `source_specific_expression` | `parse_rule_required_before_schema` | `recovery` | `authority_candidate` | 28 | Official current-fact values with special shapes need deterministic parse rules before schema redesign. |
 | `value-shape:official--source_specific_expression--u_86de52d17820` | `official` | `属性` | `source_specific_expression` | `source_specific_enum_required` | `attribute` | `authority_candidate` | 9 | Official categorical values need a reviewed source-specific enum before schema/parser work. |
-| `value-shape:official--source_specific_expression--u_1aa6a6f86513` | `official` | `技名` | `source_specific_expression` | `blocked_pending_source_review` | `move_name` | `authority_candidate` | 2 | Note-bearing official move-name variants require source/domain review before identity schema design. |
+| `value-shape:official--source_specific_expression--u_1aa6a6f86513` | `official` | `技名` | `source_specific_expression` | `schema_supports_raw_only` | `move_name` | `authority_candidate` | 2 | Source review confirmed note-bearing official move names can remain raw-only in the first schema. |
 | `value-shape:official--source_specific_expression--u_c135db53355f--u_522ba9f47afb` | `official` | `硬直差 > ガード` | `source_specific_expression` | `parse_rule_required_before_schema` | `block_advantage` | `authority_candidate` | 6 | Official current-fact values with special shapes need deterministic parse rules before schema redesign. |
 | `value-shape:official--unclassified_expression--u_c135db53355f--u_522ba9f47afb` | `official` | `硬直差 > ガード` | `unclassified_expression` | `parse_rule_required_before_schema` | `block_advantage` | `authority_candidate` | 3 | Official current-fact values with special shapes need deterministic parse rules before schema redesign. |
 | `value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69` | `official` | `硬直差 > ヒット` | `source_specific_expression` | `parse_rule_required_before_schema` | `hit_advantage` | `authority_candidate` | 4 | Official current-fact values with special shapes need deterministic parse rules before schema redesign. |
@@ -52,7 +52,7 @@ numeric authority.
 | `value-shape:supercombo--unclassified_expression--character_vitals--forward_jump_distance` | `supercombo` | `Character Vitals > Forward Jump Distance` | `unclassified_expression` | `parse_rule_required_before_schema` | `supercombo_forward_jump_distance` | `enrichment_candidate` | 2 | The SuperCombo field has special value shapes that need deterministic parse/classifier policy before schema use. |
 | `value-shape:supercombo--unclassified_expression--character_vitals--forward_walk_speed` | `supercombo` | `Character Vitals > Forward Walk Speed` | `unclassified_expression` | `parse_rule_required_before_schema` | `supercombo_forward_walk_speed` | `enrichment_candidate` | 1 | The SuperCombo field has special value shapes that need deterministic parse/classifier policy before schema use. |
 | `value-shape:supercombo--unclassified_expression--character_vitals--jump_apex` | `supercombo` | `Character Vitals > Jump Apex` | `unclassified_expression` | `parse_rule_required_before_schema` | `supercombo_jump_apex` | `enrichment_candidate` | 1 | The SuperCombo field has special value shapes that need deterministic parse/classifier policy before schema use. |
-| `value-shape:supercombo--unclassified_expression--character_vitals--throw_range_hurtbox` | `supercombo` | `Character Vitals > Throw Range / Hurtbox` | `unclassified_expression` | `blocked_pending_source_review` | `` | `enrichment_candidate` | 29 | The SuperCombo field mapping itself is blocked pending human review. |
+| `value-shape:supercombo--unclassified_expression--character_vitals--throw_range_hurtbox` | `supercombo` | `Character Vitals > Throw Range / Hurtbox` | `unclassified_expression` | `parse_rule_required_before_schema` | `supercombo_throw_range_hurtbox_pair` | `enrichment_candidate` | 29 | The SuperCombo field has special value shapes that need deterministic parse/classifier policy before schema use. |
 | `value-shape:supercombo--unclassified_expression--command_normals--active` | `supercombo` | `Command Normals > Active` | `unclassified_expression` | `parse_rule_required_before_schema` | `active` | `cross_reference_candidate` | 13 | The SuperCombo field has special value shapes that need deterministic parse/classifier policy before schema use. |
 | `value-shape:supercombo--unclassified_expression--command_normals--after_dr_blk` | `supercombo` | `Command Normals > After DR Blk` | `unclassified_expression` | `parse_rule_required_before_schema` | `supercombo_after_drive_rush_block_advantage` | `enrichment_candidate` | 11 | The SuperCombo field has special value shapes that need deterministic parse/classifier policy before schema use. |
 | `value-shape:supercombo--unclassified_expression--command_normals--after_dr_hit` | `supercombo` | `Command Normals > After DR Hit` | `unclassified_expression` | `parse_rule_required_before_schema` | `supercombo_after_drive_rush_hit_advantage` | `enrichment_candidate` | 21 | The SuperCombo field has special value shapes that need deterministic parse/classifier policy before schema use. |

--- a/src/sf6_knowledge_coach/supercombo_field_mapping.py
+++ b/src/sf6_knowledge_coach/supercombo_field_mapping.py
@@ -142,7 +142,7 @@ CHARACTER_VITALS_LABELS: dict[str, MappingPolicy] = {
     "Jump Apex": MappingPolicy("supercombo_source_specific_field_key", "mobility", "supercombo_jump_apex", None, "enrichment_candidate", "Jump apex is SuperCombo-specific mobility enrichment."),
     "Jump Speed": MappingPolicy("supercombo_source_specific_field_key", "mobility", "supercombo_jump_speed", None, "enrichment_candidate", "Jump speed is SuperCombo-specific mobility enrichment."),
     "Portrait": MappingPolicy("out_of_scope_first_normalized_export", "metadata", None, None, "enrichment_candidate", "Portrait media is excluded from first normalized and enrichment outputs."),
-    "Throw Range / Hurtbox": MappingPolicy("blocked_pending_human_review", "throw", None, None, "enrichment_candidate", "Combined throw range and hurtbox semantics require human review before mapping.", True),
+    "Throw Range / Hurtbox": MappingPolicy("supercombo_source_specific_field_key", "throw", "supercombo_throw_range_hurtbox_pair", None, "enrichment_candidate", "Source review resolved this as an ordered SuperCombo throw range and hurtbox pair."),
 }
 
 

--- a/src/sf6_knowledge_coach/value_shape_disposition.py
+++ b/src/sf6_knowledge_coach/value_shape_disposition.py
@@ -57,6 +57,7 @@ PARSE_RULE_FAMILIES = {
     "projectile",
     "scaling",
     "timing",
+    "throw",
     "vital",
 }
 ENUM_FAMILIES = {"attribute", "cancel", "defense", "guard"}
@@ -390,14 +391,14 @@ def _official_disposition_policy(item: dict[str, Any], shape_classes: list[str])
     kind = str(item.get("kind"))
     if kind == "malformed_looking_source_value":
         return _policy(
-            "blocked_pending_source_review",
+            "parse_rule_required_before_schema",
             field_key,
             semantic_family,
             display_label_ja,
-            "Malformed-looking official value must be checked against the source before schema work.",
+            "Source review confirmed the official raw value; parser policy must handle malformed-looking notation before schema work.",
             True,
-            "source review for malformed official values",
-            "Source-review blocker; do not infer numeric meaning.",
+            "deterministic parsed-value classifier policy",
+            "Source review resolved this item; do not infer numeric meaning before parser policy.",
         )
     if source_header_path == ("備考",):
         return _policy(
@@ -412,14 +413,14 @@ def _official_disposition_policy(item: dict[str, Any], shape_classes: list[str])
         )
     if source_header_path == ("技名",):
         return _policy(
-            "blocked_pending_source_review",
+            "schema_supports_raw_only",
             field_key,
             semantic_family,
             display_label_ja,
-            "Note-bearing official move-name variants require source/domain review before identity schema design.",
-            True,
-            "source review for note-bearing move names",
-            "Move identity must not be normalized from a note-bearing source string by guesswork.",
+            "Source review confirmed note-bearing official move names can remain raw-only in the first schema.",
+            False,
+            None,
+            "Later move-identity splitting may be designed separately.",
         )
     if semantic_family in {"cancel", "attribute"}:
         return _policy(

--- a/tests/test_supercombo_field_mapping.py
+++ b/tests/test_supercombo_field_mapping.py
@@ -18,10 +18,10 @@ class SuperComboFieldMappingTests(unittest.TestCase):
             self.payload["mapping_status_counts"],
             {
                 "maps_to_existing_official_field_key": 80,
-                "supercombo_source_specific_field_key": 274,
+                "supercombo_source_specific_field_key": 275,
                 "enrichment_only_no_current_fact_mapping": 10,
                 "out_of_scope_first_normalized_export": 38,
-                "blocked_pending_human_review": 1,
+                "blocked_pending_human_review": 0,
             },
         )
         self.assertEqual(self.payload["source_role_counts"], {"cross_reference_candidate": 80, "enrichment_candidate": 323})


### PR DESCRIPTION
## Summary
- consume source-review resolutions in SuperCombo field mapping and value-shape disposition artifacts
- reduce SuperCombo mapping blocked_pending_human_review from 1 to 0
- reduce value-shape disposition blocked_pending_source_review from 3 to 0
- keep JSON Schema redesign blocked by parser/classifier and enum policy only

## Validation
- git diff --check
- git diff --cached --check
- PYTHONPATH=src uv run --locked python -m unittest discover -s tests
- PYTHONPATH=src uv run --locked python tests/validation/validate_supercombo_field_mapping.py
- PYTHONPATH=src uv run --locked python tests/validation/validate_value_shape_disposition.py
- PYTHONPATH=src uv run --locked python tests/validation/validate_value_shape_source_review.py
- PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py

PLAN deviations: none.