### PR TITLE
Add current-fact JSON Schema artifacts

### DIFF
--- a/contracts/current-facts/current_fact_export.schema.json
+++ b/contracts/current-facts/current_fact_export.schema.json
@@ -1,0 +1,46 @@
+{
+  "$id": "https://sf6-knowledge-coach.local/schemas/current-facts/current_fact_export.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "artifact_schema_version": { "const": "current_fact_export/v1" },
+    "authority_boundary": {
+      "additionalProperties": false,
+      "properties": {
+        "official": { "const": "authority_candidate_only" },
+        "supercombo": { "const": "enrichment_or_cross_reference_only" }
+      },
+      "required": ["official", "supercombo"],
+      "type": "object"
+    },
+    "generated_from": {
+      "items": {
+        "pattern": "^(data|docs|contracts)/[A-Za-z0-9_.:/-]+$",
+        "type": "string"
+      },
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "records": {
+      "items": {
+        "$ref": "https://sf6-knowledge-coach.local/schemas/current-facts/current_fact_record.schema.json"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "run_id": {
+      "pattern": "^[0-9]{8}T[0-9]{6}Z$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "artifact_schema_version",
+    "authority_boundary",
+    "generated_from",
+    "records",
+    "run_id"
+  ],
+  "title": "Normalized current-fact export",
+  "type": "object"
+}

--- a/contracts/current-facts/current_fact_record.schema.json
+++ b/contracts/current-facts/current_fact_record.schema.json
@@ -1,0 +1,125 @@
+{
+  "$id": "https://sf6-knowledge-coach.local/schemas/current-facts/current_fact_record.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "source_name": { "const": "official" }
+        },
+        "required": ["source_name"]
+      },
+      "then": {
+        "properties": {
+          "source_role": { "const": "authority_candidate" }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "source_name": { "const": "supercombo" }
+        },
+        "required": ["source_name"]
+      },
+      "then": {
+        "properties": {
+          "authority_status": {
+            "enum": ["cross_reference_candidate", "enrichment_candidate", "not_authority"]
+          },
+          "source_role": {
+            "enum": ["cross_reference_candidate", "enrichment_candidate"]
+          }
+        }
+      }
+    }
+  ],
+  "properties": {
+    "authority_status": {
+      "enum": [
+        "authority_candidate",
+        "cross_reference_candidate",
+        "enrichment_candidate",
+        "not_authority"
+      ]
+    },
+    "character_slug": {
+      "pattern": "^[a-z0-9_]+$",
+      "type": "string"
+    },
+    "display_label_ja": { "type": "string" },
+    "evidence": {
+      "$ref": "https://sf6-knowledge-coach.local/schemas/current-facts/source_reference.schema.json"
+    },
+    "field_key": {
+      "pattern": "^[a-z][a-z0-9_]*$",
+      "type": "string"
+    },
+    "move_id": {
+      "type": ["string", "null"]
+    },
+    "parsed_value": {
+      "$ref": "https://sf6-knowledge-coach.local/schemas/current-facts/parsed_value.schema.json"
+    },
+    "raw_value": { "type": "string" },
+    "record_id": {
+      "pattern": "^[a-z0-9][a-z0-9_.:-]*$",
+      "type": "string"
+    },
+    "source_family": {
+      "enum": [
+        "advantage",
+        "attribute",
+        "cancel",
+        "damage",
+        "defense",
+        "gauge",
+        "identity",
+        "metadata",
+        "mobility",
+        "note",
+        "projectile",
+        "scaling",
+        "throw",
+        "timing",
+        "vital"
+      ]
+    },
+    "source_header_path": {
+      "items": { "type": "string" },
+      "minItems": 1,
+      "type": "array"
+    },
+    "source_label": { "type": "string" },
+    "source_name": { "enum": ["official", "supercombo"] },
+    "source_role": {
+      "enum": [
+        "authority_candidate",
+        "cross_reference_candidate",
+        "enrichment_candidate"
+      ]
+    },
+    "value_shape": {
+      "$ref": "https://sf6-knowledge-coach.local/schemas/current-facts/value_shape.schema.json"
+    }
+  },
+  "required": [
+    "authority_status",
+    "character_slug",
+    "display_label_ja",
+    "evidence",
+    "field_key",
+    "move_id",
+    "raw_value",
+    "record_id",
+    "source_family",
+    "source_header_path",
+    "source_label",
+    "source_name",
+    "source_role",
+    "value_shape"
+  ],
+  "title": "Normalized current-fact record",
+  "type": "object"
+}

--- a/contracts/current-facts/parsed_value.schema.json
+++ b/contracts/current-facts/parsed_value.schema.json
@@ -1,0 +1,112 @@
+{
+  "$id": "https://sf6-knowledge-coach.local/schemas/current-facts/parsed_value.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "integer" },
+        "unit": { "type": "string" },
+        "value": { "type": "integer" }
+      },
+      "required": ["kind", "value"],
+      "type": "object"
+    },
+    {
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "decimal" },
+        "unit": { "type": "string" },
+        "value": { "type": "number" }
+      },
+      "required": ["kind", "value"],
+      "type": "object"
+    },
+    {
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "signed_frame" },
+        "unit": { "const": "frame" },
+        "value": { "type": "integer" }
+      },
+      "required": ["kind", "unit", "value"],
+      "type": "object"
+    },
+    {
+      "additionalProperties": false,
+      "properties": {
+        "end": { "type": "integer" },
+        "kind": { "const": "frame_range" },
+        "start": { "type": "integer" },
+        "unit": { "const": "frame" }
+      },
+      "required": ["end", "kind", "start", "unit"],
+      "type": "object"
+    },
+    {
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "ordered_pair" },
+        "labels": {
+          "items": { "type": "string" },
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        "unit": { "type": "string" },
+        "values": {
+          "items": { "type": "number" },
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        }
+      },
+      "required": ["kind", "labels", "values"],
+      "type": "object"
+    },
+    {
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "percent" },
+        "unit": { "const": "percent" },
+        "value": { "type": "number" }
+      },
+      "required": ["kind", "unit", "value"],
+      "type": "object"
+    },
+    {
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "gauge_amount" },
+        "unit": { "enum": ["drive", "super_art"] },
+        "value": { "type": "number" }
+      },
+      "required": ["kind", "unit", "value"],
+      "type": "object"
+    },
+    {
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "enum_token" },
+        "tokens": {
+          "items": { "type": "string" },
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": ["kind", "tokens"],
+      "type": "object"
+    },
+    {
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "raw_note" },
+        "text": { "type": "string" }
+      },
+      "required": ["kind", "text"],
+      "type": "object"
+    }
+  ],
+  "title": "Parsed current-fact value"
+}

--- a/contracts/current-facts/source_reference.schema.json
+++ b/contracts/current-facts/source_reference.schema.json
@@ -1,0 +1,50 @@
+{
+  "$id": "https://sf6-knowledge-coach.local/schemas/current-facts/source_reference.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "evidence_basis": {
+      "enum": [
+        "official_raw_snapshot",
+        "supercombo_mapping_summary",
+        "source_acquisition_report",
+        "synthetic_contract_fixture",
+        "value_shape_inventory",
+        "value_shape_policy"
+      ]
+    },
+    "public_reference": {
+      "pattern": "^(data|docs|contracts)/[A-Za-z0-9_.:/-]+$",
+      "type": "string"
+    },
+    "run_id": {
+      "pattern": "^[0-9]{8}T[0-9]{6}Z$",
+      "type": "string"
+    },
+    "source_header_path": {
+      "items": { "type": "string" },
+      "minItems": 1,
+      "type": "array"
+    },
+    "source_label": { "type": "string" },
+    "source_name": { "enum": ["official", "supercombo"] },
+    "source_role": {
+      "enum": [
+        "authority_candidate",
+        "cross_reference_candidate",
+        "enrichment_candidate"
+      ]
+    }
+  },
+  "required": [
+    "evidence_basis",
+    "public_reference",
+    "run_id",
+    "source_header_path",
+    "source_label",
+    "source_name",
+    "source_role"
+  ],
+  "title": "Current-fact source reference",
+  "type": "object"
+}

--- a/contracts/current-facts/value_shape.schema.json
+++ b/contracts/current-facts/value_shape.schema.json
@@ -1,0 +1,62 @@
+{
+  "$id": "https://sf6-knowledge-coach.local/schemas/current-facts/value_shape.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "classifier_status": { "const": "parsed" }
+        },
+        "required": ["classifier_status"]
+      },
+      "then": {
+        "required": ["parser_rule_id"]
+      }
+    }
+  ],
+  "properties": {
+    "classes": {
+      "items": {
+        "enum": [
+          "blank",
+          "categorical",
+          "conditional",
+          "dash_variant",
+          "hidden_detail",
+          "landing_expression",
+          "multihit",
+          "note_prefixed",
+          "note_separated_alternate",
+          "note_suffixed",
+          "percent_expression",
+          "plus_expression",
+          "prose",
+          "range",
+          "raw_only",
+          "scalar",
+          "signed_frame",
+          "unclassified",
+          "until_landing"
+        ]
+      },
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "classifier_status": {
+      "enum": ["parsed", "raw_preserved", "review_required", "rejected"]
+    },
+    "parser_rule_id": {
+      "pattern": "^[a-z0-9][a-z0-9_.-]*$",
+      "type": "string"
+    },
+    "review_item_id": {
+      "pattern": "^[a-z0-9][a-z0-9_.:-]*$",
+      "type": "string"
+    }
+  },
+  "required": ["classes", "classifier_status"],
+  "title": "Current-fact value shape",
+  "type": "object"
+}

--- a/data/validator-audits/20260523-validator-test-fact-source-audit.json
+++ b/data/validator-audits/20260523-validator-test-fact-source-audit.json
@@ -81,7 +81,21 @@
       "primary_evidence": [
         "docs/PLAN.md",
         "AGENTS.md",
-        "clean-slate ExecPlans"
+        "clean-slate ExecPlans",
+        "current-fact JSON Schema artifacts ExecPlan"
+      ],
+      "status": "accepted_with_limits"
+    },
+    {
+      "evidence_class": "synthetic_contract",
+      "file": "tests/validation/validate_current_fact_schemas.py",
+      "limitations": [
+        "checks schema and fixture contracts only; does not prove parser correctness or source truth"
+      ],
+      "primary_evidence": [
+        "contracts/current-facts/*.schema.json",
+        "tests/fixtures/current-facts",
+        "current-fact JSON Schema redesign ExecPlans"
       ],
       "status": "accepted_with_limits"
     },

--- a/docs/execplans/2026-05-23-current-fact-json-schema-artifacts.md
+++ b/docs/execplans/2026-05-23-current-fact-json-schema-artifacts.md
@@ -1,0 +1,157 @@
+# Current-Fact JSON Schema Artifacts
+
+Status: Implemented and locally reviewed; PR pending.
+
+## Purpose
+
+Implement the first structural JSON Schema artifacts for normalized
+current-fact records, following
+`docs/execplans/2026-05-23-current-fact-json-schema-redesign.md`.
+
+This step creates schema contracts, small fixtures, and a validator. It does
+not implement parsing, normalized export generation, retrieval, answer
+behavior, or authority promotion.
+
+## Scope
+
+Included:
+
+- Add Draft 2020-12 JSON Schemas for:
+  - `current_fact_record`
+  - `parsed_value`
+  - `value_shape`
+  - `source_reference`
+  - `current_fact_export`
+- Add minimal valid and invalid fixtures.
+- Add a deterministic schema validator.
+- Add a schema review note.
+- Update validator/test evidence audit for the new validator.
+
+Excluded:
+
+- No parser/classifier implementation.
+- No generated normalized current-fact export.
+- No source acquisition or live web access.
+- No retrieval DB changes.
+- No answer behavior changes.
+- No SuperCombo numeric authority promotion.
+- No new dependencies.
+
+## Acceptance Criteria
+
+- All schema files use `https://json-schema.org/draft/2020-12/schema`.
+- Schemas validate against the Draft 2020-12 meta-schema using the locked
+  `jsonschema` package already present in `uv.lock`.
+- Valid fixtures pass.
+- Invalid fixtures fail for the intended boundaries:
+  - `source_family` cannot be source identity.
+  - SuperCombo cannot be promoted to numeric authority.
+- The validator scans public schema/fixture files for local paths, raw HTML,
+  source dumps, screenshots, secrets, logs, and private data markers.
+- The new validator is recorded in the validator/test evidence audit.
+- Existing repo validators and unit tests pass.
+
+## Files / Interfaces
+
+Added:
+
+- `contracts/current-facts/current_fact_record.schema.json`
+- `contracts/current-facts/current_fact_export.schema.json`
+- `contracts/current-facts/parsed_value.schema.json`
+- `contracts/current-facts/source_reference.schema.json`
+- `contracts/current-facts/value_shape.schema.json`
+- `tests/fixtures/current-facts/records/valid/*.json`
+- `tests/fixtures/current-facts/records/invalid/*.json`
+- `tests/fixtures/current-facts/exports/valid/*.json`
+- `tests/validation/validate_current_fact_schemas.py`
+- `docs/schema-reviews/20260521T025403Z-current-fact-json-schema-redesign.md`
+- `docs/execplans/2026-05-23-current-fact-json-schema-artifacts.md`
+
+Updated:
+
+- `data/validator-audits/20260523-validator-test-fact-source-audit.json`
+- `docs/validator-audits/20260523-validator-test-fact-source-audit.md`
+- `tests/validation/validate_clean_slate.py`
+
+## Validation Commands
+
+Run from repository root:
+
+```bash
+git diff --check
+git diff --cached --check
+uv lock --check
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_validator_test_audit.py
+for script in tests/validation/validate_*.py; do PYTHONPATH=src uv run --locked python "$script"; done
+PYTHONPATH=src uv run --locked python -m unittest discover -s tests
+git status --short --branch
+```
+
+## Progress
+
+- [x] (2026-05-23 JST) Created implementation branch
+  `impl/current-fact-json-schema-artifacts`.
+- [x] (2026-05-23 JST) Confirmed `jsonschema` is available through
+  `uv run --locked` without adding dependencies.
+- [x] (2026-05-23 JST) Added schema artifacts.
+- [x] (2026-05-23 JST) Added focused fixtures for official and SuperCombo
+  boundaries.
+- [x] (2026-05-23 JST) Added schema validator and validator audit entry.
+- [x] (2026-05-23 JST) Narrowly updated clean-slate validation to allow only
+  `contracts/current-facts/` schema files, without restoring legacy
+  `contracts/` content.
+- [x] (2026-05-23 JST) Marked SuperCombo schema fixtures as synthetic
+  contract fixtures so they are not mistaken for source truth.
+- [x] (2026-05-23 JST) Completed validation:
+  `git diff --check`,
+  `uv lock --check`,
+  `PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py`,
+  validator loop,
+  `PYTHONPATH=src uv run --locked python -m unittest discover -s tests`,
+  and JP 5LP daily-answer smoke.
+- [x] (2026-05-23 JST) Completed local reviewer check: no parser,
+  classifier implementation, normalized export, retrieval, answer behavior, or
+  authority promotion was added.
+
+## Decision Log
+
+- Decision: Use the locked `jsonschema` package rather than adding a new
+  dependency.
+  Rationale: `jsonschema` is already available in `uv.lock`; adding
+  dependencies would expand scope.
+  Date/Author: 2026-05-23 / Codex
+
+- Decision: Keep fixtures small and contract-focused.
+  Rationale: Full source rows and raw HTML belong in ignored source acquisition
+  artifacts, not schema fixture commits.
+  Date/Author: 2026-05-23 / Codex
+
+- Decision: Record the schema validator as `synthetic_contract` evidence in
+  the validator audit.
+  Rationale: Passing schema fixtures proves contract shape, not source truth or
+  parser correctness.
+  Date/Author: 2026-05-23 / Codex
+
+## Deviations
+
+- None.
+
+## Risks
+
+- The schemas are first structural contracts and may need refinement when
+  parser implementation starts.
+- Fixture values are small contract examples. Official examples are
+  source-derived smoke fixtures; SuperCombo examples are synthetic and are not
+  source facts.
+- The schemas do not make official data current-fact authority and do not make
+  SuperCombo numeric authority.
+
+## Completion Review Table
+
+| PLAN item | Implementation | Changed files | Validation command | Result | Deviation | Incomplete | Risk |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Add schema artifacts | Added five Draft 2020-12 schemas | `contracts/current-facts/*.schema.json` | `validate_current_fact_schemas.py` | Pass | None | PR review pending | Parser work may require later refinements |
+| Add fixtures | Added small valid/invalid fixtures | `tests/fixtures/current-facts/` | `validate_current_fact_schemas.py` | Pass | None | PR review pending | Fixtures are contract examples only |
+| Preserve clean-slate boundary | Allowed only `contracts/current-facts/` schemas | `validate_clean_slate.py` | `validate_clean_slate.py` | Pass | None | PR review pending | Future contracts surfaces need explicit plans |
+| Preserve evidence rigor | Added validator audit entry | validator audit JSON/MD | `validate_validator_test_audit.py` | Pass | None | PR review pending | Validator must not be treated as source truth |

--- a/docs/schema-reviews/20260521T025403Z-current-fact-json-schema-redesign.md
+++ b/docs/schema-reviews/20260521T025403Z-current-fact-json-schema-redesign.md
@@ -1,0 +1,44 @@
+# Current-Fact JSON Schema Redesign Review
+
+This review records the first schema artifact boundary for normalized
+current-fact records.
+
+The schemas are structural contracts only. They do not implement parsing, do
+not generate normalized exports, do not change retrieval or answer behavior,
+and do not promote any source to daily-answer numeric authority.
+
+## Inputs
+
+- `docs/execplans/2026-05-23-current-fact-json-schema-redesign.md`
+- `data/value-shape-inventories/20260521T025403Z-latest-source-value-shape-summary.json`
+- `data/field-mappings/20260521T025403Z-supercombo-canonical-field-mapping-summary.json`
+- `data/value-shape-dispositions/20260521T025403Z-value-shape-review-item-disposition-summary.json`
+- `data/value-shape-policies/20260521T025403Z-parsed-value-classifier-and-enum-policy.json`
+- `data/validator-audits/20260523-validator-test-fact-source-audit.json`
+
+## Decisions
+
+- Use JSON Schema Draft 2020-12.
+- Keep `source_family` as a semantic category only.
+- Keep source identity in `source_name`.
+- Keep evidence role in `source_role`.
+- Keep answer authority in `authority_status`.
+- Require `raw_value` even when `parsed_value` is present.
+- Allow `parsed_value` only as an optional policy-gated structure.
+- Keep SuperCombo as enrichment or cross-reference candidate only.
+
+## Fixture Coverage
+
+- official signed frame
+- official frame range
+- official raw-preserved move name
+- synthetic SuperCombo cross-reference signed frame
+- synthetic SuperCombo review-required ordered-pair source case
+- invalid `source_family: official`
+- invalid SuperCombo authority promotion
+
+## Limits
+
+These schemas do not prove parser correctness or source truth. The SuperCombo
+fixtures are synthetic contract fixtures, not observed game facts. The schemas
+define the shape of records that later parser and export work must satisfy.

--- a/docs/validator-audits/20260523-validator-test-fact-source-audit.md
+++ b/docs/validator-audits/20260523-validator-test-fact-source-audit.md
@@ -20,6 +20,7 @@ privacy/security boundary.
 | `tests/test_value_shape_disposition.py` | artifact consistency | accepted with limits | disposition coverage is not parse semantics |
 | `tests/test_value_shape_inventory.py` | source-derived | accepted with limits | representative shape checks are not parser semantics |
 | `tests/validation/validate_clean_slate.py` | governance boundary | accepted with limits | repo shape only |
+| `tests/validation/validate_current_fact_schemas.py` | synthetic contract | accepted with limits | schema and fixture contracts only; no parser/source truth |
 | `tests/validation/validate_validator_test_audit.py` | governance boundary | accepted with limits | audit coverage and evidence metadata only |
 | `tests/validation/validate_supercombo_field_mapping.py` | policy-derived | accepted with limits | delegates to mapping artifact validation |
 | `tests/validation/validate_value_shape_disposition.py` | artifact consistency | accepted with limits | validates disposition structure, not source truth |

--- a/tests/fixtures/current-facts/exports/valid/current_fact_export_minimal.json
+++ b/tests/fixtures/current-facts/exports/valid/current_fact_export_minimal.json
@@ -1,0 +1,47 @@
+{
+  "artifact_schema_version": "current_fact_export/v1",
+  "authority_boundary": {
+    "official": "authority_candidate_only",
+    "supercombo": "enrichment_or_cross_reference_only"
+  },
+  "generated_from": [
+    "data/value-shape-inventories/20260521T025403Z-latest-source-value-shape-summary.json",
+    "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-and-enum-policy.json"
+  ],
+  "records": [
+    {
+      "authority_status": "authority_candidate",
+      "character_slug": "jp",
+      "display_label_ja": "ガード硬直差",
+      "evidence": {
+        "evidence_basis": "official_raw_snapshot",
+        "public_reference": "data/exports/jp/official_raw.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": ["硬直差", "ガード"],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "block_advantage",
+      "move_id": "jp_001_5lp",
+      "parsed_value": {
+        "kind": "signed_frame",
+        "unit": "frame",
+        "value": -2
+      },
+      "raw_value": "-2",
+      "record_id": "official:jp:jp_001_5lp:block_advantage",
+      "source_family": "advantage",
+      "source_header_path": ["硬直差", "ガード"],
+      "source_label": "ガード",
+      "source_name": "official",
+      "source_role": "authority_candidate",
+      "value_shape": {
+        "classes": ["signed_frame"],
+        "classifier_status": "parsed",
+        "parser_rule_id": "signed_frame.v1"
+      }
+    }
+  ],
+  "run_id": "20260521T025403Z"
+}

--- a/tests/fixtures/current-facts/records/invalid/source_family_uses_source_identity.json
+++ b/tests/fixtures/current-facts/records/invalid/source_family_uses_source_identity.json
@@ -1,0 +1,27 @@
+{
+  "authority_status": "authority_candidate",
+  "character_slug": "jp",
+  "display_label_ja": "ガード硬直差",
+  "evidence": {
+    "evidence_basis": "official_raw_snapshot",
+    "public_reference": "data/exports/jp/official_raw.json",
+    "run_id": "20260521T025403Z",
+    "source_header_path": ["硬直差", "ガード"],
+    "source_label": "ガード",
+    "source_name": "official",
+    "source_role": "authority_candidate"
+  },
+  "field_key": "block_advantage",
+  "move_id": "jp_001_5lp",
+  "raw_value": "-2",
+  "record_id": "official:jp:jp_001_5lp:block_advantage",
+  "source_family": "official",
+  "source_header_path": ["硬直差", "ガード"],
+  "source_label": "ガード",
+  "source_name": "official",
+  "source_role": "authority_candidate",
+  "value_shape": {
+    "classes": ["signed_frame"],
+    "classifier_status": "raw_preserved"
+  }
+}

--- a/tests/fixtures/current-facts/records/invalid/supercombo_numeric_authority.json
+++ b/tests/fixtures/current-facts/records/invalid/supercombo_numeric_authority.json
@@ -1,0 +1,27 @@
+{
+  "authority_status": "authority_candidate",
+  "character_slug": "jp",
+  "display_label_ja": "SuperCombo ガード硬直差",
+  "evidence": {
+    "evidence_basis": "synthetic_contract_fixture",
+    "public_reference": "docs/execplans/2026-05-23-current-fact-json-schema-artifacts.md",
+    "run_id": "20260521T025403Z",
+    "source_header_path": ["Special Moves", "Block Advantage"],
+    "source_label": "Block Advantage",
+    "source_name": "supercombo",
+    "source_role": "cross_reference_candidate"
+  },
+  "field_key": "block_advantage",
+  "move_id": "synthetic:supercombo:example_special",
+  "raw_value": "-4",
+  "record_id": "synthetic:supercombo:example_special:block_advantage",
+  "source_family": "advantage",
+  "source_header_path": ["Special Moves", "Block Advantage"],
+  "source_label": "Block Advantage",
+  "source_name": "supercombo",
+  "source_role": "cross_reference_candidate",
+  "value_shape": {
+    "classes": ["signed_frame"],
+    "classifier_status": "raw_preserved"
+  }
+}

--- a/tests/fixtures/current-facts/records/valid/official_active_frame_range.json
+++ b/tests/fixtures/current-facts/records/valid/official_active_frame_range.json
@@ -1,0 +1,34 @@
+{
+  "authority_status": "authority_candidate",
+  "character_slug": "jp",
+  "display_label_ja": "持続",
+  "evidence": {
+    "evidence_basis": "official_raw_snapshot",
+    "public_reference": "data/exports/jp/official_raw.json",
+    "run_id": "20260521T025403Z",
+    "source_header_path": ["動作フレーム", "持続"],
+    "source_label": "持続",
+    "source_name": "official",
+    "source_role": "authority_candidate"
+  },
+  "field_key": "active",
+  "move_id": "jp_001_5lp",
+  "parsed_value": {
+    "end": 8,
+    "kind": "frame_range",
+    "start": 6,
+    "unit": "frame"
+  },
+  "raw_value": "6-8",
+  "record_id": "official:jp:jp_001_5lp:active",
+  "source_family": "timing",
+  "source_header_path": ["動作フレーム", "持続"],
+  "source_label": "持続",
+  "source_name": "official",
+  "source_role": "authority_candidate",
+  "value_shape": {
+    "classes": ["range"],
+    "classifier_status": "parsed",
+    "parser_rule_id": "frame_range.v1"
+  }
+}

--- a/tests/fixtures/current-facts/records/valid/official_block_advantage_signed_frame.json
+++ b/tests/fixtures/current-facts/records/valid/official_block_advantage_signed_frame.json
@@ -1,0 +1,33 @@
+{
+  "authority_status": "authority_candidate",
+  "character_slug": "jp",
+  "display_label_ja": "ガード硬直差",
+  "evidence": {
+    "evidence_basis": "official_raw_snapshot",
+    "public_reference": "data/exports/jp/official_raw.json",
+    "run_id": "20260521T025403Z",
+    "source_header_path": ["硬直差", "ガード"],
+    "source_label": "ガード",
+    "source_name": "official",
+    "source_role": "authority_candidate"
+  },
+  "field_key": "block_advantage",
+  "move_id": "jp_001_5lp",
+  "parsed_value": {
+    "kind": "signed_frame",
+    "unit": "frame",
+    "value": -2
+  },
+  "raw_value": "-2",
+  "record_id": "official:jp:jp_001_5lp:block_advantage",
+  "source_family": "advantage",
+  "source_header_path": ["硬直差", "ガード"],
+  "source_label": "ガード",
+  "source_name": "official",
+  "source_role": "authority_candidate",
+  "value_shape": {
+    "classes": ["signed_frame"],
+    "classifier_status": "parsed",
+    "parser_rule_id": "signed_frame.v1"
+  }
+}

--- a/tests/fixtures/current-facts/records/valid/official_move_name_raw_preserved.json
+++ b/tests/fixtures/current-facts/records/valid/official_move_name_raw_preserved.json
@@ -1,0 +1,27 @@
+{
+  "authority_status": "authority_candidate",
+  "character_slug": "jp",
+  "display_label_ja": "技名",
+  "evidence": {
+    "evidence_basis": "official_raw_snapshot",
+    "public_reference": "data/exports/jp/official_raw.json",
+    "run_id": "20260521T025403Z",
+    "source_header_path": ["技名"],
+    "source_label": "技名",
+    "source_name": "official",
+    "source_role": "authority_candidate"
+  },
+  "field_key": "move_name",
+  "move_id": "jp_001_5lp",
+  "raw_value": "立ち弱P（ノーシ）",
+  "record_id": "official:jp:jp_001_5lp:move_name",
+  "source_family": "identity",
+  "source_header_path": ["技名"],
+  "source_label": "技名",
+  "source_name": "official",
+  "source_role": "authority_candidate",
+  "value_shape": {
+    "classes": ["raw_only"],
+    "classifier_status": "raw_preserved"
+  }
+}

--- a/tests/fixtures/current-facts/records/valid/supercombo_block_advantage_cross_reference.json
+++ b/tests/fixtures/current-facts/records/valid/supercombo_block_advantage_cross_reference.json
@@ -1,0 +1,33 @@
+{
+  "authority_status": "cross_reference_candidate",
+  "character_slug": "jp",
+  "display_label_ja": "SuperCombo ガード硬直差",
+  "evidence": {
+    "evidence_basis": "synthetic_contract_fixture",
+    "public_reference": "docs/execplans/2026-05-23-current-fact-json-schema-artifacts.md",
+    "run_id": "20260521T025403Z",
+    "source_header_path": ["Special Moves", "Block Advantage"],
+    "source_label": "Block Advantage",
+    "source_name": "supercombo",
+    "source_role": "cross_reference_candidate"
+  },
+  "field_key": "block_advantage",
+  "move_id": "synthetic:supercombo:example_special",
+  "parsed_value": {
+    "kind": "signed_frame",
+    "unit": "frame",
+    "value": -4
+  },
+  "raw_value": "-4",
+  "record_id": "synthetic:supercombo:example_special:block_advantage",
+  "source_family": "advantage",
+  "source_header_path": ["Special Moves", "Block Advantage"],
+  "source_label": "Block Advantage",
+  "source_name": "supercombo",
+  "source_role": "cross_reference_candidate",
+  "value_shape": {
+    "classes": ["signed_frame"],
+    "classifier_status": "parsed",
+    "parser_rule_id": "signed_frame.v1"
+  }
+}

--- a/tests/fixtures/current-facts/records/valid/supercombo_throw_range_hurtbox_review_required.json
+++ b/tests/fixtures/current-facts/records/valid/supercombo_throw_range_hurtbox_review_required.json
@@ -1,0 +1,28 @@
+{
+  "authority_status": "enrichment_candidate",
+  "character_slug": "jp",
+  "display_label_ja": "SuperCombo 投げ範囲 / やられ判定",
+  "evidence": {
+    "evidence_basis": "synthetic_contract_fixture",
+    "public_reference": "docs/execplans/2026-05-23-current-fact-json-schema-artifacts.md",
+    "run_id": "20260521T025403Z",
+    "source_header_path": ["Character Vitals", "Throw Range / Hurtbox"],
+    "source_label": "Throw Range / Hurtbox",
+    "source_name": "supercombo",
+    "source_role": "enrichment_candidate"
+  },
+  "field_key": "supercombo_throw_range_hurtbox_pair",
+  "move_id": null,
+  "raw_value": "1.00 / 0.50",
+  "record_id": "supercombo:jp:vitals:throw_range_hurtbox",
+  "source_family": "throw",
+  "source_header_path": ["Character Vitals", "Throw Range / Hurtbox"],
+  "source_label": "Throw Range / Hurtbox",
+  "source_name": "supercombo",
+  "source_role": "enrichment_candidate",
+  "value_shape": {
+    "classes": ["scalar"],
+    "classifier_status": "review_required",
+    "review_item_id": "supercombo:character-vitals:throw-range-hurtbox"
+  }
+}

--- a/tests/validation/validate_clean_slate.py
+++ b/tests/validation/validate_clean_slate.py
@@ -22,7 +22,6 @@ REQUIRED_PATHS = [
 ]
 
 LEGACY_DIRS_EXPECTED_GONE = [
-    "contracts",
     "docs/architecture",
     "docs/testing",
     "evals",
@@ -39,6 +38,15 @@ LEGACY_DIRS_EXPECTED_GONE = [
 ALLOWED_GITHUB_PATHS = {
     ".github/workflows",
     ".github/workflows/ci.yml",
+}
+
+ALLOWED_CONTRACT_PATHS = {
+    "contracts/current-facts",
+    "contracts/current-facts/current_fact_export.schema.json",
+    "contracts/current-facts/current_fact_record.schema.json",
+    "contracts/current-facts/parsed_value.schema.json",
+    "contracts/current-facts/source_reference.schema.json",
+    "contracts/current-facts/value_shape.schema.json",
 }
 
 
@@ -64,6 +72,15 @@ def main() -> int:
             relative = path.relative_to(ROOT).as_posix()
             if relative not in ALLOWED_GITHUB_PATHS:
                 errors.append(f"Unexpected .github content: {relative}")
+
+    contracts_dir = ROOT / "contracts"
+    if contracts_dir.exists() and not contracts_dir.is_dir():
+        errors.append("contracts must be a directory containing only current-facts schemas")
+    if contracts_dir.is_dir():
+        for path in contracts_dir.rglob("*"):
+            relative = path.relative_to(ROOT).as_posix()
+            if relative not in ALLOWED_CONTRACT_PATHS:
+                errors.append(f"Unexpected contracts content: {relative}")
 
     for json_path in (ROOT / "data").rglob("*.json"):
         try:

--- a/tests/validation/validate_current_fact_schemas.py
+++ b/tests/validation/validate_current_fact_schemas.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_DIR = ROOT / "contracts/current-facts"
+FIXTURE_DIR = ROOT / "tests/fixtures/current-facts"
+RECORD_SCHEMA_ID = "https://sf6-knowledge-coach.local/schemas/current-facts/current_fact_record.schema.json"
+EXPORT_SCHEMA_ID = "https://sf6-knowledge-coach.local/schemas/current-facts/current_fact_export.schema.json"
+SCHEMA_FILES = [
+    "parsed_value.schema.json",
+    "value_shape.schema.json",
+    "source_reference.schema.json",
+    "current_fact_record.schema.json",
+    "current_fact_export.schema.json",
+]
+FORBIDDEN_PUBLIC_PATTERNS = [
+    re.compile(r"(?i)(?:^|[\s\"'`])(?:/[a-z0-9_.-]+)+"),
+    re.compile(r"(?i)(?:^|[\s\"'`(])[A-Z]:[\\/]"),
+    re.compile(r"(?i)\b(?:cookie|authorization|bearer|token|password|secret)\b"),
+    re.compile(r"(?i)<html|</html|<!doctype|<table|</table|<tr|</tr|<td|</td|<th|</th"),
+    re.compile(r"(?i)\b(?:screenshot|trace|debug dump|answer[-_ ]?log|training[-_ ]?log|private[-_ ]?vault)\b"),
+]
+
+
+def main() -> int:
+    errors: list[str] = []
+    schemas = _load_schemas(errors)
+    if errors:
+        return _finish(errors)
+
+    registry = Registry().with_resources(
+        (schema["$id"], Resource.from_contents(schema)) for schema in schemas.values()
+    )
+    for path, schema in schemas.items():
+        try:
+            Draft202012Validator.check_schema(schema)
+        except Exception as exc:  # pragma: no cover - message matters more than exception type here
+            errors.append(f"{path.relative_to(ROOT)} is not a valid Draft 2020-12 schema: {exc}")
+
+    record_validator = Draft202012Validator(schemas[SCHEMA_DIR / "current_fact_record.schema.json"], registry=registry)
+    export_validator = Draft202012Validator(schemas[SCHEMA_DIR / "current_fact_export.schema.json"], registry=registry)
+    _validate_valid_fixtures(record_validator, FIXTURE_DIR / "records/valid", errors)
+    _validate_invalid_fixtures(record_validator, FIXTURE_DIR / "records/invalid", errors)
+    _validate_valid_fixtures(export_validator, FIXTURE_DIR / "exports/valid", errors)
+    _scan_public_files([*schemas, *FIXTURE_DIR.rglob("*.json")], errors)
+    return _finish(errors)
+
+
+def _load_schemas(errors: list[str]) -> dict[Path, dict[str, Any]]:
+    schemas: dict[Path, dict[str, Any]] = {}
+    for name in SCHEMA_FILES:
+        path = SCHEMA_DIR / name
+        if not path.exists():
+            errors.append(f"Missing {path.relative_to(ROOT)}")
+            continue
+        schemas[path] = json.loads(path.read_text(encoding="utf-8"))
+        if schemas[path].get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+            errors.append(f"{path.relative_to(ROOT)} must use JSON Schema Draft 2020-12")
+    return schemas
+
+
+def _validate_valid_fixtures(validator: Draft202012Validator, directory: Path, errors: list[str]) -> None:
+    fixtures = sorted(directory.glob("*.json"))
+    if not fixtures:
+        errors.append(f"Missing valid fixtures under {directory.relative_to(ROOT)}")
+    for path in fixtures:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        failures = sorted(validator.iter_errors(payload), key=lambda error: list(error.path))
+        if failures:
+            errors.append(f"{path.relative_to(ROOT)} should be valid: {failures[0].message}")
+
+
+def _validate_invalid_fixtures(validator: Draft202012Validator, directory: Path, errors: list[str]) -> None:
+    fixtures = sorted(directory.glob("*.json"))
+    if not fixtures:
+        errors.append(f"Missing invalid fixtures under {directory.relative_to(ROOT)}")
+    for path in fixtures:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not list(validator.iter_errors(payload)):
+            errors.append(f"{path.relative_to(ROOT)} should be rejected")
+
+
+def _scan_public_files(paths: list[Path], errors: list[str]) -> None:
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        for pattern in FORBIDDEN_PUBLIC_PATTERNS:
+            if pattern.search(text):
+                errors.append(f"{path.relative_to(ROOT)} contains forbidden public content")
+                break
+
+
+def _finish(errors: list[str]) -> int:
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("Current-fact schema validation OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add Draft 2020-12 current-fact schema artifacts
- add small valid/invalid fixtures for official and SuperCombo boundaries
- add schema validator and register it in validator/test evidence audit
- narrowly allow only contracts/current-facts in clean-slate validation

## Boundaries
- no parser/classifier implementation
- no normalized export generation
- no retrieval/answer behavior changes
- no authority promotion
- no new dependencies

## Validation
- git diff --check
- git diff --cached --check
- uv lock --check
- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py
- for script in tests/validation/validate_*.py; do PYTHONPATH=src uv run --locked python "$script"; done
- PYTHONPATH=src uv run --locked python -m unittest discover -s tests
- PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.cli answer prepare "JPの5LPはガードで何F？"