### PR TITLE
Complete parsed-value classifier ExecPlan

### DIFF
--- a/docs/execplans/2026-05-23-deterministic-parsed-value-classifier-implementation.md
+++ b/docs/execplans/2026-05-23-deterministic-parsed-value-classifier-implementation.md
@@ -211,8 +211,12 @@ git status --short --branch
   `git diff --check`, `git diff --cached --check`, `uv lock --check`,
   `PYTHONPATH=src uv run --locked python -m unittest discover -s tests`, all
   `tests/validation/validate_*.py`, and `git status --short --branch`.
-- [x] (2026-05-23 JST) Completed implementation review with
-  `codex review --commit 1332e1d`; no correctness issues were identified.
+- [x] (2026-05-23 JST) Completed full implementation review with
+  `codex review --base d849741`; fixed the P2 SuperCombo gauge unit inference
+  issue it identified.
+- [x] (2026-05-23 JST) Re-ran full implementation review after the gauge-unit
+  fix with `codex review --base d849741`; no discrete correctness issues were
+  identified.
 
 ## Decision Log
 
@@ -267,6 +271,13 @@ git status --short --branch
   examples must remain `review_required`.
   Date/Author: 2026-05-23 / Codex
 
+- Decision: Infer gauge units from explicit field semantics only.
+  Rationale: `supercombo_` is a source prefix, not Super Art semantics. Drive
+  gauge fields such as `supercombo_drive_gain` and
+  `supercombo_drive_damage_on_block` must remain `drive`; only `sa_gain` and
+  `super_gain` fields classify as `super_art`.
+  Date/Author: 2026-05-23 / Codex
+
 ## Deviations
 
 - None.
@@ -284,7 +295,7 @@ git status --short --branch
 
 | PLAN item | Implementation | Changed files | Validation command | Result | Deviation | Incomplete | Risk |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Parser/classifier module | Added deterministic strict parsers, enum preservation for reviewed representative examples, raw-preserved handling, review-required handling, and out-of-scope rejection | `src/sf6_knowledge_coach/parsed_value_classifier.py` | `PYTHONPATH=src uv run --locked python -m unittest discover -s tests` | Passed, 48 tests | None | None | Strict parsed outputs still require later domain/source/unit checks before calculator use |
+| Parser/classifier module | Added deterministic strict parsers, enum preservation for reviewed representative examples, raw-preserved handling, review-required handling, and out-of-scope rejection | `src/sf6_knowledge_coach/parsed_value_classifier.py` | `PYTHONPATH=src uv run --locked python -m unittest discover -s tests` | Passed, 49 tests | None | None | Strict parsed outputs still require later domain/source/unit checks before calculator use |
 | Parser/classifier coverage | Classified all 247 disposition groups: 1 parsed numeric/structured, 16 enum, 207 review-required, 6 raw-preserved, 17 out-of-scope | `data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json`, `docs/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.md` | `PYTHONPATH=src uv run --locked python tests/validation/validate_parsed_value_classifier.py` | Passed | None | None | Coverage is policy-derived, not live source truth |
 | Current-fact schema compatibility | Added focused fixtures for enum, review-required scaling, and SuperCombo ordered pair without promoting SuperCombo authority | `tests/fixtures/current-facts/records/valid/*.json` | `PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py` | Passed | None | None | Fixtures prove schema compatibility only |
 | Validator audit | Added audit entries for new unittest and validator | `data/validator-audits/20260523-validator-test-fact-source-audit.json`, `docs/validator-audits/20260523-validator-test-fact-source-audit.md` | `PYTHONPATH=src uv run --locked python tests/validation/validate_validator_test_audit.py` | Passed | None | None | Audit remains accepted-with-limits |

--- a/docs/execplans/2026-05-23-deterministic-parsed-value-classifier-implementation.md
+++ b/docs/execplans/2026-05-23-deterministic-parsed-value-classifier-implementation.md
@@ -1,6 +1,6 @@
 # Deterministic Parsed-Value Classifier Implementation
 
-Status: Implemented; validation passed; implementation review pending.
+Status: Complete; validation and implementation review passed.
 
 ## Purpose
 
@@ -211,7 +211,8 @@ git status --short --branch
   `git diff --check`, `git diff --cached --check`, `uv lock --check`,
   `PYTHONPATH=src uv run --locked python -m unittest discover -s tests`, all
   `tests/validation/validate_*.py`, and `git status --short --branch`.
-- [ ] Complete implementation review.
+- [x] (2026-05-23 JST) Completed implementation review with
+  `codex review --commit 1332e1d`; no correctness issues were identified.
 
 ## Decision Log
 
@@ -283,9 +284,9 @@ git status --short --branch
 
 | PLAN item | Implementation | Changed files | Validation command | Result | Deviation | Incomplete | Risk |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Parser/classifier module | Added deterministic strict parsers, enum preservation for reviewed representative examples, raw-preserved handling, review-required handling, and out-of-scope rejection | `src/sf6_knowledge_coach/parsed_value_classifier.py` | `PYTHONPATH=src uv run --locked python -m unittest discover -s tests` | Passed, 47 tests | None | Implementation review pending | Strict parsed outputs still require later domain/source/unit checks before calculator use |
-| Parser/classifier coverage | Classified all 247 disposition groups: 1 parsed numeric/structured, 16 enum, 207 review-required, 6 raw-preserved, 17 out-of-scope | `data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json`, `docs/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.md` | `PYTHONPATH=src uv run --locked python tests/validation/validate_parsed_value_classifier.py` | Passed | None | Implementation review pending | Coverage is policy-derived, not live source truth |
-| Current-fact schema compatibility | Added focused fixtures for enum, review-required scaling, and SuperCombo ordered pair without promoting SuperCombo authority | `tests/fixtures/current-facts/records/valid/*.json` | `PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py` | Passed | None | Implementation review pending | Fixtures prove schema compatibility only |
-| Validator audit | Added audit entries for new unittest and validator | `data/validator-audits/20260523-validator-test-fact-source-audit.json`, `docs/validator-audits/20260523-validator-test-fact-source-audit.md` | `PYTHONPATH=src uv run --locked python tests/validation/validate_validator_test_audit.py` | Passed | None | Implementation review pending | Audit remains accepted-with-limits |
-| Preserve calculation safety | Kept scaling, juggle metadata, SuperCombo active-window sequences, note-bearing values, parenthesized values, bracketed values, KD/HKD/stateful values, multihit values, and unknown enum tokens review-required | Parser/classifier module and coverage artifacts | Full validation command set | Passed | None | Implementation review pending | Future calculators must enforce parsed-only plus source/role/unit/domain eligibility |
-| Preserve scope exclusions | Did not add calculators, normalized exports, retrieval changes, answer changes, authority promotion, live acquisition, or SymPy calculation logic | All changed files | Diff review and validation | Passed | None | Implementation review pending | Later calculator ExecPlan still required |
+| Parser/classifier module | Added deterministic strict parsers, enum preservation for reviewed representative examples, raw-preserved handling, review-required handling, and out-of-scope rejection | `src/sf6_knowledge_coach/parsed_value_classifier.py` | `PYTHONPATH=src uv run --locked python -m unittest discover -s tests` | Passed, 48 tests | None | None | Strict parsed outputs still require later domain/source/unit checks before calculator use |
+| Parser/classifier coverage | Classified all 247 disposition groups: 1 parsed numeric/structured, 16 enum, 207 review-required, 6 raw-preserved, 17 out-of-scope | `data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json`, `docs/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.md` | `PYTHONPATH=src uv run --locked python tests/validation/validate_parsed_value_classifier.py` | Passed | None | None | Coverage is policy-derived, not live source truth |
+| Current-fact schema compatibility | Added focused fixtures for enum, review-required scaling, and SuperCombo ordered pair without promoting SuperCombo authority | `tests/fixtures/current-facts/records/valid/*.json` | `PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py` | Passed | None | None | Fixtures prove schema compatibility only |
+| Validator audit | Added audit entries for new unittest and validator | `data/validator-audits/20260523-validator-test-fact-source-audit.json`, `docs/validator-audits/20260523-validator-test-fact-source-audit.md` | `PYTHONPATH=src uv run --locked python tests/validation/validate_validator_test_audit.py` | Passed | None | None | Audit remains accepted-with-limits |
+| Preserve calculation safety | Kept scaling, juggle metadata, SuperCombo active-window sequences, note-bearing values, parenthesized values, bracketed values, KD/HKD/stateful values, multihit values, and unknown enum tokens review-required | Parser/classifier module and coverage artifacts | Full validation command set | Passed | None | None | Future calculators must enforce parsed-only plus source/role/unit/domain eligibility |
+| Preserve scope exclusions | Did not add calculators, normalized exports, retrieval changes, answer changes, authority promotion, live acquisition, or SymPy calculation logic | All changed files | Diff review and validation | Passed | None | None | Later calculator ExecPlan still required |

--- a/src/sf6_knowledge_coach/parsed_value_classifier.py
+++ b/src/sf6_knowledge_coach/parsed_value_classifier.py
@@ -619,7 +619,7 @@ def _parse_supported_value(raw: str, *, family: str, field_key: str) -> tuple[di
     if family == "damage" and UNSIGNED_INTEGER_RE.fullmatch(raw):
         return {"kind": "integer", "unit": "damage", "value": int(raw)}, "integer_damage.strict.v1"
     if family == "gauge" and DECIMAL_RE.fullmatch(raw):
-        unit = "super_art" if ("super" in field_key or field_key == "sa_gain") else "drive"
+        unit = _gauge_amount_unit(field_key)
         value = float(raw) if "." in raw else int(raw)
         return {"kind": "gauge_amount", "unit": unit, "value": value}, "gauge_amount.strict.v1"
     if family == "throw":
@@ -756,6 +756,12 @@ def _decimal_metric_unit(field_key: str) -> str:
     if "range" in field_key or "distance" in field_key or "apex" in field_key:
         return "source_native_distance"
     return "source_native_metric"
+
+
+def _gauge_amount_unit(field_key: str) -> str:
+    if field_key == "sa_gain" or field_key.startswith("super_gain") or "_super_gain" in field_key:
+        return "super_art"
+    return "drive"
 
 
 def _mechanics_anchor_presence(text: str) -> dict[str, bool]:

--- a/tests/test_parsed_value_classifier.py
+++ b/tests/test_parsed_value_classifier.py
@@ -56,6 +56,20 @@ class ParsedValueClassifierTests(unittest.TestCase):
         self.assertEqual(result.parsed_value["values"], [0.8, 0.33])
         self.assertEqual(result.calculation_input_status, "not_numeric_authority")
 
+    def test_gauge_scalar_unit_does_not_confuse_supercombo_prefix(self) -> None:
+        drive_gain = self.records["value-shape:supercombo--unclassified_expression--command_normals--drive_gain"]
+        result = classifier.classify_raw_value("1000", drive_gain)
+        self.assertEqual(result.parsed_value, {"kind": "gauge_amount", "unit": "drive", "value": 1000})
+        self.assertEqual(result.calculation_input_status, "not_numeric_authority")
+
+        drive_damage = self.records["value-shape:supercombo--unclassified_expression--command_normals--drivedmg_blk"]
+        result = classifier.classify_raw_value("1000", drive_damage)
+        self.assertEqual(result.parsed_value, {"kind": "gauge_amount", "unit": "drive", "value": 1000})
+
+        super_gain = self.records["value-shape:supercombo--unclassified_expression--command_normals--super_gain_hit"]
+        result = classifier.classify_raw_value("1000", super_gain)
+        self.assertEqual(result.parsed_value, {"kind": "gauge_amount", "unit": "super_art", "value": 1000})
+
     def test_supercombo_parsed_coverage_is_not_numeric_authority(self) -> None:
         payload = classifier.build_coverage_payload(disposition=self.disposition)
         supercombo_parsed = [


### PR DESCRIPTION
## Summary
- Mark the deterministic parsed-value classifier ExecPlan complete after implementation review.
- Fix gauge unit inference so the `supercombo_` source prefix does not imply Super Art gauge.
- Add regression coverage: SuperCombo Drive fields remain `drive`; `sa_gain` / `super_gain` fields use `super_art`.

## Validation
- `git diff --check origin/main...HEAD`
- `git diff --cached --check`
- `uv lock --check`
- `PYTHONPATH=src uv run --locked python -m unittest discover -s tests`
- `for script in tests/validation/validate_*.py; do PYTHONPATH=src uv run --locked python "$script"; done`
- `PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate`
- `git diff-tree --check --no-commit-id --root -r HEAD`

PLAN deviations: none.
