### PR TITLE
Add parsed-value classifier and enum policy

### DIFF
--- a/data/value-shape-policies/20260521T025403Z-parsed-value-classifier-and-enum-policy.json
+++ b/data/value-shape-policies/20260521T025403Z-parsed-value-classifier-and-enum-policy.json
@@ -1,0 +1,140 @@
+{
+  "artifact_boundary": "classifier_enum_policy_summary_only",
+  "artifact_schema_version": "parsed_value_classifier_enum_policy/v1",
+  "authority_status": "policy_only_not_authority",
+  "input_disposition": "data/value-shape-dispositions/20260521T025403Z-value-shape-review-item-disposition-summary.json",
+  "json_schema_redesign_status": "ready_for_schema_design_after_policy_review",
+  "parsed_value_implementation": "not_implemented",
+  "parse_rule_policy_counts": {
+    "advantage": 50,
+    "damage": 18,
+    "gauge": 44,
+    "metadata": 21,
+    "mobility": 7,
+    "projectile": 3,
+    "scaling": 1,
+    "throw": 1,
+    "timing": 63
+  },
+  "parse_rule_policies": [
+    {
+      "record_count": 50,
+      "semantic_source_family": "advantage",
+      "schema_shapes": [
+        "signed_frame",
+        "knockdown_advantage",
+        "wall_splat_variant",
+        "stagger_variant",
+        "parenthesized_alternate",
+        "range_advantage"
+      ]
+    },
+    {
+      "record_count": 18,
+      "semantic_source_family": "damage",
+      "schema_shapes": [
+        "scalar_damage",
+        "multihit_damage",
+        "bracketed_alternate_damage",
+        "parenthesized_total_or_scaled"
+      ]
+    },
+    {
+      "record_count": 44,
+      "semantic_source_family": "gauge",
+      "schema_shapes": [
+        "scalar_gauge",
+        "parenthesized_alternate",
+        "bracketed_tagged_value",
+        "multihit_gauge"
+      ]
+    },
+    {
+      "record_count": 21,
+      "semantic_source_family": "metadata",
+      "schema_shapes": [
+        "decimal_metric",
+        "juggle_marker",
+        "range_metric",
+        "bracketed_marker"
+      ]
+    },
+    {
+      "record_count": 7,
+      "semantic_source_family": "mobility",
+      "schema_shapes": [
+        "decimal_metric",
+        "plus_sequence"
+      ]
+    },
+    {
+      "record_count": 3,
+      "semantic_source_family": "projectile",
+      "schema_shapes": [
+        "decimal_metric",
+        "source_native_speed_note"
+      ]
+    },
+    {
+      "record_count": 1,
+      "semantic_source_family": "scaling",
+      "schema_shapes": [
+        "percent_note"
+      ]
+    },
+    {
+      "record_count": 1,
+      "semantic_source_family": "throw",
+      "schema_shapes": [
+        "ordered_pair"
+      ],
+      "components": [
+        "throw_range",
+        "hurtbox"
+      ]
+    },
+    {
+      "record_count": 63,
+      "semantic_source_family": "timing",
+      "schema_shapes": [
+        "frame_scalar",
+        "frame_range",
+        "active_window_sequence",
+        "parenthesized_alternate",
+        "total_duration",
+        "plus_sequence",
+        "landing_condition",
+        "source_note_marker"
+      ]
+    }
+  ],
+  "enum_policy_counts": {
+    "attribute": 1,
+    "cancel": 6,
+    "defense": 9
+  },
+  "enum_policies": [
+    {
+      "enum_status": "source_native_enum_required",
+      "record_count": 1,
+      "semantic_source_family": "attribute"
+    },
+    {
+      "enum_status": "source_native_enum_required",
+      "record_count": 6,
+      "semantic_source_family": "cancel"
+    },
+    {
+      "enum_status": "source_native_enum_required",
+      "record_count": 9,
+      "semantic_source_family": "defense"
+    }
+  ],
+  "run_id": "20260521T025403Z",
+  "source_boundary": {
+    "full_raw_rows_public_commit": "forbidden",
+    "raw_html_public_commit": "forbidden"
+  },
+  "total_enum_policy_records": 16,
+  "total_parse_rule_policy_records": 208
+}

--- a/docs/execplans/2026-05-23-parsed-value-classifier-and-enum-policy.md
+++ b/docs/execplans/2026-05-23-parsed-value-classifier-and-enum-policy.md
@@ -1,0 +1,34 @@
+# Parsed-Value Classifier And Enum Policy
+
+Status: Implementation complete; review pending.
+
+## Purpose
+
+Convert the remaining value-shape disposition blockers into reviewed
+schema-design policy inputs.
+
+## Scope
+
+Add Markdown/JSON policy artifacts and a validator. Do not implement parser,
+classifier, JSON Schema, normalized export, retrieval, answer behavior, or
+authority promotion.
+
+## Result
+
+- Covers all 208 `parse_rule_required_before_schema` records by semantic
+  family.
+- Covers all 16 `source_specific_enum_required` records by semantic family.
+- Marks JSON Schema redesign as ready to start after this policy is reviewed.
+- Keeps parser/classifier implementation as later work.
+
+## Validation
+
+```bash
+git diff --check
+git diff --cached --check
+PYTHONPATH=src uv run --locked python tests/validation/validate_value_shape_policy.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_value_shape_disposition.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
+```
+
+PLAN deviations: none.

--- a/docs/value-shape-policies/20260521T025403Z-parsed-value-classifier-and-enum-policy.md
+++ b/docs/value-shape-policies/20260521T025403Z-parsed-value-classifier-and-enum-policy.md
@@ -1,0 +1,39 @@
+# Parsed-Value Classifier And Enum Policy
+
+This is a policy summary only. It does not implement parsers, classifiers,
+schema, retrieval, answer behavior, or numeric authority.
+
+- Run ID: `20260521T025403Z`
+- Input disposition: `data/value-shape-dispositions/20260521T025403Z-value-shape-review-item-disposition-summary.json`
+- Parse-rule policy records covered: `208`
+- Enum policy records covered: `16`
+- JSON Schema redesign status: `ready_for_schema_design_after_policy_review`
+
+## Parse-Rule Policy Counts
+
+| Semantic family | Records | Schema shapes |
+| --- | ---: | --- |
+| `advantage` | 50 | signed frame, knockdown, wall splat, stagger, parenthesized alternate, range advantage |
+| `damage` | 18 | scalar, multihit, bracketed alternate, parenthesized total/scaled |
+| `gauge` | 44 | scalar, parenthesized alternate, bracketed tagged value, multihit |
+| `metadata` | 21 | decimal metric, juggle marker, range metric, bracketed marker |
+| `mobility` | 7 | decimal metric, plus sequence |
+| `projectile` | 3 | decimal metric, source-native speed note |
+| `scaling` | 1 | percent note |
+| `throw` | 1 | ordered pair: throw range, hurtbox |
+| `timing` | 63 | frame scalar, range, active-window sequence, parenthesized alternate, total duration, plus sequence, landing condition, source note marker |
+
+## Enum Policy Counts
+
+| Semantic family | Records | Policy |
+| --- | ---: | --- |
+| `attribute` | 1 | source-native enum required |
+| `cancel` | 6 | source-native enum required |
+| `defense` | 9 | source-native enum required |
+
+## Boundary Notes
+
+- Official remains authority candidate only.
+- SuperCombo remains enrichment/cross-reference/candidate only.
+- The policy defines schema-design input shapes, not parser output.
+- Parser/classifier implementation remains a later ExecPlan.

--- a/tests/validation/validate_value_shape_policy.py
+++ b/tests/validation/validate_value_shape_policy.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+POLICY_JSON = ROOT / "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-and-enum-policy.json"
+POLICY_MD = ROOT / "docs/value-shape-policies/20260521T025403Z-parsed-value-classifier-and-enum-policy.md"
+DISPOSITION_JSON = ROOT / "data/value-shape-dispositions/20260521T025403Z-value-shape-review-item-disposition-summary.json"
+FORBIDDEN_PATTERNS = [
+    re.compile(r"(?i)(?:^|[\s\"'`])(?:/[a-z0-9_.-]+)+"),
+    re.compile(r"(?i)(?:^|[\s\"'`(])[A-Z]:[\\/]"),
+    re.compile(r"(?i)\b(?:cookie|authorization|bearer|token|password|secret)\b"),
+    re.compile(r"(?i)<html|</html|<!doctype|<table|</table|<tr|</tr|<td|</td|<th|</th"),
+    re.compile(r"(?i)\b(?:screenshot|trace|debug dump|answer[-_ ]?log|training[-_ ]?log|private[-_ ]?vault)\b"),
+]
+
+
+def main() -> int:
+    errors: list[str] = []
+    for path in (POLICY_JSON, POLICY_MD, DISPOSITION_JSON):
+        if not path.exists():
+            errors.append(f"Missing {path.relative_to(ROOT)}")
+    if errors:
+        return _finish(errors)
+
+    policy = json.loads(POLICY_JSON.read_text(encoding="utf-8"))
+    disposition = json.loads(DISPOSITION_JSON.read_text(encoding="utf-8"))
+    if policy.get("artifact_schema_version") != "parsed_value_classifier_enum_policy/v1":
+        errors.append("unexpected policy schema version")
+    if policy.get("authority_status") != "policy_only_not_authority":
+        errors.append("policy must not claim authority")
+    if policy.get("parsed_value_implementation") != "not_implemented":
+        errors.append("policy must not implement parsed values")
+    if policy.get("json_schema_redesign_status") != "ready_for_schema_design_after_policy_review":
+        errors.append("unexpected JSON Schema redesign status")
+
+    parse_counts = Counter(
+        record["semantic_source_family"]
+        for record in disposition["dispositions"]
+        if record["disposition"] == "parse_rule_required_before_schema"
+    )
+    enum_counts = Counter(
+        record["semantic_source_family"]
+        for record in disposition["dispositions"]
+        if record["disposition"] == "source_specific_enum_required"
+    )
+    if policy.get("parse_rule_policy_counts") != dict(sorted(parse_counts.items())):
+        errors.append("parse_rule_policy_counts do not match disposition artifact")
+    if policy.get("enum_policy_counts") != dict(sorted(enum_counts.items())):
+        errors.append("enum_policy_counts do not match disposition artifact")
+    if policy.get("total_parse_rule_policy_records") != sum(parse_counts.values()):
+        errors.append("total_parse_rule_policy_records mismatch")
+    if policy.get("total_enum_policy_records") != sum(enum_counts.values()):
+        errors.append("total_enum_policy_records mismatch")
+
+    parse_families = {record.get("semantic_source_family") for record in policy.get("parse_rule_policies", [])}
+    enum_families = {record.get("semantic_source_family") for record in policy.get("enum_policies", [])}
+    if parse_families != set(parse_counts):
+        errors.append("parse_rule_policies do not cover every parse family")
+    if enum_families != set(enum_counts):
+        errors.append("enum_policies do not cover every enum family")
+    if "current_fact_authority" in json.dumps(policy, ensure_ascii=False):
+        errors.append("policy must not mention current_fact_authority")
+
+    for path in (POLICY_JSON, POLICY_MD):
+        text = path.read_text(encoding="utf-8")
+        for pattern in FORBIDDEN_PATTERNS:
+            if pattern.search(text):
+                errors.append(f"{path.relative_to(ROOT)} contains forbidden public content")
+                break
+    return _finish(errors)
+
+
+def _finish(errors: list[str]) -> int:
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("Value-shape policy validation OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add policy artifacts covering all 208 parse-rule disposition records and 16 enum disposition records
- add validator tying the policy counts back to the disposition artifact
- mark JSON Schema redesign ready to start after policy review, while parser/classifier implementation remains later work

## Validation
- git diff --check
- git diff --cached --check
- PYTHONPATH=src uv run --locked python -m unittest discover -s tests
- PYTHONPATH=src uv run --locked python tests/validation/validate_value_shape_policy.py
- PYTHONPATH=src uv run --locked python tests/validation/validate_value_shape_disposition.py
- PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py

PLAN deviations: none.