### PR TITLE
Implement official signed range parser

### DIFF
--- a/data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json
+++ b/data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json
@@ -6,15 +6,16 @@
     "enum_only_not_arithmetic": 16,
     "not_numeric_authority": 1,
     "out_of_scope_not_emitted": 17,
+    "parsed_range_not_single_value_calculation_safe": 2,
     "raw_preserved_not_calculation": 6,
-    "review_required_not_calculation_safe": 207
+    "review_required_not_calculation_safe": 205
   },
   "classifier_decision_counts": {
     "enum_classified": 16,
     "out_of_scope_first_normalized_export": 17,
-    "parsed_numeric_structured": 1,
+    "parsed_numeric_structured": 3,
     "raw_preserved_non_calculation": 6,
-    "review_required": 207
+    "review_required": 205
   },
   "coverage_records": [
     {
@@ -382,10 +383,12 @@
       "value_shape_classifier_status": "review_required"
     },
     {
-      "calculation_input_status": "review_required_not_calculation_safe",
-      "classifier_decision": "review_required",
-      "parser_rule_ids": [],
-      "policy_note": "Reviewed representative examples do not parse under strict rules; this disposition group remains review-required.",
+      "calculation_input_status": "parsed_range_not_single_value_calculation_safe",
+      "classifier_decision": "parsed_numeric_structured",
+      "parser_rule_ids": [
+        "frame_range.official_signed_wave_dash.v1"
+      ],
+      "policy_note": "Official signed range parses to frame_range endpoints, but range reason is unknown and it is not single-value calculation-safe.",
       "proposed_field_key": "block_advantage",
       "raw_value_policy": "preserve_raw_value_always",
       "review_item_id": "value-shape:official--unclassified_expression--u_c135db53355f--u_522ba9f47afb",
@@ -409,7 +412,7 @@
       "source_name": "official",
       "source_role": "authority_candidate",
       "supercombo_authority_policy": "not_applicable",
-      "value_shape_classifier_status": "review_required"
+      "value_shape_classifier_status": "parsed"
     },
     {
       "calculation_input_status": "review_required_not_calculation_safe",
@@ -442,10 +445,12 @@
       "value_shape_classifier_status": "review_required"
     },
     {
-      "calculation_input_status": "review_required_not_calculation_safe",
-      "classifier_decision": "review_required",
-      "parser_rule_ids": [],
-      "policy_note": "Reviewed representative examples do not parse under strict rules; this disposition group remains review-required.",
+      "calculation_input_status": "parsed_range_not_single_value_calculation_safe",
+      "classifier_decision": "parsed_numeric_structured",
+      "parser_rule_ids": [
+        "frame_range.official_signed_wave_dash.v1"
+      ],
+      "policy_note": "Official signed range parses to frame_range endpoints, but range reason is unknown and it is not single-value calculation-safe.",
       "proposed_field_key": "hit_advantage",
       "raw_value_policy": "preserve_raw_value_always",
       "review_item_id": "value-shape:official--unclassified_expression--u_c135db53355f--u_7acd6c7b6e69",
@@ -469,7 +474,7 @@
       "source_name": "official",
       "source_role": "authority_candidate",
       "supercombo_authority_policy": "not_applicable",
-      "value_shape_classifier_status": "review_required"
+      "value_shape_classifier_status": "parsed"
     },
     {
       "calculation_input_status": "review_required_not_calculation_safe",

--- a/docs/execplans/2026-05-23-official-signed-range-parser.md
+++ b/docs/execplans/2026-05-23-official-signed-range-parser.md
@@ -1,14 +1,14 @@
 # Official Signed Range Parser
 
-Status: Drafted for review.
+Status: Implemented; validation passed.
 
 ## Purpose
 
-Plan the smallest parser implementation slice for official signed `～`
-advantage ranges only.
+Implement the smallest parser slice for official signed `～` advantage ranges
+only.
 
-This ExecPlan is docs-only. It does not implement parser, schema, classifier,
-calculator, retrieval, answer, export, live acquisition, or SymPy changes.
+This ExecPlan does not authorize schema, calculator, retrieval, answer,
+export, live acquisition, or SymPy changes.
 
 ## Inputs
 
@@ -98,8 +98,8 @@ silently widen `frame_range`.
 
 ## Parser Design
 
-Future implementation should add a narrowly scoped parser helper for official
-signed Japanese wave-dash advantage ranges.
+Implementation adds a narrowly scoped parser helper for official signed
+Japanese wave-dash advantage ranges.
 
 Required behavior:
 
@@ -151,9 +151,9 @@ groups `review_required_not_calculation_safe` and do not parse them until a
 range-reason representation is approved. Do not parse them while marking them
 as ordinary calculation-eligible numeric values.
 
-## Future Implementation Plan
+## Implementation Plan
 
-A later implementation PR may touch only the surfaces required for this slice:
+This implementation PR may touch only the surfaces required for this slice:
 
 - `src/sf6_knowledge_coach/parsed_value_classifier.py`
 - `tests/test_parsed_value_classifier.py`
@@ -167,7 +167,7 @@ A later implementation PR may touch only the surfaces required for this slice:
 It must not touch current-fact schemas unless review rejects the schema
 decision above and this ExecPlan is amended first.
 
-Expected coverage movement, if the preferred design is approved:
+Expected coverage movement:
 
 - the two target groups move from `review_required` to
   `parsed_numeric_structured`;
@@ -177,7 +177,7 @@ Expected coverage movement, if the preferred design is approved:
 
 ## Required Tests
 
-Future tests must prove:
+Tests must prove:
 
 - `-12～-1` parses for the official `block_advantage` target group as:
   `{"kind": "frame_range", "unit": "frame", "start": -12, "end": -1}`;
@@ -203,14 +203,20 @@ Future tests must prove:
 - Parsed ranges are not treated as single-value calculation-safe.
 - Raw values are preserved exactly.
 - Parser rule ID and test expectations are explicit.
-- No implementation changes are made in this docs-only planning unit.
+- Implementation changes are limited to the scoped parser, tests, validator
+  coverage, generated coverage artifacts, and this ExecPlan.
 - Validation commands pass.
 
 ## Files / Interfaces
 
-This docs-only planning unit changes only:
+This implementation changes only:
 
 - `docs/execplans/2026-05-23-official-signed-range-parser.md`
+- `src/sf6_knowledge_coach/parsed_value_classifier.py`
+- `tests/test_parsed_value_classifier.py`
+- `tests/validation/validate_parsed_value_classifier.py`
+- `data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json`
+- `docs/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.md`
 
 ## Validation Commands
 
@@ -218,7 +224,11 @@ Run from repository root:
 
 ```bash
 git diff --check
+git diff --cached --check
+uv lock --check
+PYTHONPATH=src uv run --locked python -m unittest discover -s tests
 PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
+PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier build
 PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
 git status --short --branch
 ```
@@ -235,7 +245,25 @@ git status --short --branch
   `PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py`,
   `PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate`,
   and `git status --short --branch`.
-- [ ] Complete review before implementation approval.
+- [x] (2026-05-23 JST) Implementation approval received; created branch
+  `impl/official-signed-range-parser`.
+- [x] (2026-05-23 JST) Added target-ID-limited
+  `frame_range.official_signed_wave_dash.v1` parser.
+- [x] (2026-05-23 JST) Added tests for target parsing, invalid delimiter
+  rejection, note/active exclusions, and SuperCombo exclusion.
+- [x] (2026-05-23 JST) Added validator coverage for the new calculation
+  status, target IDs, parser rule, and count changes.
+- [x] (2026-05-23 JST) Regenerated parsed-value classifier coverage artifacts.
+- [x] (2026-05-23 JST) Final validation passed:
+  `git diff --check`,
+  `git diff --cached --check`,
+  `uv lock --check`,
+  `PYTHONPATH=src uv run --locked python -m unittest discover -s tests`,
+  `PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py`,
+  `PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier build`,
+  `PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate`,
+  and `git status --short --branch`.
+- [ ] Complete implementation review.
 
 ## Decision Log
 
@@ -282,23 +310,24 @@ git status --short --branch
 
 | PLAN item | Implementation | Changed files | Validation command | Result | Deviation | Incomplete | Risk |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Docs-only signed range parser plan | Drafted implementation-prep plan for exactly two official signed `～` advantage range groups | `docs/execplans/2026-05-23-official-signed-range-parser.md` | `git diff --check`; clean-slate validator; parsed-value classifier validator; `git status --short --branch` | Passed | None | Review pending | Calculation status naming needs review |
-| Scope exclusions | No parser/schema/classifier/calculator/retrieval/answer/export/live acquisition/SymPy implementation added | This ExecPlan only | Diff/status review | Passed | None | Future implementation ExecPlan approval required | Later work must not expand beyond target groups |
+| Official signed range parser | Added target-ID-limited parser rule for two official signed `～` advantage range groups | `src/sf6_knowledge_coach/parsed_value_classifier.py`; coverage artifacts | Full validation command set | Passed | None | Review pending | Future calculators must not consume ranges as single values |
+| Calculation status guard | Added `parsed_range_not_single_value_calculation_safe` and validator/test coverage for count/status expectations | `src/sf6_knowledge_coach/parsed_value_classifier.py`; `tests/test_parsed_value_classifier.py`; `tests/validation/validate_parsed_value_classifier.py` | Full validation command set | Passed | None | Review pending | Status must remain fixed by validator |
+| Scope exclusions | No schema/calculator/retrieval/answer/export/live acquisition/SymPy implementation added | Scoped implementation files only | Diff/status review | Passed | None | Review pending | Later work must not expand beyond target groups |
 
 ## Next Reviewer Prompt
 
 ```text
-Review docs/execplans/2026-05-23-official-signed-range-parser.md.
+Review the implementation of docs/execplans/2026-05-23-official-signed-range-parser.md.
 
-Confirm whether it is acceptable as the implementation ExecPlan for only the
-two official signed `～` advantage range groups.
+Confirm whether the implementation matches the ExecPlan for only the two
+official signed `～` advantage range groups.
 
 Check:
-- it covers exactly the two target official review_required groups;
-- existing `parsed_value.kind == "frame_range"` is reused appropriately;
+- the parser applies exactly to the two target official review_required groups;
+- `parsed_value.kind == "frame_range"` is reused without schema changes;
 - delimiter preservation relies on raw_value, not parsed_value widening;
 - range reason remains unknown and is not hidden by parser success;
-- parsed signed ranges are not treated as single-value calculation-safe;
+- parsed signed ranges use `parsed_range_not_single_value_calculation_safe`;
 - ASCII `~`, note-bearing values, active dot/double-dash values, damage,
   scaling, total_duration, SuperCombo, calculators, retrieval, answers,
   exports, live acquisition, and SymPy remain out of scope.

--- a/docs/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.md
+++ b/docs/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.md
@@ -14,17 +14,18 @@ promote SuperCombo values to numeric authority.
 
 - `enum_classified`: 16
 - `out_of_scope_first_normalized_export`: 17
-- `parsed_numeric_structured`: 1
+- `parsed_numeric_structured`: 3
 - `raw_preserved_non_calculation`: 6
-- `review_required`: 207
+- `review_required`: 205
 
 ## Calculation Input Status
 
 - `enum_only_not_arithmetic`: 16
 - `not_numeric_authority`: 1
 - `out_of_scope_not_emitted`: 17
+- `parsed_range_not_single_value_calculation_safe`: 2
 - `raw_preserved_not_calculation`: 6
-- `review_required_not_calculation_safe`: 207
+- `review_required_not_calculation_safe`: 205
 
 ## Mechanics Anchors
 
@@ -56,9 +57,9 @@ promote SuperCombo values to numeric authority.
 | `value-shape:official--source_specific_expression--u_86de52d17820` | `official` | `attribute` | `attribute` | `source_specific_enum_required` | `enum_classified` | `enum_only_not_arithmetic` | `enum_token.source_native_examples.v1` | Representative source-native enum tokens are preserved; unknown tokens are review-required. |
 | `value-shape:official--source_specific_expression--u_1aa6a6f86513` | `official` | `identity` | `move_name` | `schema_supports_raw_only` | `raw_preserved_non_calculation` | `raw_preserved_not_calculation` | `` | Reviewed raw-only field is preserved for display/context and excluded from calculation. |
 | `value-shape:official--source_specific_expression--u_c135db53355f--u_522ba9f47afb` | `official` | `advantage` | `block_advantage` | `parse_rule_required_before_schema` | `review_required` | `review_required_not_calculation_safe` | `` | Reviewed representative examples do not parse under strict rules; this disposition group remains review-required. |
-| `value-shape:official--unclassified_expression--u_c135db53355f--u_522ba9f47afb` | `official` | `advantage` | `block_advantage` | `parse_rule_required_before_schema` | `review_required` | `review_required_not_calculation_safe` | `` | Reviewed representative examples do not parse under strict rules; this disposition group remains review-required. |
+| `value-shape:official--unclassified_expression--u_c135db53355f--u_522ba9f47afb` | `official` | `advantage` | `block_advantage` | `parse_rule_required_before_schema` | `parsed_numeric_structured` | `parsed_range_not_single_value_calculation_safe` | `frame_range.official_signed_wave_dash.v1` | Official signed range parses to frame_range endpoints, but range reason is unknown and it is not single-value calculation-safe. |
 | `value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69` | `official` | `advantage` | `hit_advantage` | `parse_rule_required_before_schema` | `review_required` | `review_required_not_calculation_safe` | `` | Reviewed representative examples do not parse under strict rules; this disposition group remains review-required. |
-| `value-shape:official--unclassified_expression--u_c135db53355f--u_7acd6c7b6e69` | `official` | `advantage` | `hit_advantage` | `parse_rule_required_before_schema` | `review_required` | `review_required_not_calculation_safe` | `` | Reviewed representative examples do not parse under strict rules; this disposition group remains review-required. |
+| `value-shape:official--unclassified_expression--u_c135db53355f--u_7acd6c7b6e69` | `official` | `advantage` | `hit_advantage` | `parse_rule_required_before_schema` | `parsed_numeric_structured` | `parsed_range_not_single_value_calculation_safe` | `frame_range.official_signed_wave_dash.v1` | Official signed range parses to frame_range endpoints, but range reason is unknown and it is not single-value calculation-safe. |
 | `value-shape:supercombo--unclassified_expression--character_vitals--back_dash_distance` | `supercombo` | `mobility` | `supercombo_back_dash_distance` | `parse_rule_required_before_schema` | `review_required` | `review_required_not_calculation_safe` | `` | Reviewed representative examples do not parse under strict rules; this disposition group remains review-required. |
 | `value-shape:supercombo--unclassified_expression--character_vitals--back_jump_distance` | `supercombo` | `mobility` | `supercombo_back_jump_distance` | `parse_rule_required_before_schema` | `review_required` | `review_required_not_calculation_safe` | `` | Reviewed representative examples do not parse under strict rules; this disposition group remains review-required. |
 | `value-shape:supercombo--unclassified_expression--character_vitals--back_walk_speed` | `supercombo` | `mobility` | `supercombo_back_walk_speed` | `parse_rule_required_before_schema` | `review_required` | `review_required_not_calculation_safe` | `` | Reviewed representative examples do not parse under strict rules; this disposition group remains review-required. |

--- a/src/sf6_knowledge_coach/parsed_value_classifier.py
+++ b/src/sf6_knowledge_coach/parsed_value_classifier.py
@@ -61,7 +61,16 @@ INTEGER_RE = re.compile(r"^[+-]?\d+$")
 UNSIGNED_INTEGER_RE = re.compile(r"^\d+$")
 DECIMAL_RE = re.compile(r"^[+-]?(?:\d+\.\d+|\d+)$")
 FRAME_RANGE_RE = re.compile(r"^(\d+)\s*[-~]\s*(\d+)$")
+OFFICIAL_SIGNED_WAVE_DASH_RANGE_RE = re.compile(r"^([+-]?\d+)～([+-]?\d+)$")
 THROW_PAIR_RE = re.compile(r"^(\d+(?:\.\d+)?)\s*/\s*(\d+(?:\.\d+)?)$")
+OFFICIAL_SIGNED_WAVE_DASH_RANGE_RULE_ID = "frame_range.official_signed_wave_dash.v1"
+PARSED_RANGE_NOT_SINGLE_VALUE_CALCULATION_SAFE = "parsed_range_not_single_value_calculation_safe"
+OFFICIAL_SIGNED_WAVE_DASH_RANGE_REVIEW_ITEM_IDS = frozenset(
+    {
+        "value-shape:official--unclassified_expression--u_c135db53355f--u_522ba9f47afb",
+        "value-shape:official--unclassified_expression--u_c135db53355f--u_7acd6c7b6e69",
+    }
+)
 FORBIDDEN_PUBLIC_PATTERNS = [
     re.compile(r"(?i)(?:^|[\s\"'`])(?:/[a-z0-9_.-]+)+"),
     re.compile(r"(?i)(?:^|[\s\"'`(])[A-Z]:[\\/]"),
@@ -143,6 +152,7 @@ def classify_raw_value(raw_value: str | None, disposition_record: dict[str, Any]
     review_item_id = str(disposition_record.get("review_item_id"))
     family = str(disposition_record.get("semantic_source_family"))
     field_key = str(disposition_record.get("proposed_field_key") or "")
+    source_name = str(disposition_record.get("source_name") or "")
 
     if disposition == "out_of_scope_first_normalized_export":
         return _non_parsed_result(
@@ -180,7 +190,13 @@ def classify_raw_value(raw_value: str | None, disposition_record: dict[str, Any]
     if unsupported_reason:
         return _review_required(raw, review_item_id, unsupported_reason)
     if family == "throw":
-        parsed = _parse_supported_value(stripped, family=family, field_key=field_key)
+        parsed = _parse_supported_value(
+            stripped,
+            family=family,
+            field_key=field_key,
+            review_item_id=review_item_id,
+            source_name=source_name,
+        )
         if parsed is not None:
             parsed_value, parser_rule_id = parsed
             return ClassificationResult(
@@ -193,14 +209,20 @@ def classify_raw_value(raw_value: str | None, disposition_record: dict[str, Any]
                     "review_item_id": review_item_id,
                 },
                 parsed_value=parsed_value,
-                calculation_input_status=_parsed_calculation_status(disposition_record),
+                calculation_input_status=_parsed_calculation_status(disposition_record, parser_rule_id=parser_rule_id),
                 policy_note="Parsed by a strict deterministic rule; calculators must still check source role, authority status, kind, unit, and domain.",
             )
     complex_reason = _complex_expression_reason(stripped)
     if complex_reason:
         return _review_required(raw, review_item_id, complex_reason)
 
-    parsed = _parse_supported_value(stripped, family=family, field_key=field_key)
+    parsed = _parse_supported_value(
+        stripped,
+        family=family,
+        field_key=field_key,
+        review_item_id=review_item_id,
+        source_name=source_name,
+    )
     if parsed is None:
         return _review_required(raw, review_item_id, "No deterministic parser rule accepts this raw value shape.")
     parsed_value, parser_rule_id = parsed
@@ -214,7 +236,7 @@ def classify_raw_value(raw_value: str | None, disposition_record: dict[str, Any]
             "review_item_id": review_item_id,
         },
         parsed_value=parsed_value,
-        calculation_input_status=_parsed_calculation_status(disposition_record),
+        calculation_input_status=_parsed_calculation_status(disposition_record, parser_rule_id=parser_rule_id),
         policy_note="Parsed by a strict deterministic rule; calculators must still check source role, authority status, kind, unit, and domain.",
     )
 
@@ -461,13 +483,16 @@ def _coverage_record(record: dict[str, Any]) -> dict[str, Any]:
             decision = "review_required"
             note = unsupported_reason
         else:
-            parser_rule_ids = SUPPORTED_PARSE_RULES_BY_FAMILY.get(family, [])
+            parser_rule_ids = _supported_parse_rule_ids(record)
             parsed_examples = _parsed_representative_examples(record)
             if parser_rule_ids and parsed_examples:
                 decision = "parsed_numeric_structured"
                 value_shape_status = "parsed"
-                calculation_status = _parsed_calculation_status(record)
-                note = "Reviewed representative examples parse under strict rules; complex variants still remain review-required at raw-value classification time."
+                calculation_status = _parsed_calculation_status(record, parser_rule_id=parser_rule_ids[0])
+                if calculation_status == PARSED_RANGE_NOT_SINGLE_VALUE_CALCULATION_SAFE:
+                    note = "Official signed range parses to frame_range endpoints, but range reason is unknown and it is not single-value calculation-safe."
+                else:
+                    note = "Reviewed representative examples parse under strict rules; complex variants still remain review-required at raw-value classification time."
             else:
                 decision = "review_required"
                 parser_rule_ids = []
@@ -599,15 +624,45 @@ def _parsed_representative_examples(record: dict[str, Any]) -> list[str]:
     return parsed
 
 
-def _parsed_calculation_status(disposition_record: dict[str, Any]) -> str:
+def _supported_parse_rule_ids(record: dict[str, Any]) -> list[str]:
+    if _is_official_signed_wave_dash_range_record(record):
+        return [OFFICIAL_SIGNED_WAVE_DASH_RANGE_RULE_ID]
+    family = str(record.get("semantic_source_family"))
+    return SUPPORTED_PARSE_RULES_BY_FAMILY.get(family, [])
+
+
+def _parsed_calculation_status(disposition_record: dict[str, Any], *, parser_rule_id: str) -> str:
+    if parser_rule_id == OFFICIAL_SIGNED_WAVE_DASH_RANGE_RULE_ID:
+        return PARSED_RANGE_NOT_SINGLE_VALUE_CALCULATION_SAFE
     if disposition_record.get("source_name") == "supercombo":
         return "not_numeric_authority"
     return "eligible_only_after_domain_source_and_unit_checks"
 
 
-def _parse_supported_value(raw: str, *, family: str, field_key: str) -> tuple[dict[str, Any], str] | None:
+def _parse_supported_value(
+    raw: str,
+    *,
+    family: str,
+    field_key: str,
+    review_item_id: str,
+    source_name: str,
+) -> tuple[dict[str, Any], str] | None:
     if family == "advantage" and INTEGER_RE.fullmatch(raw):
         return {"kind": "signed_frame", "unit": "frame", "value": int(raw)}, "signed_frame.strict.v1"
+    if _is_official_signed_wave_dash_range_target(
+        review_item_id=review_item_id,
+        source_name=source_name,
+        family=family,
+        field_key=field_key,
+    ):
+        match = OFFICIAL_SIGNED_WAVE_DASH_RANGE_RE.fullmatch(raw)
+        if match:
+            start, end = int(match.group(1)), int(match.group(2))
+            if start <= end:
+                return (
+                    {"kind": "frame_range", "unit": "frame", "start": start, "end": end},
+                    OFFICIAL_SIGNED_WAVE_DASH_RANGE_RULE_ID,
+                )
     if family == "timing":
         match = FRAME_RANGE_RE.fullmatch(raw)
         if match:
@@ -639,6 +694,30 @@ def _parse_supported_value(raw: str, *, family: str, field_key: str) -> tuple[di
         value = float(raw) if "." in raw else int(raw)
         return {"kind": "decimal", "unit": unit, "value": value}, "decimal_metric.strict.v1"
     return None
+
+
+def _is_official_signed_wave_dash_range_record(record: dict[str, Any]) -> bool:
+    return (
+        record.get("review_item_id") in OFFICIAL_SIGNED_WAVE_DASH_RANGE_REVIEW_ITEM_IDS
+        and record.get("source_name") == "official"
+        and record.get("semantic_source_family") == "advantage"
+        and record.get("proposed_field_key") in {"block_advantage", "hit_advantage"}
+    )
+
+
+def _is_official_signed_wave_dash_range_target(
+    *,
+    review_item_id: str,
+    source_name: str,
+    family: str,
+    field_key: str,
+) -> bool:
+    return (
+        review_item_id in OFFICIAL_SIGNED_WAVE_DASH_RANGE_REVIEW_ITEM_IDS
+        and source_name == "official"
+        and family == "advantage"
+        and field_key in {"block_advantage", "hit_advantage"}
+    )
 
 
 def _unsupported_field_reason(record: dict[str, Any]) -> str | None:

--- a/tests/test_parsed_value_classifier.py
+++ b/tests/test_parsed_value_classifier.py
@@ -20,9 +20,20 @@ class ParsedValueClassifierTests(unittest.TestCase):
             {
                 "enum_classified": 16,
                 "out_of_scope_first_normalized_export": 17,
-                "parsed_numeric_structured": 1,
+                "parsed_numeric_structured": 3,
                 "raw_preserved_non_calculation": 6,
-                "review_required": 207,
+                "review_required": 205,
+            },
+        )
+        self.assertEqual(
+            payload["calculation_input_status_counts"],
+            {
+                "enum_only_not_arithmetic": 16,
+                "not_numeric_authority": 1,
+                "out_of_scope_not_emitted": 17,
+                "parsed_range_not_single_value_calculation_safe": 2,
+                "raw_preserved_not_calculation": 6,
+                "review_required_not_calculation_safe": 205,
             },
         )
         self.assertEqual(payload["parse_rule_policy_counts"]["timing"], 63)
@@ -69,6 +80,54 @@ class ParsedValueClassifierTests(unittest.TestCase):
         super_gain = self.records["value-shape:supercombo--unclassified_expression--command_normals--super_gain_hit"]
         result = classifier.classify_raw_value("1000", super_gain)
         self.assertEqual(result.parsed_value, {"kind": "gauge_amount", "unit": "super_art", "value": 1000})
+
+    def test_official_signed_wave_dash_advantage_ranges_parse_but_are_not_calculation_safe(self) -> None:
+        block_advantage = self.records[
+            "value-shape:official--unclassified_expression--u_c135db53355f--u_522ba9f47afb"
+        ]
+        block_examples = {
+            "-12～-1": {"kind": "frame_range", "unit": "frame", "start": -12, "end": -1},
+            "-4～-1": {"kind": "frame_range", "unit": "frame", "start": -4, "end": -1},
+            "-39～-33": {"kind": "frame_range", "unit": "frame", "start": -39, "end": -33},
+        }
+        for raw, expected in block_examples.items():
+            result = classifier.classify_raw_value(raw, block_advantage)
+            self.assertEqual(result.raw_value, raw)
+            self.assertEqual(result.parsed_value, expected)
+            self.assertEqual(result.value_shape["parser_rule_id"], "frame_range.official_signed_wave_dash.v1")
+            self.assertEqual(result.calculation_input_status, "parsed_range_not_single_value_calculation_safe")
+
+        hit_advantage = self.records["value-shape:official--unclassified_expression--u_c135db53355f--u_7acd6c7b6e69"]
+        result = classifier.classify_raw_value("-28～-23", hit_advantage)
+        self.assertEqual(result.parsed_value, {"kind": "frame_range", "unit": "frame", "start": -28, "end": -23})
+        self.assertEqual(result.value_shape["parser_rule_id"], "frame_range.official_signed_wave_dash.v1")
+        self.assertEqual(result.calculation_input_status, "parsed_range_not_single_value_calculation_safe")
+
+        for raw in ("-12~-1", "-12--1", "-1～-12"):
+            result = classifier.classify_raw_value(raw, block_advantage)
+            self.assertEqual(result.value_shape["classifier_status"], "review_required")
+            self.assertIsNone(result.parsed_value)
+
+    def test_official_signed_wave_dash_slice_does_not_expand_other_parsers(self) -> None:
+        note_bearing_advantage = self.records[
+            "value-shape:official--source_specific_expression--u_c135db53355f--u_522ba9f47afb"
+        ]
+        result = classifier.classify_raw_value("※-4", note_bearing_advantage)
+        self.assertEqual(result.value_shape["classifier_status"], "review_required")
+        self.assertIsNone(result.parsed_value)
+
+        active = self.records["value-shape:official--malformed_looking_source_value--u_fdb49a2113ba--u_c2b75204faf1"]
+        for raw in ("30-34.35", "20-24.25", "23--33"):
+            result = classifier.classify_raw_value(raw, active)
+            self.assertEqual(result.value_shape["classifier_status"], "review_required")
+            self.assertIsNone(result.parsed_value)
+
+        supercombo_advantage = self.records[
+            "value-shape:supercombo--unclassified_expression--command_normals--hit_advantage"
+        ]
+        result = classifier.classify_raw_value("-12～-1", supercombo_advantage)
+        self.assertEqual(result.value_shape["classifier_status"], "review_required")
+        self.assertIsNone(result.parsed_value)
 
     def test_supercombo_parsed_coverage_is_not_numeric_authority(self) -> None:
         payload = classifier.build_coverage_payload(disposition=self.disposition)

--- a/tests/validation/validate_parsed_value_classifier.py
+++ b/tests/validation/validate_parsed_value_classifier.py
@@ -17,6 +17,12 @@ COVERAGE_JSON = ROOT / "data/value-shape-policies/20260521T025403Z-parsed-value-
 COVERAGE_MD = ROOT / "docs/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.md"
 SCHEMA_DIR = ROOT / "contracts/current-facts"
 RECORD_SCHEMA_ID = "https://sf6-knowledge-coach.local/schemas/current-facts/current_fact_record.schema.json"
+SIGNED_WAVE_DASH_RULE_ID = "frame_range.official_signed_wave_dash.v1"
+SIGNED_WAVE_DASH_CALCULATION_STATUS = "parsed_range_not_single_value_calculation_safe"
+SIGNED_WAVE_DASH_TARGET_IDS = {
+    "value-shape:official--unclassified_expression--u_c135db53355f--u_522ba9f47afb",
+    "value-shape:official--unclassified_expression--u_c135db53355f--u_7acd6c7b6e69",
+}
 SCHEMA_FILES = [
     "parsed_value.schema.json",
     "value_shape.schema.json",
@@ -62,9 +68,64 @@ def main() -> int:
     rendered = classifier.render_coverage_markdown(coverage)
     if COVERAGE_MD.read_text(encoding="utf-8") != rendered:
         errors.append("coverage markdown is not the deterministic classifier rendering")
+    _validate_signed_wave_dash_slice(coverage, errors)
     errors.extend(_validate_current_fact_compatible_outputs(disposition))
     _scan_public_files([COVERAGE_JSON, COVERAGE_MD], errors)
     return _finish(errors)
+
+
+def _validate_signed_wave_dash_slice(coverage: dict[str, Any], errors: list[str]) -> None:
+    if coverage.get("classifier_decision_counts", {}).get("parsed_numeric_structured") != 3:
+        errors.append("parsed_numeric_structured count must include exactly two official signed wave-dash ranges")
+    if coverage.get("classifier_decision_counts", {}).get("review_required") != 205:
+        errors.append("review_required count must decrease only for the two official signed wave-dash ranges")
+
+    calculation_counts = coverage.get("calculation_input_status_counts", {})
+    if calculation_counts.get(SIGNED_WAVE_DASH_CALCULATION_STATUS) != 2:
+        errors.append(f"{SIGNED_WAVE_DASH_CALCULATION_STATUS} count must be 2")
+    if calculation_counts.get("review_required_not_calculation_safe") != 205:
+        errors.append("review_required_not_calculation_safe count must be 205")
+    if calculation_counts.get("not_numeric_authority") != 1:
+        errors.append("not_numeric_authority count must remain 1")
+
+    records = coverage.get("coverage_records", [])
+    by_id = {record.get("review_item_id"): record for record in records if isinstance(record, dict)}
+    for review_item_id in SIGNED_WAVE_DASH_TARGET_IDS:
+        record = by_id.get(review_item_id)
+        if record is None:
+            errors.append(f"Missing signed wave-dash target coverage record: {review_item_id}")
+            continue
+        if record.get("source_name") != "official":
+            errors.append(f"{review_item_id} must remain official")
+        if record.get("source_role") != "authority_candidate":
+            errors.append(f"{review_item_id} must remain authority_candidate")
+        if record.get("classifier_decision") != "parsed_numeric_structured":
+            errors.append(f"{review_item_id} must be parsed_numeric_structured")
+        if record.get("calculation_input_status") != SIGNED_WAVE_DASH_CALCULATION_STATUS:
+            errors.append(f"{review_item_id} must not be single-value calculation-safe")
+        if record.get("parser_rule_ids") != [SIGNED_WAVE_DASH_RULE_ID]:
+            errors.append(f"{review_item_id} must use only {SIGNED_WAVE_DASH_RULE_ID}")
+
+    extra_rule_records = [
+        record.get("review_item_id")
+        for record in records
+        if isinstance(record, dict)
+        and SIGNED_WAVE_DASH_RULE_ID in record.get("parser_rule_ids", [])
+        and record.get("review_item_id") not in SIGNED_WAVE_DASH_TARGET_IDS
+    ]
+    if extra_rule_records:
+        errors.append(f"{SIGNED_WAVE_DASH_RULE_ID} leaked outside target groups: {extra_rule_records[:3]}")
+
+    unsafe_official_ranges = [
+        record.get("review_item_id")
+        for record in records
+        if isinstance(record, dict)
+        and record.get("source_name") == "official"
+        and SIGNED_WAVE_DASH_RULE_ID in record.get("parser_rule_ids", [])
+        and record.get("calculation_input_status") == "eligible_only_after_domain_source_and_unit_checks"
+    ]
+    if unsafe_official_ranges:
+        errors.append(f"official signed ranges must not be calculation-eligible: {unsafe_official_ranges[:3]}")
 
 
 def _validate_current_fact_compatible_outputs(disposition: dict[str, Any]) -> list[str]:


### PR DESCRIPTION
## Summary
- Adds `frame_range.official_signed_wave_dash.v1` for the two official signed `～` advantage range groups only.
- Reuses existing `frame_range` parsed_value shape and preserves the raw delimiter in `raw_value`.
- Adds `parsed_range_not_single_value_calculation_safe` coverage status and fixes it in unit/validation tests.
- Regenerates parsed-value classifier coverage artifacts.

## Validation
- git diff --check
- git diff --cached --check
- uv lock --check
- PYTHONPATH=src uv run --locked python -m unittest discover -s tests
- PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
- PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier build
- PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
- git status --short --branch

## Exclusions
- No schema changes.
- No calculator/SymPy, retrieval, answer, export, source acquisition, SuperCombo parser, note marker, active-window, damage, scaling, or total_duration implementation.