### PR TITLE
Implement official note linkage source review

### DIFF
--- a/data/source-reviews/20260524-official-note-linkage-source-review-summary.json
+++ b/data/source-reviews/20260524-official-note-linkage-source-review-summary.json
@@ -1,0 +1,480 @@
+{
+  "artifact_boundary": "source_review_summary_only",
+  "artifact_schema_version": "official_note_linkage_source_review_summary/v1",
+  "authority_status": "review_decision_only_not_authority",
+  "input_coverage": "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+  "input_disposition": "data/value-shape-dispositions/20260521T025403Z-value-shape-review-item-disposition-summary.json",
+  "review_counts": {
+    "blocked_pending_acquisition_fields": 8,
+    "not_note_linkage_target": 1,
+    "source_confirmed_non_note_grammar_blocked": 1,
+    "source_evidence_found_acquisition_field_gap": 8,
+    "total_review_records": 9
+  },
+  "review_records": [
+    {
+      "acquisition_field_gap": "row_note_text_not_structured_in_table_row_artifact",
+      "affected_count": 8,
+      "cell_boundary_status": "confirmed_source_column",
+      "later_parser_eligibility": "blocked_pending_acquisition_fields",
+      "marker_roles": [
+        "note_marker_on_value"
+      ],
+      "note_id": null,
+      "note_marker": "※",
+      "note_review_status": "linked_in_reviewer_evidence",
+      "note_scope": "row_source_column_condition",
+      "note_text_excerpt": "SAゲージ増加量が上昇",
+      "note_text_status": "row_note_evidence_found",
+      "proposed_field_key": "sa_gain",
+      "representative_examples": [
+        {
+          "raw_value": "※3000",
+          "raw_value_length": 5,
+          "raw_value_sha256": "sha256:4c4f8cd60d1e01551610896f047680a43c97a49914268acacca83e4e9e98d667"
+        },
+        {
+          "raw_value": "※2150",
+          "raw_value_length": 5,
+          "raw_value_sha256": "sha256:d49bcb60ba5acd324808127bdbca50fcb374e98612a2c3e72c201a9a618aba7a"
+        }
+      ],
+      "required_source_fields_checked": [
+        "source_column_header_path",
+        "source_text_stripped",
+        "visible_text",
+        "hidden_detail_text",
+        "row_identity",
+        "row_note_list_from_ignored_html_capture"
+      ],
+      "review_item_id": "value-shape:official--source_specific_expression--sa",
+      "reviewer_notes": "Reviewer evidence links the marker to row-local medal-level SA gauge conditions, but the structured table-row artifact does not expose row notes.",
+      "row_identity_status": "confirmed_public_character_move_reference",
+      "semantic_source_family": "gauge",
+      "source_header_path": [
+        "SAゲージ増加"
+      ],
+      "source_name": "official",
+      "source_review_id": "source-review:official-note-linkage-sa-gain",
+      "source_review_result": "source_evidence_found_acquisition_field_gap",
+      "source_role": "authority_candidate",
+      "visible_hidden_detail_status": "not_applicable_or_empty"
+    },
+    {
+      "acquisition_field_gap": "row_note_text_not_structured_in_table_row_artifact",
+      "affected_count": 55,
+      "cell_boundary_status": "confirmed_source_column",
+      "later_parser_eligibility": "blocked_pending_acquisition_fields",
+      "marker_roles": [
+        "note_marker_on_value",
+        "standalone_marker",
+        "mixed_scaling_marker"
+      ],
+      "note_id": null,
+      "note_marker": "※",
+      "note_review_status": "mixed_linked_in_reviewer_evidence",
+      "note_scope": "row_scaling_condition",
+      "note_text_excerpt": "必殺技キャンセル時のみ適用",
+      "note_text_status": "mixed_row_note_evidence_found",
+      "proposed_field_key": "combo_scaling",
+      "representative_examples": [
+        {
+          "raw_value": "※即時補正10%",
+          "raw_value_length": 8,
+          "raw_value_sha256": "sha256:a98990239438de4d0088e4c77e3675dec4d355c037d47195a4a47872d4916a36"
+        },
+        {
+          "raw_value": "※始動補正30%コンボ補正20%",
+          "raw_value_length": 16,
+          "raw_value_sha256": "sha256:8649105bf85a1a93d4df2da5e0f3693b9de4a308d4059afad03facd044499819"
+        }
+      ],
+      "required_source_fields_checked": [
+        "source_column_header_path",
+        "source_text_stripped",
+        "visible_text",
+        "hidden_detail_text",
+        "row_identity",
+        "row_note_list_from_ignored_html_capture"
+      ],
+      "review_item_id": "value-shape:official--source_specific_expression--u_55d872f6091a",
+      "reviewer_notes": "Reviewer evidence shows row-local scaling notes, but the notes vary by move and must be captured per row before any scaling parser is safe.",
+      "row_identity_status": "confirmed_public_character_move_reference",
+      "semantic_source_family": "scaling",
+      "source_header_path": [
+        "コンボ補正値"
+      ],
+      "source_name": "official",
+      "source_review_id": "source-review:official-note-linkage-combo-scaling",
+      "source_review_result": "source_evidence_found_acquisition_field_gap",
+      "source_role": "authority_candidate",
+      "visible_hidden_detail_status": "not_applicable_or_empty"
+    },
+    {
+      "acquisition_field_gap": "row_note_text_not_structured_in_table_row_artifact",
+      "affected_count": 36,
+      "cell_boundary_status": "confirmed_source_column",
+      "later_parser_eligibility": "blocked_pending_acquisition_fields",
+      "marker_roles": [
+        "note_marker_on_value"
+      ],
+      "note_id": null,
+      "note_marker": "※",
+      "note_review_status": "mixed_linked_in_reviewer_evidence",
+      "note_scope": "row_damage_condition",
+      "note_text_excerpt": "毒破裂時ダメージ",
+      "note_text_status": "mixed_row_note_evidence_found",
+      "proposed_field_key": "damage",
+      "representative_examples": [
+        {
+          "raw_value": "※500",
+          "raw_value_length": 4,
+          "raw_value_sha256": "sha256:46cf29a0ae2b7509618d84379073b70c52e8b7891daa55a511736a69da7db622"
+        },
+        {
+          "raw_value": "※1000",
+          "raw_value_length": 5,
+          "raw_value_sha256": "sha256:45bae50f68fe189635acdf558601808ec2f976f075c9c3ca1b338cb301d362d2"
+        }
+      ],
+      "required_source_fields_checked": [
+        "source_column_header_path",
+        "source_text_stripped",
+        "visible_text",
+        "hidden_detail_text",
+        "row_identity",
+        "row_note_list_from_ignored_html_capture"
+      ],
+      "review_item_id": "value-shape:official--source_specific_expression--u_202a059d9b1b",
+      "reviewer_notes": "Damage examples are confirmed inside the source-native damage column, not caused by adjacent cancel cells. Row notes still need structured acquisition before parsing.",
+      "row_identity_status": "confirmed_public_character_move_reference",
+      "semantic_source_family": "damage",
+      "source_header_path": [
+        "ダメージ"
+      ],
+      "source_name": "official",
+      "source_review_id": "source-review:official-note-linkage-damage",
+      "source_review_result": "source_evidence_found_acquisition_field_gap",
+      "source_role": "authority_candidate",
+      "visible_hidden_detail_status": "not_applicable_or_empty"
+    },
+    {
+      "acquisition_field_gap": "none_for_note_linkage",
+      "affected_count": 3,
+      "cell_boundary_status": "confirmed_source_column",
+      "later_parser_eligibility": "not_note_linkage_target",
+      "marker_roles": [
+        "not_note_linkage_target"
+      ],
+      "note_id": null,
+      "note_marker": null,
+      "note_review_status": "not_applicable",
+      "note_scope": "not_applicable",
+      "note_text_excerpt": null,
+      "note_text_status": "not_applicable",
+      "proposed_field_key": "active",
+      "representative_examples": [
+        {
+          "raw_value": "30-34.35",
+          "raw_value_length": 8,
+          "raw_value_sha256": "sha256:e5b63d5b999e4db9832b8b739603d13d176c510a6750e710d92f5f824f98aafa"
+        },
+        {
+          "raw_value": "23--33",
+          "raw_value_length": 6,
+          "raw_value_sha256": "sha256:b3f49b438e943f1d1fdf65ee8140af8175bef8ead3dafb7a553052caec70342a"
+        }
+      ],
+      "required_source_fields_checked": [
+        "source_column_header_path",
+        "source_text_stripped",
+        "visible_text",
+        "hidden_detail_text",
+        "row_identity",
+        "row_note_list_from_ignored_html_capture"
+      ],
+      "review_item_id": "value-shape:official--malformed_looking_source_value--u_fdb49a2113ba--u_c2b75204faf1",
+      "reviewer_notes": "Dot and double-hyphen active strings are source-confirmed active cells, but this source review does not resolve their grammar or calculation meaning.",
+      "row_identity_status": "confirmed_public_character_move_reference",
+      "semantic_source_family": "timing",
+      "source_header_path": [
+        "動作フレーム",
+        "持続"
+      ],
+      "source_name": "official",
+      "source_review_id": "source-review:official-active-non-note-grammar",
+      "source_review_result": "source_confirmed_non_note_grammar_blocked",
+      "source_role": "authority_candidate",
+      "visible_hidden_detail_status": "visible_text_preserved"
+    },
+    {
+      "acquisition_field_gap": "row_note_text_not_structured_in_table_row_artifact",
+      "affected_count": 44,
+      "cell_boundary_status": "confirmed_source_column_with_hidden_detail",
+      "later_parser_eligibility": "blocked_pending_acquisition_fields",
+      "marker_roles": [
+        "standalone_marker",
+        "bracketed_note_id",
+        "note_marker_on_component",
+        "visible_hidden_detail_concatenation"
+      ],
+      "note_id": "mixed",
+      "note_marker": "※",
+      "note_review_status": "mixed_linked_in_reviewer_evidence",
+      "note_scope": "row_active_component",
+      "note_text_excerpt": "ボタンホールドでパリィの持続を延長可",
+      "note_text_status": "mixed_row_note_evidence_found",
+      "proposed_field_key": "active",
+      "representative_examples": [
+        {
+          "raw_value": "※",
+          "raw_value_length": 1,
+          "raw_value_sha256": "sha256:0eaf29bb40975e849d389b860f8b79ee02a1466c79529393897c3dd82dde4299"
+        },
+        {
+          "raw_value": "[※2] 1-12",
+          "raw_value_length": 9,
+          "raw_value_sha256": "sha256:48b1d47bb3ef93ac50f2ca93e16c2c5ada96e4aab7dfdd641391105edd24e052"
+        },
+        {
+          "raw_value": "6-366-11, 13-18※,20-25, 34-36",
+          "raw_value_length": 29,
+          "raw_value_sha256": "sha256:7ba333b1fe2d4c4ca9f73ff9c7f64725db008134e8d3a71568d081a9bfa0eee3"
+        }
+      ],
+      "required_source_fields_checked": [
+        "source_column_header_path",
+        "source_text_stripped",
+        "visible_text",
+        "hidden_detail_text",
+        "row_identity",
+        "row_note_list_from_ignored_html_capture"
+      ],
+      "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_c2b75204faf1",
+      "reviewer_notes": "Active cells mix standalone markers, bracketed note ids, and hidden-detail concatenation. Future parser must consume separated visible and hidden fields, not only concatenated source text.",
+      "row_identity_status": "confirmed_public_character_move_reference",
+      "semantic_source_family": "timing",
+      "source_header_path": [
+        "動作フレーム",
+        "持続"
+      ],
+      "source_name": "official",
+      "source_review_id": "source-review:official-note-linkage-active",
+      "source_review_result": "source_evidence_found_acquisition_field_gap",
+      "source_role": "authority_candidate",
+      "visible_hidden_detail_status": "separated_fields_available_with_concatenated_source_text"
+    },
+    {
+      "acquisition_field_gap": "row_note_text_not_structured_in_table_row_artifact",
+      "affected_count": 6,
+      "cell_boundary_status": "confirmed_source_column",
+      "later_parser_eligibility": "blocked_pending_acquisition_fields",
+      "marker_roles": [
+        "note_marker_on_value"
+      ],
+      "note_id": null,
+      "note_marker": "※",
+      "note_review_status": "linked_in_reviewer_evidence",
+      "note_scope": "row_startup_condition",
+      "note_text_excerpt": "画面中央で発動した際の数値",
+      "note_text_status": "row_note_evidence_found",
+      "proposed_field_key": "startup",
+      "representative_examples": [
+        {
+          "raw_value": "122※",
+          "raw_value_length": 4,
+          "raw_value_sha256": "sha256:1a036dd4c06cd18cde9b72d219f3bf9ff2c41ec171022dbe1058e162cf96df7c"
+        },
+        {
+          "raw_value": "128※",
+          "raw_value_length": 4,
+          "raw_value_sha256": "sha256:3c911b4c4f5d473c3e4bd988a924818f3c760adbd14fd241a7fdccf42c99b814"
+        }
+      ],
+      "required_source_fields_checked": [
+        "source_column_header_path",
+        "source_text_stripped",
+        "visible_text",
+        "hidden_detail_text",
+        "row_identity",
+        "row_note_list_from_ignored_html_capture"
+      ],
+      "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100",
+      "reviewer_notes": "Startup suffix markers are row-local conditional values. Row-note extraction is required before annotated startup parsing.",
+      "row_identity_status": "confirmed_public_character_move_reference",
+      "semantic_source_family": "timing",
+      "source_header_path": [
+        "動作フレーム",
+        "発生"
+      ],
+      "source_name": "official",
+      "source_review_id": "source-review:official-note-linkage-startup",
+      "source_review_result": "source_evidence_found_acquisition_field_gap",
+      "source_role": "authority_candidate",
+      "visible_hidden_detail_status": "not_applicable_or_empty"
+    },
+    {
+      "acquisition_field_gap": "row_note_text_not_structured_in_table_row_artifact",
+      "affected_count": 28,
+      "cell_boundary_status": "confirmed_source_column",
+      "later_parser_eligibility": "blocked_pending_acquisition_fields",
+      "marker_roles": [
+        "note_marker_on_value",
+        "total_duration_label"
+      ],
+      "note_id": null,
+      "note_marker": "※",
+      "note_review_status": "mixed_linked_in_reviewer_evidence",
+      "note_scope": "row_recovery_or_total_duration_condition",
+      "note_text_excerpt": "裏回り時 全体",
+      "note_text_status": "mixed_row_note_evidence_found",
+      "proposed_field_key": "recovery",
+      "representative_examples": [
+        {
+          "raw_value": "全体 ※43",
+          "raw_value_length": 6,
+          "raw_value_sha256": "sha256:847d034b457bbcdbb2e72bd8a36624baf2cdab0d3454e52ae1b0d55b400c01ce"
+        },
+        {
+          "raw_value": "※16",
+          "raw_value_length": 3,
+          "raw_value_sha256": "sha256:d7c3b005226e7f940c02a6eb54efbff369513f0fcb9e5358ea6523cfefa6db5c"
+        }
+      ],
+      "required_source_fields_checked": [
+        "source_column_header_path",
+        "source_text_stripped",
+        "visible_text",
+        "hidden_detail_text",
+        "row_identity",
+        "row_note_list_from_ignored_html_capture"
+      ],
+      "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_4b3674d32cef",
+      "reviewer_notes": "The source column is recovery, but values prefixed with the source label for total duration must not be treated as ordinary recovery frames.",
+      "row_identity_status": "confirmed_public_character_move_reference",
+      "semantic_source_family": "timing",
+      "source_header_path": [
+        "動作フレーム",
+        "硬直"
+      ],
+      "source_name": "official",
+      "source_review_id": "source-review:official-note-linkage-recovery",
+      "source_review_result": "source_evidence_found_acquisition_field_gap",
+      "source_role": "authority_candidate",
+      "visible_hidden_detail_status": "not_applicable_or_empty"
+    },
+    {
+      "acquisition_field_gap": "row_note_text_not_structured_in_table_row_artifact",
+      "affected_count": 6,
+      "cell_boundary_status": "confirmed_source_column",
+      "later_parser_eligibility": "blocked_pending_acquisition_fields",
+      "marker_roles": [
+        "note_marker_on_value",
+        "embedded_alternate_value_marker"
+      ],
+      "note_id": null,
+      "note_marker": "※",
+      "note_review_status": "mixed_linked_in_reviewer_evidence",
+      "note_scope": "row_block_advantage_condition",
+      "note_text_excerpt": "行雲流水を継続した場合の数値",
+      "note_text_status": "mixed_row_note_evidence_found",
+      "proposed_field_key": "block_advantage",
+      "representative_examples": [
+        {
+          "raw_value": "※-4",
+          "raw_value_length": 3,
+          "raw_value_sha256": "sha256:b5112d05eab37a8ef2062523ba1cce640a8350c6cba7ef40bf66072550f3609c"
+        },
+        {
+          "raw_value": "※-2",
+          "raw_value_length": 3,
+          "raw_value_sha256": "sha256:522076e6afe25969ab0fe38642fcf471a681152e0f919f489622873b188357e6"
+        }
+      ],
+      "required_source_fields_checked": [
+        "source_column_header_path",
+        "source_text_stripped",
+        "visible_text",
+        "hidden_detail_text",
+        "row_identity",
+        "row_note_list_from_ignored_html_capture"
+      ],
+      "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_522ba9f47afb",
+      "reviewer_notes": "Block advantage markers are row-local conditions. Embedded alternate forms such as a marker between two signed values need a separate parser rule.",
+      "row_identity_status": "confirmed_public_character_move_reference",
+      "semantic_source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ガード"
+      ],
+      "source_name": "official",
+      "source_review_id": "source-review:official-note-linkage-block-advantage",
+      "source_review_result": "source_evidence_found_acquisition_field_gap",
+      "source_role": "authority_candidate",
+      "visible_hidden_detail_status": "not_applicable_or_empty"
+    },
+    {
+      "acquisition_field_gap": "row_note_text_not_structured_in_table_row_artifact",
+      "affected_count": 4,
+      "cell_boundary_status": "confirmed_source_column",
+      "later_parser_eligibility": "blocked_pending_acquisition_fields",
+      "marker_roles": [
+        "note_marker_on_value"
+      ],
+      "note_id": null,
+      "note_marker": "※",
+      "note_review_status": "mixed_linked_in_reviewer_evidence",
+      "note_scope": "row_hit_advantage_condition",
+      "note_text_excerpt": "行雲流水を継続した場合の数値",
+      "note_text_status": "mixed_row_note_evidence_found",
+      "proposed_field_key": "hit_advantage",
+      "representative_examples": [
+        {
+          "raw_value": "※-3",
+          "raw_value_length": 3,
+          "raw_value_sha256": "sha256:38098349c914433f0d197b466d52fc182309a3043e91d401f8c2a98b3b8917ca"
+        },
+        {
+          "raw_value": "※1",
+          "raw_value_length": 2,
+          "raw_value_sha256": "sha256:cdbdef563e30978a50724b9a6d38e2e93f159fe241dcf0089ac429fe4d1e99c5"
+        }
+      ],
+      "required_source_fields_checked": [
+        "source_column_header_path",
+        "source_text_stripped",
+        "visible_text",
+        "hidden_detail_text",
+        "row_identity",
+        "row_note_list_from_ignored_html_capture"
+      ],
+      "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69",
+      "reviewer_notes": "Hit advantage markers are row-local conditions. Positive values without an explicit plus sign remain column-context dependent.",
+      "row_identity_status": "confirmed_public_character_move_reference",
+      "semantic_source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ヒット"
+      ],
+      "source_name": "official",
+      "source_review_id": "source-review:official-note-linkage-hit-advantage",
+      "source_review_result": "source_evidence_found_acquisition_field_gap",
+      "source_role": "authority_candidate",
+      "visible_hidden_detail_status": "not_applicable_or_empty"
+    }
+  ],
+  "run_id": "20260524",
+  "source_boundary": {
+    "full_raw_rows_public_commit": "forbidden",
+    "local_artifacts_public_commit": "forbidden",
+    "raw_html_public_commit": "forbidden"
+  },
+  "source_evidence_summary": {
+    "live_acquisition_run": false,
+    "row_note_text_in_structured_table_row_artifact": false,
+    "row_note_text_seen_in_ignored_reviewer_html_capture": true,
+    "table_cell_boundaries_seen_in_structured_table_row_artifact": true,
+    "visible_hidden_detail_fields_seen_in_structured_table_row_artifact": true
+  },
+  "total_review_records": 9
+}

--- a/data/validator-audits/20260523-validator-test-fact-source-audit.json
+++ b/data/validator-audits/20260523-validator-test-fact-source-audit.json
@@ -113,6 +113,19 @@
       "status": "accepted_with_limits"
     },
     {
+      "evidence_class": "source_derived",
+      "file": "tests/validation/validate_official_note_linkage_source_review.py",
+      "limitations": [
+        "checks official note-linkage source-review summary boundaries; full row-note context remains ignored local evidence"
+      ],
+      "primary_evidence": [
+        "official note-linkage source-review artifact",
+        "parsed-value classifier coverage artifact",
+        "ignored local official source artifacts"
+      ],
+      "status": "accepted_with_limits"
+    },
+    {
       "evidence_class": "governance_boundary",
       "file": "tests/validation/validate_validator_test_audit.py",
       "limitations": [

--- a/docs/execplans/2026-05-24-official-note-linkage-source-review.md
+++ b/docs/execplans/2026-05-24-official-note-linkage-source-review.md
@@ -1,16 +1,16 @@
 # Official Note Linkage Source Review
 
-Status: Drafted for review.
+Status: Implementation complete; review pending.
 
 ## Purpose
 
-Plan how to review and represent official note linkage for `※` and `*`
-annotated official values before any note-bearing parser can become
-calculation-safe.
+Review and represent official note linkage for `※` and `*` annotated official
+values before any note-bearing parser can become calculation-safe.
 
-This ExecPlan is docs-only. It does not implement parser, schema, classifier,
-calculator, retrieval, answer, export, validator, generated coverage artifact,
-live acquisition, or SymPy changes.
+This ExecPlan produced source-review summary artifacts and a focused validator.
+It does not implement parser, schema, classifier, calculator, retrieval,
+answer, export, generated coverage artifact, live acquisition, or SymPy
+changes.
 
 ## Inputs
 
@@ -24,7 +24,7 @@ live acquisition, or SymPy changes.
 - Existing ignored `.local/` reviewer artifacts, if available, as reviewer
   input only.
 
-Live official page checks are not part of this docs-only plan. If later source
+Live official page checks are not part of this implementation. If later source
 review needs live official page checks, they must be run only in reviewer or
 update mode, never in CI or daily-answer mode.
 
@@ -58,7 +58,7 @@ Known risks:
 
 Included:
 
-- Plan source-review artifacts only.
+- Implement source-review summary artifacts only.
 - Define how to link `note_marker`, `note_id`, `note_text`, `note_scope`,
   `source_column_header_path`, row/move identity, and raw value.
 - Define how to distinguish:
@@ -79,14 +79,15 @@ Excluded:
 - No parser implementation.
 - No schema implementation.
 - No classifier behavior changes.
-- No validator changes.
+- No validator changes except the focused source-review summary validator and
+  its evidence-audit entry.
 - No generated coverage artifact changes.
 - No calculator implementation.
 - No SymPy calculation logic.
 - No retrieval, answer, export, or runtime changes.
 - No numeric authority promotion.
 - No SuperCombo authority promotion.
-- No live acquisition in this planning step.
+- No live acquisition in this implementation.
 - No weakening validators to fit current artifacts.
 
 ## Exact Official Groups Covered
@@ -115,9 +116,9 @@ Those two official signed `～` advantage range groups are already parsed as
 `frame_range` and remain not single-value calculation-safe under the frame
 range consumer guard plan.
 
-## Planned Source-Review Artifacts
+## Source-Review Artifacts
 
-A later source-review implementation ExecPlan may create:
+This implementation creates:
 
 - `docs/source-reviews/20260524-official-note-linkage-source-review.md`
 - `data/source-reviews/20260524-official-note-linkage-source-review-summary.json`
@@ -127,7 +128,7 @@ source dumps or private/local evidence.
 
 ### Public Markdown Summary
 
-The Markdown summary should include:
+The Markdown summary includes:
 
 - run id and source-review summary version;
 - input coverage and disposition artifact paths;
@@ -143,7 +144,7 @@ The Markdown summary should include:
 
 ### Public JSON Summary
 
-The JSON summary should use a small deterministic structure such as:
+The JSON summary uses a small deterministic structure:
 
 ```json
 {
@@ -290,25 +291,24 @@ gap rather than guessing.
 
 ## Source-Review Procedure
 
-A later source-review implementation should:
+This implementation:
 
-1. Inventory the current ignored reviewer artifacts without committing them.
-2. For each target review item, locate representative official rows and cells.
-3. Confirm `source_column_header_path` and cell boundary for each targeted
+1. Inventoried the current ignored reviewer artifacts without committing them.
+2. Located representative official rows and cells for each target review item.
+3. Confirmed `source_column_header_path` and cell boundary for each targeted
    example, especially `damage` examples such as `※500`.
-4. Record row or move identity using public summary-safe identifiers only.
-5. Extract marker role and marker placement from the value cell.
-6. Link marker/id to source note text when deterministic evidence exists.
-7. Record note scope and note review status.
-8. For active cells, compare separated `visible_text` and
+4. Recorded row or move identity using public summary-safe identifiers only.
+5. Extracted marker role and marker placement from the value cell.
+6. Linked marker/id to source note text when deterministic evidence exists.
+7. Recorded note scope and note review status.
+8. Compared separated `visible_text` and
    `hidden_detail_text` against concatenated `source_text_stripped`.
-9. Mark each group as later parser-eligible, blocked pending source review,
-   or blocked pending acquisition-field support.
-10. Emit public Markdown and JSON summaries only.
+9. Marked every note-bearing group blocked pending acquisition-field support
+   because row note text is not structured in the table-row artifact.
+10. Emitted public Markdown and JSON summaries only.
 
-No live official page checks should be run unless a later source-review
-implementation ExecPlan explicitly approves them as reviewer/update-mode
-steps.
+No live official page checks were run. Later live checks require a separate
+reviewer/update-mode ExecPlan.
 
 ## Required Review Decisions
 
@@ -375,20 +375,19 @@ Ignored `.local/` artifacts may be used as reviewer input, but they must remain
 uncommitted. The public summary should describe evidence status without
 leaking local artifact paths or full private/local dumps.
 
-## Future Implementation Files
+## Implementation Files
 
-A later source-review implementation ExecPlan may touch:
+This source-review implementation touches:
 
 - `docs/source-reviews/20260524-official-note-linkage-source-review.md`
 - `data/source-reviews/20260524-official-note-linkage-source-review-summary.json`
-- a focused validator for the source-review summary, only if the validator is
-  grounded in this ExecPlan, the coverage artifact, and synthetic contract
-  fixtures.
+- `tests/validation/validate_official_note_linkage_source_review.py`
+- `data/validator-audits/20260523-validator-test-fact-source-audit.json`
+- `docs/validator-audits/20260523-validator-test-fact-source-audit.md`
 
-That later implementation must not touch parser, schema, classifier,
-calculator, retrieval, answer, export, runtime, generated coverage artifacts,
-or live acquisition unless a separate approved ExecPlan explicitly expands the
-scope.
+This implementation does not touch parser, schema, classifier, calculator,
+retrieval, answer, export, runtime, generated coverage artifacts, or live
+acquisition.
 
 ## Acceptance Criteria
 
@@ -404,14 +403,21 @@ scope.
 - The ExecPlan keeps ignored `.local/` artifacts as reviewer input only.
 - The ExecPlan does not implement parser/schema/classifier/calculator/
   retrieval/answer/export/runtime changes.
-- The ExecPlan does not modify validators or generated coverage artifacts.
+- The source-review validator checks only the public summary boundary and is
+  grounded in this ExecPlan and parsed-value coverage.
+- The implementation does not modify generated coverage artifacts.
 - Validation commands pass.
 
 ## Files / Interfaces
 
-This docs-only planning unit changes only:
+This source-review implementation changes only:
 
 - `docs/execplans/2026-05-24-official-note-linkage-source-review.md`
+- `docs/source-reviews/20260524-official-note-linkage-source-review.md`
+- `data/source-reviews/20260524-official-note-linkage-source-review-summary.json`
+- `tests/validation/validate_official_note_linkage_source_review.py`
+- `data/validator-audits/20260523-validator-test-fact-source-audit.json`
+- `docs/validator-audits/20260523-validator-test-fact-source-audit.md`
 
 ## Validation Commands
 
@@ -421,6 +427,8 @@ Run from repository root:
 git diff --check
 PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
 PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
+PYTHONPATH=src uv run --locked python tests/validation/validate_official_note_linkage_source_review.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_validator_test_audit.py
 git status --short --branch
 ```
 
@@ -432,15 +440,27 @@ git status --short --branch
   `eeeba999382f632cf11396c4ea47a516924f21bb` before branching.
 - [x] (2026-05-24 JST) Identified the `9` remaining official
   `review_required` groups from parsed-value classifier coverage.
-- [x] (2026-05-24 JST) Drafted this docs-only ExecPlan.
+- [x] (2026-05-24 JST) Drafted the docs-only ExecPlan.
 - [x] (2026-05-24 JST) Validation passed:
   `git diff --check`,
   `PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py`,
   `PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate`,
   and `git status --short --branch`. New-file whitespace check also produced
   no whitespace error output.
-- [ ] Complete mandatory review before any source-review artifact
-  implementation.
+- [x] (2026-05-24 JST) PR #336 merged, approving this source-review plan.
+- [x] (2026-05-24 JST) Created implementation branch
+  `impl/official-note-linkage-source-review`.
+- [x] (2026-05-24 JST) Reviewed ignored official artifacts. Structured
+  table-row artifacts expose source-native column paths, raw cell text,
+  visible text, hidden detail text, and row identity. Row-local note text is
+  visible in ignored official HTML captures but is not structured in the
+  table-row artifact.
+- [x] (2026-05-24 JST) Added public source-review Markdown and JSON summary
+  artifacts.
+- [x] (2026-05-24 JST) Added a focused source-review summary validator.
+- [x] (2026-05-24 JST) Updated the validator/test evidence audit for the new
+  validator.
+- [ ] Complete mandatory review before staging.
 
 ## Decision Log
 
@@ -464,8 +484,29 @@ git status --short --branch
   Date/Author: 2026-05-24 / Codex
 
 - Decision: Do not run live official page acquisition in this plan.
-  Rationale: The user requested a docs-only planner. Any live checks belong in
-  a later reviewer/update-mode source-review implementation plan.
+  Rationale: Any live checks belong in a separate reviewer/update-mode
+  source-review plan.
+  Date/Author: 2026-05-24 / Codex
+
+- Decision: Keep all note-bearing groups blocked pending acquisition-field
+  support.
+  Rationale: Reviewer evidence found row-local notes in ignored official HTML
+  captures, but the structured table-row artifact does not expose row note
+  text. A parser should not depend on ad hoc HTML review or group-level note
+  assumptions.
+  Date/Author: 2026-05-24 / Codex
+
+- Decision: Treat the active dot/double-hyphen group as source-confirmed but
+  not a note-linkage target.
+  Rationale: The values are official active cells, but this source review does
+  not establish dot or double-hyphen grammar or calculation meaning.
+  Date/Author: 2026-05-24 / Codex
+
+- Decision: Update the validator/test evidence audit for the new source-review
+  validator.
+  Rationale: Repository policy requires every test and validator to declare
+  its evidence basis. The new validator is source-derived but proves only
+  public summary consistency and boundary rules, not parser correctness.
   Date/Author: 2026-05-24 / Codex
 
 ## Deviations
@@ -474,8 +515,9 @@ git status --short --branch
 
 ## Risks
 
-- Current ignored reviewer artifacts may not expose official note text or
-  row/cell linkage fields needed for deterministic review.
+- Current structured table-row artifacts do not expose official row-local note
+  text, so note-bearing parser work remains blocked pending acquisition-field
+  support.
 - `*` can have multiple roles; treating it as a note marker without source
   location evidence would be unsafe.
 - Active cells may require acquisition improvements if only concatenated text
@@ -490,33 +532,43 @@ git status --short --branch
 
 | PLAN item | Implementation | Changed files | Validation command | Result | Deviation | Incomplete | Risk |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Official note-linkage source-review plan | Drafted docs-only plan for source-review artifact boundaries and marker linkage decisions | `docs/execplans/2026-05-24-official-note-linkage-source-review.md` | `git diff --check`; clean-slate validator; parsed-value classifier validator; `git status --short --branch` | Passed | None | Review pending | Future source-review artifacts and validators still need separate implementation |
-| Scope exclusions | No parser/schema/classifier/calculator/retrieval/answer/export/runtime/validator/artifact changes added | This ExecPlan only | Diff/status review | Passed | None | Future implementation ExecPlan required | Note-bearing values remain blocked |
+| Official note-linkage source-review artifacts | Added public Markdown and JSON summaries for the 9 remaining official note-bearing or note-adjacent groups | Source-review Markdown and JSON summary | Source-review validator | Pending | None | Review pending | Note-bearing values remain blocked pending acquisition-field support |
+| Source-review validator | Added focused validator grounded in this ExecPlan and coverage artifact | `tests/validation/validate_official_note_linkage_source_review.py` | Source-review validator | Pending | None | Review pending | Validator checks boundary and consistency, not parser correctness |
+| Validator audit | Added evidence-basis audit entry for the new validator | Validator audit JSON/Markdown | `validate_validator_test_audit.py` | Pending | None | Review pending | Audit remains accepted-with-limits |
+| Scope exclusions | No parser/schema/classifier/calculator/retrieval/answer/export/runtime/generated coverage/live acquisition changes added | Scoped files only | Diff/status review | Pending | None | Review pending | Note-bearing values remain blocked |
 
 ## Next Reviewer Prompt
 
 ```text
-Review docs/execplans/2026-05-24-official-note-linkage-source-review.md.
-
-Confirm whether it is acceptable as the docs-only planner for official
-note-linkage source review before any note-bearing parser/schema implementation.
+Review the official note-linkage source-review implementation.
 
 Check:
-- it covers exactly the remaining official review_required note-bearing or
-  note-adjacent groups after the signed range parser slice;
-- it plans only source-review artifacts and does not implement parser/schema/
-  classifier/calculator/retrieval/answer/export/runtime changes;
-- it does not modify validators or generated coverage artifacts;
-- it keeps ignored .local artifacts as reviewer input only;
-- it defines how to link note_marker, note_id, note_text, note_scope,
-  source_column_header_path, row/move identity, and raw value;
-- it distinguishes note marker on value, cancel marker, bracketed note id,
-  standalone marker, visible/hidden detail concatenation, and actual source
-  note text;
-- it keeps full raw rows, raw HTML, screenshots, cookies, browser profiles,
-  traces, debug dumps, local paths, and private data out of Git;
-- it does not authorize parser output, current-fact authority promotion,
-  calculator work, SymPy, SuperCombo authority, or live acquisition.
+- changed files are limited to the ExecPlan, public source-review Markdown,
+  public source-review JSON, focused source-review validator, and
+  validator/test evidence audit entries;
+- the JSON covers exactly the 9 remaining official review_required records
+  after the signed range parser slice;
+- note-bearing records remain blocked pending acquisition-field support;
+- the active dot/double-hyphen group is source-confirmed but not treated as a
+  note-linkage target;
+- no parser/schema/classifier/calculator/retrieval/answer/export/runtime,
+  generated coverage artifact, live acquisition, or SymPy behavior was added;
+- public artifacts include summaries only and no full source rows, raw HTML,
+  browser images, cookies, profiles, traces, debug dumps, local paths, answer
+  logs, training logs, or private data;
+- official remains authority candidate only and no value becomes
+  calculation-safe.
 
-Return blocking findings first, then PLAN deviations and remaining risks.
+Run:
+- `git diff --check`
+- `git diff --cached --check`
+- `PYTHONPATH=src uv run --locked python -m unittest discover -s tests`
+- `PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py`
+- `PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate`
+- `PYTHONPATH=src uv run --locked python tests/validation/validate_official_note_linkage_source_review.py`
+- `PYTHONPATH=src uv run --locked python tests/validation/validate_validator_test_audit.py`
+- `git status --short --branch`
+
+Return blocking findings first, then validation results, PLAN deviations,
+remaining risks, and whether this is stage-ready.
 ```

--- a/docs/source-reviews/20260524-official-note-linkage-source-review.md
+++ b/docs/source-reviews/20260524-official-note-linkage-source-review.md
@@ -1,0 +1,48 @@
+# Official Note Linkage Source Review
+
+This is a source-review summary only. It does not implement parser, schema,
+classifier, calculator, retrieval, answer behavior, export behavior, or
+numeric authority.
+
+- Run ID: `20260524`
+- Input coverage:
+  `data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json`
+- Input disposition:
+  `data/value-shape-dispositions/20260521T025403Z-value-shape-review-item-disposition-summary.json`
+- Review records: `9`
+
+## Source Evidence Summary
+
+The current structured official table-row artifacts preserve source-native
+column paths, raw cell text, visible text, hidden detail text, and row
+identity. They do not expose row-local note text as structured fields.
+
+Reviewer inspection of the ignored official HTML captures found row-local note
+evidence for the note-bearing groups. Because those notes are not present as
+structured table-row fields, every note-bearing group remains blocked pending
+acquisition-field support before parser work.
+
+No live acquisition was run for this source review.
+
+## Decisions
+
+| Review item | Field | Source header path | Affected | Result | Later parser eligibility | Notes |
+| --- | --- | --- | ---: | --- | --- | --- |
+| `value-shape:official--source_specific_expression--sa` | `sa_gain` | `SAゲージ増加` | 8 | `source_evidence_found_acquisition_field_gap` | `blocked_pending_acquisition_fields` | Marker links to row-local medal-level SA gauge conditions in reviewer evidence, but row notes are not structured in the table-row artifact. |
+| `value-shape:official--source_specific_expression--u_55d872f6091a` | `combo_scaling` | `コンボ補正値` | 55 | `source_evidence_found_acquisition_field_gap` | `blocked_pending_acquisition_fields` | Row-local scaling notes vary by move; parser work needs per-row notes, not group-level assumptions. |
+| `value-shape:official--source_specific_expression--u_202a059d9b1b` | `damage` | `ダメージ` | 36 | `source_evidence_found_acquisition_field_gap` | `blocked_pending_acquisition_fields` | `※` damage examples are confirmed inside the source-native damage column, not adjacent cancel cells. Row notes still need structured extraction. |
+| `value-shape:official--malformed_looking_source_value--u_fdb49a2113ba--u_c2b75204faf1` | `active` | `動作フレーム > 持続` | 3 | `source_confirmed_non_note_grammar_blocked` | `not_note_linkage_target` | Dot and double-hyphen active values are source-confirmed active cells, but this review does not resolve their grammar or calculation meaning. |
+| `value-shape:official--source_specific_expression--u_fdb49a2113ba--u_c2b75204faf1` | `active` | `動作フレーム > 持続` | 44 | `source_evidence_found_acquisition_field_gap` | `blocked_pending_acquisition_fields` | Active cells mix standalone markers, bracketed note ids, component markers, and hidden-detail text. Future parsing must use separated visible and hidden fields. |
+| `value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100` | `startup` | `動作フレーム > 発生` | 6 | `source_evidence_found_acquisition_field_gap` | `blocked_pending_acquisition_fields` | Suffix markers are row-local conditional startup values. |
+| `value-shape:official--source_specific_expression--u_fdb49a2113ba--u_4b3674d32cef` | `recovery` | `動作フレーム > 硬直` | 28 | `source_evidence_found_acquisition_field_gap` | `blocked_pending_acquisition_fields` | `全体` values must not be treated as ordinary recovery frames. |
+| `value-shape:official--source_specific_expression--u_c135db53355f--u_522ba9f47afb` | `block_advantage` | `硬直差 > ガード` | 6 | `source_evidence_found_acquisition_field_gap` | `blocked_pending_acquisition_fields` | Block advantage markers are row-local conditions; embedded alternate forms require a separate parser rule. |
+| `value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69` | `hit_advantage` | `硬直差 > ヒット` | 4 | `source_evidence_found_acquisition_field_gap` | `blocked_pending_acquisition_fields` | Hit advantage markers are row-local conditions; positive values remain column-context dependent. |
+
+## Boundary Notes
+
+- Official remains authority candidate only.
+- No current-fact authority is added.
+- No parser output or calculation-safe value is emitted.
+- No full source rows, raw source dumps, browser images, local paths, cookies,
+  browser profiles, traces, debug dumps, answer logs, training logs, or
+  private data are included.

--- a/docs/validator-audits/20260523-validator-test-fact-source-audit.md
+++ b/docs/validator-audits/20260523-validator-test-fact-source-audit.md
@@ -22,6 +22,7 @@ privacy/security boundary.
 | `tests/test_value_shape_inventory.py` | source-derived | accepted with limits | representative shape checks are not parser semantics |
 | `tests/validation/validate_clean_slate.py` | governance boundary | accepted with limits | repo shape only |
 | `tests/validation/validate_current_fact_schemas.py` | synthetic contract | accepted with limits | schema and fixture contracts only; no parser/source truth |
+| `tests/validation/validate_official_note_linkage_source_review.py` | source-derived | accepted with limits | source-review summary; full row-note context remains ignored local evidence |
 | `tests/validation/validate_parsed_value_classifier.py` | artifact consistency | accepted with limits | coverage artifact, mechanics anchors, and schema-compatible samples only |
 | `tests/validation/validate_validator_test_audit.py` | governance boundary | accepted with limits | audit coverage and evidence metadata only |
 | `tests/validation/validate_supercombo_field_mapping.py` | policy-derived | accepted with limits | delegates to mapping artifact validation |

--- a/tests/validation/validate_official_note_linkage_source_review.py
+++ b/tests/validation/validate_official_note_linkage_source_review.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+import re
+import sys
+from hashlib import sha256
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+JSON_PATH = ROOT / "data/source-reviews/20260524-official-note-linkage-source-review-summary.json"
+MD_PATH = ROOT / "docs/source-reviews/20260524-official-note-linkage-source-review.md"
+COVERAGE_PATH = ROOT / "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+
+ALLOWED_RESULTS = {
+    "source_evidence_found_acquisition_field_gap",
+    "source_confirmed_non_note_grammar_blocked",
+}
+ALLOWED_ELIGIBILITY = {
+    "blocked_pending_acquisition_fields",
+    "not_note_linkage_target",
+}
+FORBIDDEN_PATTERNS = [
+    re.compile(r"(?i)(?:^|[\s\"'`])(?:/(?:home|mnt|Users)/[^\s\"'`]+)"),
+    re.compile(r"(?i)(?:^|[\s\"'`(])[A-Z]:[\\/]"),
+    re.compile(r"(?i)\b(?:cookie|authorization|bearer|token|password|secret)\b"),
+    re.compile(r"(?i)<html|</html|<!doctype|<table|</table|<tr|</tr|<td|</td|<th|</th"),
+]
+FORBIDDEN_LITERALS = {
+    ".agents/",
+    ".local/",
+    ".venv/",
+    "/tmp",
+    "__NEXT_DATA__.json",
+    "official_table_rows.raw.json",
+    "page.html",
+}
+
+
+def main() -> int:
+    errors: list[str] = []
+    if not JSON_PATH.exists():
+        errors.append(f"Missing {JSON_PATH.relative_to(ROOT)}")
+    if not MD_PATH.exists():
+        errors.append(f"Missing {MD_PATH.relative_to(ROOT)}")
+    if not COVERAGE_PATH.exists():
+        errors.append(f"Missing {COVERAGE_PATH.relative_to(ROOT)}")
+    if errors:
+        return _finish(errors)
+
+    payload = json.loads(JSON_PATH.read_text(encoding="utf-8"))
+    coverage = json.loads(COVERAGE_PATH.read_text(encoding="utf-8"))
+    expected_ids = {
+        record["review_item_id"]
+        for record in coverage["coverage_records"]
+        if record.get("source_name") == "official" and record.get("classifier_decision") == "review_required"
+    }
+
+    if payload.get("artifact_schema_version") != "official_note_linkage_source_review_summary/v1":
+        errors.append("unexpected artifact_schema_version")
+    if payload.get("run_id") != "20260524":
+        errors.append("unexpected run_id")
+    if payload.get("artifact_boundary") != "source_review_summary_only":
+        errors.append("artifact_boundary must be source_review_summary_only")
+    if payload.get("authority_status") != "review_decision_only_not_authority":
+        errors.append("authority_status must be review_decision_only_not_authority")
+    if payload.get("total_review_records") != 9 or payload.get("review_counts", {}).get("total_review_records") != 9:
+        errors.append("official note-linkage source review must contain exactly 9 records")
+
+    records = payload.get("review_records", [])
+    actual_ids = {record.get("review_item_id") for record in records}
+    if actual_ids != expected_ids:
+        errors.append("review_records do not match official review_required coverage records")
+
+    for index, record in enumerate(records):
+        _validate_record(index, record, errors)
+
+    for record in records:
+        if record.get("review_item_id", "").startswith("value-shape:official--malformed_looking_source_value"):
+            if record.get("later_parser_eligibility") != "not_note_linkage_target":
+                errors.append("malformed active group must remain not_note_linkage_target")
+        elif record.get("later_parser_eligibility") != "blocked_pending_acquisition_fields":
+            errors.append(f"{record.get('review_item_id')} must remain blocked_pending_acquisition_fields")
+
+    for path in (JSON_PATH, MD_PATH):
+        text = path.read_text(encoding="utf-8")
+        for pattern in FORBIDDEN_PATTERNS:
+            if pattern.search(text):
+                errors.append(f"{path.relative_to(ROOT)} contains forbidden public content")
+                break
+        for literal in FORBIDDEN_LITERALS:
+            if literal in text:
+                errors.append(f"{path.relative_to(ROOT)} contains forbidden literal: {literal}")
+
+    return _finish(errors)
+
+
+def _validate_record(index: int, record: dict[str, object], errors: list[str]) -> None:
+    required = {
+        "affected_count",
+        "cell_boundary_status",
+        "later_parser_eligibility",
+        "marker_roles",
+        "note_review_status",
+        "note_scope",
+        "note_text_status",
+        "proposed_field_key",
+        "representative_examples",
+        "required_source_fields_checked",
+        "review_item_id",
+        "row_identity_status",
+        "semantic_source_family",
+        "source_header_path",
+        "source_name",
+        "source_review_id",
+        "source_review_result",
+        "source_role",
+        "visible_hidden_detail_status",
+    }
+    missing = sorted(required - set(record))
+    if missing:
+        errors.append(f"review_records[{index}] missing keys: {', '.join(missing)}")
+    if record.get("source_name") != "official":
+        errors.append(f"review_records[{index}] source_name must be official")
+    if record.get("source_role") != "authority_candidate":
+        errors.append(f"review_records[{index}] source_role must remain authority_candidate")
+    if record.get("source_review_result") not in ALLOWED_RESULTS:
+        errors.append(f"review_records[{index}] has invalid source_review_result")
+    if record.get("later_parser_eligibility") not in ALLOWED_ELIGIBILITY:
+        errors.append(f"review_records[{index}] has invalid later_parser_eligibility")
+    if "parsed_value" in record or "current_fact_authority" in json.dumps(record, ensure_ascii=False):
+        errors.append(f"review_records[{index}] must not include parsed values or authority promotion")
+
+    examples = record.get("representative_examples")
+    if not isinstance(examples, list) or not examples or len(examples) > 3:
+        errors.append(f"review_records[{index}] must include 1-3 representative examples")
+        return
+    for example_index, example in enumerate(examples):
+        if not isinstance(example, dict):
+            errors.append(f"review_records[{index}].representative_examples[{example_index}] must be an object")
+            continue
+        raw_value = example.get("raw_value")
+        raw_length = example.get("raw_value_length")
+        raw_hash = example.get("raw_value_sha256")
+        if not isinstance(raw_value, str) or len(raw_value) > 80:
+            errors.append(f"review_records[{index}].representative_examples[{example_index}] has invalid raw_value")
+            continue
+        if raw_length != len(raw_value):
+            errors.append(f"review_records[{index}].representative_examples[{example_index}] has invalid length")
+        expected_hash = "sha256:" + sha256(raw_value.encode("utf-8")).hexdigest()
+        if raw_hash != expected_hash:
+            errors.append(f"review_records[{index}].representative_examples[{example_index}] has invalid hash")
+
+
+def _finish(errors: list[str]) -> int:
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("Official note-linkage source review validation OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add official note-linkage source-review Markdown and JSON summary artifacts
- add a focused validator for the source-review summary
- record the new validator in the validator/test evidence audit

## Validation
- git diff --check
- git diff --cached --check
- uv lock --check
- PYTHONPATH=src uv run --locked python -m unittest discover -s tests
- PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
- PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
- PYTHONPATH=src uv run --locked python tests/validation/validate_official_note_linkage_source_review.py
- PYTHONPATH=src uv run --locked python tests/validation/validate_validator_test_audit.py
- all tests/validation/validate_*.py

## Boundaries
- no parser/schema/classifier/calculator/retrieval/answer/export/runtime changes
- no live acquisition or SymPy work
- official remains authority candidate only; no value becomes calculation-safe
