### PR TITLE
Update official note-linkage source review from v4 evidence

### DIFF
--- a/data/source-reviews/20260524-official-note-linkage-source-review-summary.json
+++ b/data/source-reviews/20260524-official-note-linkage-source-review-summary.json
@@ -5,27 +5,29 @@
   "input_coverage": "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
   "input_disposition": "data/value-shape-dispositions/20260521T025403Z-value-shape-review-item-disposition-summary.json",
   "review_counts": {
-    "blocked_pending_acquisition_fields": 8,
+    "blocked_pending_source_review": 4,
+    "later_annotated_parser_eligible": 4,
     "not_note_linkage_target": 1,
     "source_confirmed_non_note_grammar_blocked": 1,
-    "source_evidence_found_acquisition_field_gap": 8,
+    "structured_row_note_evidence_ambiguous": 4,
+    "structured_row_note_evidence_found": 4,
     "total_review_records": 9
   },
   "review_records": [
     {
-      "acquisition_field_gap": "row_note_text_not_structured_in_table_row_artifact",
+      "acquisition_field_gap": "resolved_by_v4_row_note_fields",
       "affected_count": 8,
       "cell_boundary_status": "confirmed_source_column",
-      "later_parser_eligibility": "blocked_pending_acquisition_fields",
+      "later_parser_eligibility": "blocked_pending_source_review",
       "marker_roles": [
         "note_marker_on_value"
       ],
       "note_id": null,
       "note_marker": "※",
-      "note_review_status": "linked_in_reviewer_evidence",
+      "note_review_status": "structured_multiple_candidates_ambiguous",
       "note_scope": "row_source_column_condition",
       "note_text_excerpt": "SAゲージ増加量が上昇",
-      "note_text_status": "row_note_evidence_found",
+      "note_text_status": "structured_row_note_text_found_ambiguous",
       "proposed_field_key": "sa_gain",
       "representative_examples": [
         {
@@ -45,10 +47,17 @@
         "visible_text",
         "hidden_detail_text",
         "row_identity",
-        "row_note_list_from_ignored_html_capture"
+        "official_table_rows_raw/v4",
+        "row_note_count",
+        "row_notes",
+        "row_note_extraction_status",
+        "cell_note_markers",
+        "cell_note_ids",
+        "row_note_reference_candidates",
+        "note_linkage_status"
       ],
       "review_item_id": "value-shape:official--source_specific_expression--sa",
-      "reviewer_notes": "Reviewer evidence links the marker to row-local medal-level SA gauge conditions, but the structured table-row artifact does not expose row notes.",
+      "reviewer_notes": "v4 row_notes expose row-local text, but representative SA cells have multiple same-row ※ candidates, including damage and SA-gauge notes. This remains blocked until marker-to-field linkage is reviewed beyond marker presence.",
       "row_identity_status": "confirmed_public_character_move_reference",
       "semantic_source_family": "gauge",
       "source_header_path": [
@@ -56,15 +65,29 @@
       ],
       "source_name": "official",
       "source_review_id": "source-review:official-note-linkage-sa-gain",
-      "source_review_result": "source_evidence_found_acquisition_field_gap",
+      "source_review_result": "structured_row_note_evidence_ambiguous",
       "source_role": "authority_candidate",
+      "v4_representative_evidence": {
+        "cell_note_ids_present": false,
+        "cell_note_markers_present": true,
+        "note_linkage_status_counts": {
+          "ambiguous_marker_without_id": 8
+        },
+        "representative_match_count": 8,
+        "row_note_reference_candidate_count_range": [
+          2,
+          4
+        ],
+        "row_note_text_structured": true,
+        "visible_hidden_detail_evidence": "visible_text_only"
+      },
       "visible_hidden_detail_status": "not_applicable_or_empty"
     },
     {
-      "acquisition_field_gap": "row_note_text_not_structured_in_table_row_artifact",
+      "acquisition_field_gap": "resolved_by_v4_row_note_fields",
       "affected_count": 55,
       "cell_boundary_status": "confirmed_source_column",
-      "later_parser_eligibility": "blocked_pending_acquisition_fields",
+      "later_parser_eligibility": "blocked_pending_source_review",
       "marker_roles": [
         "note_marker_on_value",
         "standalone_marker",
@@ -72,10 +95,10 @@
       ],
       "note_id": null,
       "note_marker": "※",
-      "note_review_status": "mixed_linked_in_reviewer_evidence",
+      "note_review_status": "structured_mixed_candidate_statuses",
       "note_scope": "row_scaling_condition",
       "note_text_excerpt": "必殺技キャンセル時のみ適用",
-      "note_text_status": "mixed_row_note_evidence_found",
+      "note_text_status": "structured_row_note_text_found_mixed",
       "proposed_field_key": "combo_scaling",
       "representative_examples": [
         {
@@ -95,10 +118,17 @@
         "visible_text",
         "hidden_detail_text",
         "row_identity",
-        "row_note_list_from_ignored_html_capture"
+        "official_table_rows_raw/v4",
+        "row_note_count",
+        "row_notes",
+        "row_note_extraction_status",
+        "cell_note_markers",
+        "cell_note_ids",
+        "row_note_reference_candidates",
+        "note_linkage_status"
       ],
       "review_item_id": "value-shape:official--source_specific_expression--u_55d872f6091a",
-      "reviewer_notes": "Reviewer evidence shows row-local scaling notes, but the notes vary by move and must be captured per row before any scaling parser is safe.",
+      "reviewer_notes": "v4 row_notes expose row-local scaling notes for representative values. Most have a single candidate, but some representative rows still have multiple same-row ※ candidates, so the group remains blocked pending source review.",
       "row_identity_status": "confirmed_public_character_move_reference",
       "semantic_source_family": "scaling",
       "source_header_path": [
@@ -106,24 +136,39 @@
       ],
       "source_name": "official",
       "source_review_id": "source-review:official-note-linkage-combo-scaling",
-      "source_review_result": "source_evidence_found_acquisition_field_gap",
+      "source_review_result": "structured_row_note_evidence_ambiguous",
       "source_role": "authority_candidate",
+      "v4_representative_evidence": {
+        "cell_note_ids_present": false,
+        "cell_note_markers_present": true,
+        "note_linkage_status_counts": {
+          "ambiguous_marker_without_id": 2,
+          "same_row_note_candidates_available": 33
+        },
+        "representative_match_count": 35,
+        "row_note_reference_candidate_count_range": [
+          1,
+          2
+        ],
+        "row_note_text_structured": true,
+        "visible_hidden_detail_evidence": "visible_text_only"
+      },
       "visible_hidden_detail_status": "not_applicable_or_empty"
     },
     {
-      "acquisition_field_gap": "row_note_text_not_structured_in_table_row_artifact",
+      "acquisition_field_gap": "resolved_by_v4_row_note_fields",
       "affected_count": 36,
       "cell_boundary_status": "confirmed_source_column",
-      "later_parser_eligibility": "blocked_pending_acquisition_fields",
+      "later_parser_eligibility": "blocked_pending_source_review",
       "marker_roles": [
         "note_marker_on_value"
       ],
       "note_id": null,
       "note_marker": "※",
-      "note_review_status": "mixed_linked_in_reviewer_evidence",
+      "note_review_status": "structured_mixed_candidate_statuses",
       "note_scope": "row_damage_condition",
       "note_text_excerpt": "毒破裂時ダメージ",
-      "note_text_status": "mixed_row_note_evidence_found",
+      "note_text_status": "structured_row_note_text_found_mixed",
       "proposed_field_key": "damage",
       "representative_examples": [
         {
@@ -143,10 +188,17 @@
         "visible_text",
         "hidden_detail_text",
         "row_identity",
-        "row_note_list_from_ignored_html_capture"
+        "official_table_rows_raw/v4",
+        "row_note_count",
+        "row_notes",
+        "row_note_extraction_status",
+        "cell_note_markers",
+        "cell_note_ids",
+        "row_note_reference_candidates",
+        "note_linkage_status"
       ],
       "review_item_id": "value-shape:official--source_specific_expression--u_202a059d9b1b",
-      "reviewer_notes": "Damage examples are confirmed inside the source-native damage column, not caused by adjacent cancel cells. Row notes still need structured acquisition before parsing.",
+      "reviewer_notes": "v4 row_notes confirm source-native damage column boundaries and row-local note text for representative damage values, but at least one representative row has multiple same-row ※ candidates. Damage remains blocked pending source review.",
       "row_identity_status": "confirmed_public_character_move_reference",
       "semantic_source_family": "damage",
       "source_header_path": [
@@ -154,8 +206,23 @@
       ],
       "source_name": "official",
       "source_review_id": "source-review:official-note-linkage-damage",
-      "source_review_result": "source_evidence_found_acquisition_field_gap",
+      "source_review_result": "structured_row_note_evidence_ambiguous",
       "source_role": "authority_candidate",
+      "v4_representative_evidence": {
+        "cell_note_ids_present": false,
+        "cell_note_markers_present": true,
+        "note_linkage_status_counts": {
+          "ambiguous_marker_without_id": 1,
+          "same_row_note_candidates_available": 4
+        },
+        "representative_match_count": 5,
+        "row_note_reference_candidate_count_range": [
+          1,
+          2
+        ],
+        "row_note_text_structured": true,
+        "visible_hidden_detail_evidence": "visible_text_only"
+      },
       "visible_hidden_detail_status": "not_applicable_or_empty"
     },
     {
@@ -191,10 +258,17 @@
         "visible_text",
         "hidden_detail_text",
         "row_identity",
-        "row_note_list_from_ignored_html_capture"
+        "official_table_rows_raw/v4",
+        "row_note_count",
+        "row_notes",
+        "row_note_extraction_status",
+        "cell_note_markers",
+        "cell_note_ids",
+        "row_note_reference_candidates",
+        "note_linkage_status"
       ],
       "review_item_id": "value-shape:official--malformed_looking_source_value--u_fdb49a2113ba--u_c2b75204faf1",
-      "reviewer_notes": "Dot and double-hyphen active strings are source-confirmed active cells, but this source review does not resolve their grammar or calculation meaning.",
+      "reviewer_notes": "v4 evidence confirms these representative active values are source-native active cells with no cell note markers. Dot and double-hyphen active grammar remains a non-note blocker outside this review.",
       "row_identity_status": "confirmed_public_character_move_reference",
       "semantic_source_family": "timing",
       "source_header_path": [
@@ -205,13 +279,27 @@
       "source_review_id": "source-review:official-active-non-note-grammar",
       "source_review_result": "source_confirmed_non_note_grammar_blocked",
       "source_role": "authority_candidate",
+      "v4_representative_evidence": {
+        "cell_note_ids_present": false,
+        "cell_note_markers_present": false,
+        "note_linkage_status_counts": {
+          "no_cell_note_markers": 2
+        },
+        "representative_match_count": 2,
+        "row_note_reference_candidate_count_range": [
+          0,
+          0
+        ],
+        "row_note_text_structured": true,
+        "visible_hidden_detail_evidence": "visible_text_only"
+      },
       "visible_hidden_detail_status": "visible_text_preserved"
     },
     {
-      "acquisition_field_gap": "row_note_text_not_structured_in_table_row_artifact",
+      "acquisition_field_gap": "resolved_by_v4_row_note_fields",
       "affected_count": 44,
       "cell_boundary_status": "confirmed_source_column_with_hidden_detail",
-      "later_parser_eligibility": "blocked_pending_acquisition_fields",
+      "later_parser_eligibility": "blocked_pending_source_review",
       "marker_roles": [
         "standalone_marker",
         "bracketed_note_id",
@@ -220,10 +308,10 @@
       ],
       "note_id": "mixed",
       "note_marker": "※",
-      "note_review_status": "mixed_linked_in_reviewer_evidence",
+      "note_review_status": "structured_mixed_candidate_statuses",
       "note_scope": "row_active_component",
       "note_text_excerpt": "ボタンホールドでパリィの持続を延長可",
-      "note_text_status": "mixed_row_note_evidence_found",
+      "note_text_status": "structured_row_note_text_found_mixed",
       "proposed_field_key": "active",
       "representative_examples": [
         {
@@ -248,10 +336,17 @@
         "visible_text",
         "hidden_detail_text",
         "row_identity",
-        "row_note_list_from_ignored_html_capture"
+        "official_table_rows_raw/v4",
+        "row_note_count",
+        "row_notes",
+        "row_note_extraction_status",
+        "cell_note_markers",
+        "cell_note_ids",
+        "row_note_reference_candidates",
+        "note_linkage_status"
       ],
       "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_c2b75204faf1",
-      "reviewer_notes": "Active cells mix standalone markers, bracketed note ids, and hidden-detail concatenation. Future parser must consume separated visible and hidden fields, not only concatenated source text.",
+      "reviewer_notes": "v4 row_notes expose row-local active notes and preserve visible/hidden detail separation. The group still mixes standalone markers, bracketed note ids, and visible/hidden concatenation, with ambiguous representative rows, so it remains blocked pending source review.",
       "row_identity_status": "confirmed_public_character_move_reference",
       "semantic_source_family": "timing",
       "source_header_path": [
@@ -260,24 +355,39 @@
       ],
       "source_name": "official",
       "source_review_id": "source-review:official-note-linkage-active",
-      "source_review_result": "source_evidence_found_acquisition_field_gap",
+      "source_review_result": "structured_row_note_evidence_ambiguous",
       "source_role": "authority_candidate",
+      "v4_representative_evidence": {
+        "cell_note_ids_present": true,
+        "cell_note_markers_present": true,
+        "note_linkage_status_counts": {
+          "ambiguous_marker_without_id": 2,
+          "same_row_note_candidates_available": 30
+        },
+        "representative_match_count": 32,
+        "row_note_reference_candidate_count_range": [
+          1,
+          3
+        ],
+        "row_note_text_structured": true,
+        "visible_hidden_detail_evidence": "separated_visible_and_hidden_detail_present"
+      },
       "visible_hidden_detail_status": "separated_fields_available_with_concatenated_source_text"
     },
     {
-      "acquisition_field_gap": "row_note_text_not_structured_in_table_row_artifact",
+      "acquisition_field_gap": "resolved_by_v4_row_note_fields",
       "affected_count": 6,
       "cell_boundary_status": "confirmed_source_column",
-      "later_parser_eligibility": "blocked_pending_acquisition_fields",
+      "later_parser_eligibility": "later_annotated_parser_eligible",
       "marker_roles": [
         "note_marker_on_value"
       ],
       "note_id": null,
       "note_marker": "※",
-      "note_review_status": "linked_in_reviewer_evidence",
+      "note_review_status": "structured_single_candidate",
       "note_scope": "row_startup_condition",
       "note_text_excerpt": "画面中央で発動した際の数値",
-      "note_text_status": "row_note_evidence_found",
+      "note_text_status": "structured_row_note_text_found",
       "proposed_field_key": "startup",
       "representative_examples": [
         {
@@ -297,10 +407,17 @@
         "visible_text",
         "hidden_detail_text",
         "row_identity",
-        "row_note_list_from_ignored_html_capture"
+        "official_table_rows_raw/v4",
+        "row_note_count",
+        "row_notes",
+        "row_note_extraction_status",
+        "cell_note_markers",
+        "cell_note_ids",
+        "row_note_reference_candidates",
+        "note_linkage_status"
       ],
       "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100",
-      "reviewer_notes": "Startup suffix markers are row-local conditional values. Row-note extraction is required before annotated startup parsing.",
+      "reviewer_notes": "v4 row_notes provide a single same-row note candidate for representative startup suffix-marker values. This is source-review readiness only; no parser or calculation-safe promotion is granted.",
       "row_identity_status": "confirmed_public_character_move_reference",
       "semantic_source_family": "timing",
       "source_header_path": [
@@ -309,25 +426,39 @@
       ],
       "source_name": "official",
       "source_review_id": "source-review:official-note-linkage-startup",
-      "source_review_result": "source_evidence_found_acquisition_field_gap",
+      "source_review_result": "structured_row_note_evidence_found",
       "source_role": "authority_candidate",
+      "v4_representative_evidence": {
+        "cell_note_ids_present": false,
+        "cell_note_markers_present": true,
+        "note_linkage_status_counts": {
+          "same_row_note_candidates_available": 4
+        },
+        "representative_match_count": 4,
+        "row_note_reference_candidate_count_range": [
+          1,
+          1
+        ],
+        "row_note_text_structured": true,
+        "visible_hidden_detail_evidence": "visible_text_only"
+      },
       "visible_hidden_detail_status": "not_applicable_or_empty"
     },
     {
-      "acquisition_field_gap": "row_note_text_not_structured_in_table_row_artifact",
+      "acquisition_field_gap": "resolved_by_v4_row_note_fields",
       "affected_count": 28,
       "cell_boundary_status": "confirmed_source_column",
-      "later_parser_eligibility": "blocked_pending_acquisition_fields",
+      "later_parser_eligibility": "later_annotated_parser_eligible",
       "marker_roles": [
         "note_marker_on_value",
         "total_duration_label"
       ],
       "note_id": null,
       "note_marker": "※",
-      "note_review_status": "mixed_linked_in_reviewer_evidence",
+      "note_review_status": "structured_single_candidate",
       "note_scope": "row_recovery_or_total_duration_condition",
       "note_text_excerpt": "裏回り時 全体",
-      "note_text_status": "mixed_row_note_evidence_found",
+      "note_text_status": "structured_row_note_text_found",
       "proposed_field_key": "recovery",
       "representative_examples": [
         {
@@ -347,10 +478,17 @@
         "visible_text",
         "hidden_detail_text",
         "row_identity",
-        "row_note_list_from_ignored_html_capture"
+        "official_table_rows_raw/v4",
+        "row_note_count",
+        "row_notes",
+        "row_note_extraction_status",
+        "cell_note_markers",
+        "cell_note_ids",
+        "row_note_reference_candidates",
+        "note_linkage_status"
       ],
       "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_4b3674d32cef",
-      "reviewer_notes": "The source column is recovery, but values prefixed with the source label for total duration must not be treated as ordinary recovery frames.",
+      "reviewer_notes": "v4 row_notes provide single same-row note candidates for representative recovery-column values. Values with 全体 remain a later total_duration/schema design concern and are not calculation-safe here.",
       "row_identity_status": "confirmed_public_character_move_reference",
       "semantic_source_family": "timing",
       "source_header_path": [
@@ -359,25 +497,39 @@
       ],
       "source_name": "official",
       "source_review_id": "source-review:official-note-linkage-recovery",
-      "source_review_result": "source_evidence_found_acquisition_field_gap",
+      "source_review_result": "structured_row_note_evidence_found",
       "source_role": "authority_candidate",
+      "v4_representative_evidence": {
+        "cell_note_ids_present": false,
+        "cell_note_markers_present": true,
+        "note_linkage_status_counts": {
+          "same_row_note_candidates_available": 3
+        },
+        "representative_match_count": 3,
+        "row_note_reference_candidate_count_range": [
+          1,
+          1
+        ],
+        "row_note_text_structured": true,
+        "visible_hidden_detail_evidence": "visible_text_only"
+      },
       "visible_hidden_detail_status": "not_applicable_or_empty"
     },
     {
-      "acquisition_field_gap": "row_note_text_not_structured_in_table_row_artifact",
+      "acquisition_field_gap": "resolved_by_v4_row_note_fields",
       "affected_count": 6,
       "cell_boundary_status": "confirmed_source_column",
-      "later_parser_eligibility": "blocked_pending_acquisition_fields",
+      "later_parser_eligibility": "later_annotated_parser_eligible",
       "marker_roles": [
         "note_marker_on_value",
         "embedded_alternate_value_marker"
       ],
       "note_id": null,
       "note_marker": "※",
-      "note_review_status": "mixed_linked_in_reviewer_evidence",
+      "note_review_status": "structured_single_candidate",
       "note_scope": "row_block_advantage_condition",
       "note_text_excerpt": "行雲流水を継続した場合の数値",
-      "note_text_status": "mixed_row_note_evidence_found",
+      "note_text_status": "structured_row_note_text_found",
       "proposed_field_key": "block_advantage",
       "representative_examples": [
         {
@@ -397,10 +549,17 @@
         "visible_text",
         "hidden_detail_text",
         "row_identity",
-        "row_note_list_from_ignored_html_capture"
+        "official_table_rows_raw/v4",
+        "row_note_count",
+        "row_notes",
+        "row_note_extraction_status",
+        "cell_note_markers",
+        "cell_note_ids",
+        "row_note_reference_candidates",
+        "note_linkage_status"
       ],
       "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_522ba9f47afb",
-      "reviewer_notes": "Block advantage markers are row-local conditions. Embedded alternate forms such as a marker between two signed values need a separate parser rule.",
+      "reviewer_notes": "v4 row_notes provide a single same-row note candidate for representative block-advantage marker values. This enables later annotated parser planning only, not scalar advantage calculation.",
       "row_identity_status": "confirmed_public_character_move_reference",
       "semantic_source_family": "advantage",
       "source_header_path": [
@@ -409,24 +568,38 @@
       ],
       "source_name": "official",
       "source_review_id": "source-review:official-note-linkage-block-advantage",
-      "source_review_result": "source_evidence_found_acquisition_field_gap",
+      "source_review_result": "structured_row_note_evidence_found",
       "source_role": "authority_candidate",
+      "v4_representative_evidence": {
+        "cell_note_ids_present": false,
+        "cell_note_markers_present": true,
+        "note_linkage_status_counts": {
+          "same_row_note_candidates_available": 2
+        },
+        "representative_match_count": 2,
+        "row_note_reference_candidate_count_range": [
+          1,
+          1
+        ],
+        "row_note_text_structured": true,
+        "visible_hidden_detail_evidence": "visible_text_only"
+      },
       "visible_hidden_detail_status": "not_applicable_or_empty"
     },
     {
-      "acquisition_field_gap": "row_note_text_not_structured_in_table_row_artifact",
+      "acquisition_field_gap": "resolved_by_v4_row_note_fields",
       "affected_count": 4,
       "cell_boundary_status": "confirmed_source_column",
-      "later_parser_eligibility": "blocked_pending_acquisition_fields",
+      "later_parser_eligibility": "later_annotated_parser_eligible",
       "marker_roles": [
         "note_marker_on_value"
       ],
       "note_id": null,
       "note_marker": "※",
-      "note_review_status": "mixed_linked_in_reviewer_evidence",
+      "note_review_status": "structured_single_candidate",
       "note_scope": "row_hit_advantage_condition",
       "note_text_excerpt": "行雲流水を継続した場合の数値",
-      "note_text_status": "mixed_row_note_evidence_found",
+      "note_text_status": "structured_row_note_text_found",
       "proposed_field_key": "hit_advantage",
       "representative_examples": [
         {
@@ -446,10 +619,17 @@
         "visible_text",
         "hidden_detail_text",
         "row_identity",
-        "row_note_list_from_ignored_html_capture"
+        "official_table_rows_raw/v4",
+        "row_note_count",
+        "row_notes",
+        "row_note_extraction_status",
+        "cell_note_markers",
+        "cell_note_ids",
+        "row_note_reference_candidates",
+        "note_linkage_status"
       ],
       "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69",
-      "reviewer_notes": "Hit advantage markers are row-local conditions. Positive values without an explicit plus sign remain column-context dependent.",
+      "reviewer_notes": "v4 row_notes provide a single same-row note candidate for representative hit-advantage marker values. This enables later annotated parser planning only, not scalar advantage calculation.",
       "row_identity_status": "confirmed_public_character_move_reference",
       "semantic_source_family": "advantage",
       "source_header_path": [
@@ -458,8 +638,22 @@
       ],
       "source_name": "official",
       "source_review_id": "source-review:official-note-linkage-hit-advantage",
-      "source_review_result": "source_evidence_found_acquisition_field_gap",
+      "source_review_result": "structured_row_note_evidence_found",
       "source_role": "authority_candidate",
+      "v4_representative_evidence": {
+        "cell_note_ids_present": false,
+        "cell_note_markers_present": true,
+        "note_linkage_status_counts": {
+          "same_row_note_candidates_available": 2
+        },
+        "representative_match_count": 2,
+        "row_note_reference_candidate_count_range": [
+          1,
+          1
+        ],
+        "row_note_text_structured": true,
+        "visible_hidden_detail_evidence": "visible_text_only"
+      },
       "visible_hidden_detail_status": "not_applicable_or_empty"
     }
   ],
@@ -471,7 +665,9 @@
   },
   "source_evidence_summary": {
     "live_acquisition_run": false,
-    "row_note_text_in_structured_table_row_artifact": false,
+    "official_table_rows_v4_seen": true,
+    "reviewer_only_chatgpt_vlm_observation_used": false,
+    "row_note_text_in_structured_table_row_artifact": true,
     "row_note_text_seen_in_ignored_reviewer_html_capture": true,
     "table_cell_boundaries_seen_in_structured_table_row_artifact": true,
     "visible_hidden_detail_fields_seen_in_structured_table_row_artifact": true

--- a/docs/execplans/2026-05-24-official-note-linkage-v4-source-review-update.md
+++ b/docs/execplans/2026-05-24-official-note-linkage-v4-source-review-update.md
@@ -1,6 +1,6 @@
 # Official Note Linkage V4 Source Review Update
 
-Status: Drafted for review.
+Status: Implemented; ready for review.
 
 ## Purpose
 
@@ -257,7 +257,26 @@ git status --short --branch
   `validate-artifacts`, parsed-value classifier validator, clean-slate
   validator, and `git status --short --branch`. New-file whitespace check
   produced no whitespace error output.
-- [ ] Complete mandatory review before any source-review artifact update.
+- [x] (2026-05-24 JST) Completed mandatory review for PR #340 with no blocking
+  findings.
+- [x] (2026-05-24 JST) PR #340 was marked ready and merged with normal merge
+  commit `c11a18fee4aa8e281eed03bf6ebb0334c54156f3`.
+- [x] (2026-05-24 JST) Local `main` was updated to `origin/main` at the PR
+  #340 merge commit.
+- [x] (2026-05-24 JST) Confirmed main CI for the PR #340 merge commit passed:
+  run `26352319121`.
+- [x] (2026-05-24 JST) Created branch
+  `impl/official-note-linkage-v4-source-review-update`.
+- [x] (2026-05-24 JST) Updated source-review summary artifacts using existing
+  ignored official v4 row-note artifacts as reviewer input.
+- [x] (2026-05-24 JST) Updated the focused source-review validator to enforce
+  v4 source-review statuses, public artifact boundaries, and blocked ambiguous
+  cases.
+- [x] (2026-05-24 JST) Validation passed: `git diff --check`,
+  `git diff --cached --check`, `uv lock --check`, official note-linkage
+  source-review validator, source-acquisition `validate-report`,
+  source-acquisition `validate-artifacts`, parsed-value classifier validator,
+  clean-slate validator, and `git status --short --branch`.
 
 ## Decision Log
 
@@ -305,19 +324,20 @@ git status --short --branch
 
 | PLAN item | Implementation | Changed files | Validation command | Result | Deviation | Incomplete | Risk |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Official note-linkage v4 source-review update plan | Drafted docs-only plan for updating source-review artifacts using v4 row-note fields | `docs/execplans/2026-05-24-official-note-linkage-v4-source-review-update.md` | `git diff --check`; `uv lock --check`; source-review validator; validate-report; validate-artifacts; parsed-value classifier validator; clean-slate validator; status check | Passed | None | Review pending | Future source-review update still required |
-| Scope exclusions | No parser/schema/classifier/calculator/retrieval/answer/export/runtime implementation added | This ExecPlan only | Diff/status review | Passed | None | Future implementation ExecPlan required | Note-bearing values remain not calculation-safe |
+| Official note-linkage v4 source-review update plan | Drafted docs-only plan for updating source-review artifacts using v4 row-note fields | `docs/execplans/2026-05-24-official-note-linkage-v4-source-review-update.md` | `git diff --check`; `uv lock --check`; source-review validator; validate-report; validate-artifacts; parsed-value classifier validator; clean-slate validator; status check | Passed | None | Complete | Future parser/schema ExecPlan still required |
+| Source-review artifact update | Re-evaluated the 9 official note-bearing or note-adjacent records using v4 row-note evidence | `docs/source-reviews/20260524-official-note-linkage-source-review.md`; `data/source-reviews/20260524-official-note-linkage-source-review-summary.json`; `tests/validation/validate_official_note_linkage_source_review.py`; this ExecPlan | Requested validation suite | Passed | None | Complete | Ambiguous groups remain blocked pending source review |
+| Scope exclusions | No parser/schema/classifier/calculator/retrieval/answer/export/runtime implementation added | Source-review artifacts, focused validator, and this ExecPlan only | Diff/status review | Passed | None | Complete | No value is calculation-safe or numeric authority |
 
 ## Next Reviewer Prompt
 
 ```text
-Review docs/execplans/2026-05-24-official-note-linkage-v4-source-review-update.md.
+Review the implementation of docs/execplans/2026-05-24-official-note-linkage-v4-source-review-update.md.
 
 Check:
-- it plans only source-review summary artifact updates using v4 official
-  row-note fields from PR #339;
-- it uses existing ignored .local official v4 artifacts as reviewer input only;
-- it re-evaluates the 9 official note-bearing or note-adjacent groups;
+- changed files are limited to source-review summary artifacts, the focused
+  source-review validator, and this ExecPlan;
+- it uses existing ignored official v4 artifacts as reviewer input only;
+- it re-evaluates exactly the 9 official note-bearing or note-adjacent groups;
 - unresolved and ambiguous cases remain blocked;
 - it does not implement parser/schema/classifier/calculator/retrieval/answer/
   export/runtime behavior;
@@ -327,8 +347,8 @@ Check:
   profiles, traces, debug dumps, answer logs, training logs, private data, or
   .local artifacts;
 - ChatGPT/VLM bundles, if used, remain local reviewer-only observation_candidate;
-- validator updates, if planned, remain evidence-first and boundary-based.
+- validator updates remain evidence-first and boundary-based.
 
 Return findings, unresolved cases, PLAN deviations, and whether the
-source-review update plan is ready.
+implementation is stage-ready.
 ```

--- a/docs/source-reviews/20260524-official-note-linkage-source-review.md
+++ b/docs/source-reviews/20260524-official-note-linkage-source-review.md
@@ -13,36 +13,46 @@ numeric authority.
 
 ## Source Evidence Summary
 
-The current structured official table-row artifacts preserve source-native
-column paths, raw cell text, visible text, hidden detail text, and row
-identity. They do not expose row-local note text as structured fields.
+The v4 structured official table-row artifacts preserve source-native column
+paths, raw cell text, visible text, hidden detail text, row identity, row-local
+notes, cell note markers, cell note ids, row note reference candidates, and note
+linkage status. These fields are sufficient to distinguish groups with
+deterministic single-candidate note evidence from groups that remain ambiguous.
 
-Reviewer inspection of the ignored official HTML captures found row-local note
-evidence for the note-bearing groups. Because those notes are not present as
-structured table-row fields, every note-bearing group remains blocked pending
-acquisition-field support before parser work.
+This update used existing ignored official v4 artifacts as reviewer input only.
+No live acquisition was run. No reviewer-only ChatGPT/VLM observation was used.
 
-No live acquisition was run for this source review.
+The review outcome is:
+
+- `structured_row_note_evidence_found`: `4`
+- `structured_row_note_evidence_ambiguous`: `4`
+- `source_confirmed_non_note_grammar_blocked`: `1`
+
+The `4` ambiguous groups remain blocked pending source review. The `4` found
+groups are only later annotated-parser candidates; no parser approval,
+calculation-safe value, numeric authority, or current-fact authority is added.
 
 ## Decisions
 
 | Review item | Field | Source header path | Affected | Result | Later parser eligibility | Notes |
 | --- | --- | --- | ---: | --- | --- | --- |
-| `value-shape:official--source_specific_expression--sa` | `sa_gain` | `SAゲージ増加` | 8 | `source_evidence_found_acquisition_field_gap` | `blocked_pending_acquisition_fields` | Marker links to row-local medal-level SA gauge conditions in reviewer evidence, but row notes are not structured in the table-row artifact. |
-| `value-shape:official--source_specific_expression--u_55d872f6091a` | `combo_scaling` | `コンボ補正値` | 55 | `source_evidence_found_acquisition_field_gap` | `blocked_pending_acquisition_fields` | Row-local scaling notes vary by move; parser work needs per-row notes, not group-level assumptions. |
-| `value-shape:official--source_specific_expression--u_202a059d9b1b` | `damage` | `ダメージ` | 36 | `source_evidence_found_acquisition_field_gap` | `blocked_pending_acquisition_fields` | `※` damage examples are confirmed inside the source-native damage column, not adjacent cancel cells. Row notes still need structured extraction. |
-| `value-shape:official--malformed_looking_source_value--u_fdb49a2113ba--u_c2b75204faf1` | `active` | `動作フレーム > 持続` | 3 | `source_confirmed_non_note_grammar_blocked` | `not_note_linkage_target` | Dot and double-hyphen active values are source-confirmed active cells, but this review does not resolve their grammar or calculation meaning. |
-| `value-shape:official--source_specific_expression--u_fdb49a2113ba--u_c2b75204faf1` | `active` | `動作フレーム > 持続` | 44 | `source_evidence_found_acquisition_field_gap` | `blocked_pending_acquisition_fields` | Active cells mix standalone markers, bracketed note ids, component markers, and hidden-detail text. Future parsing must use separated visible and hidden fields. |
-| `value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100` | `startup` | `動作フレーム > 発生` | 6 | `source_evidence_found_acquisition_field_gap` | `blocked_pending_acquisition_fields` | Suffix markers are row-local conditional startup values. |
-| `value-shape:official--source_specific_expression--u_fdb49a2113ba--u_4b3674d32cef` | `recovery` | `動作フレーム > 硬直` | 28 | `source_evidence_found_acquisition_field_gap` | `blocked_pending_acquisition_fields` | `全体` values must not be treated as ordinary recovery frames. |
-| `value-shape:official--source_specific_expression--u_c135db53355f--u_522ba9f47afb` | `block_advantage` | `硬直差 > ガード` | 6 | `source_evidence_found_acquisition_field_gap` | `blocked_pending_acquisition_fields` | Block advantage markers are row-local conditions; embedded alternate forms require a separate parser rule. |
-| `value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69` | `hit_advantage` | `硬直差 > ヒット` | 4 | `source_evidence_found_acquisition_field_gap` | `blocked_pending_acquisition_fields` | Hit advantage markers are row-local conditions; positive values remain column-context dependent. |
+| `value-shape:official--source_specific_expression--sa` | `sa_gain` | `SAゲージ増加` | 8 | `structured_row_note_evidence_ambiguous` | `blocked_pending_source_review` | v4 row notes expose row-local text, but representative cells have multiple same-row `※` candidates, including damage and SA-gauge notes. |
+| `value-shape:official--source_specific_expression--u_55d872f6091a` | `combo_scaling` | `コンボ補正値` | 55 | `structured_row_note_evidence_ambiguous` | `blocked_pending_source_review` | Most representative rows have a single candidate, but some rows still have multiple same-row `※` candidates. |
+| `value-shape:official--source_specific_expression--u_202a059d9b1b` | `damage` | `ダメージ` | 36 | `structured_row_note_evidence_ambiguous` | `blocked_pending_source_review` | v4 evidence confirms damage column boundaries, but at least one representative row has multiple same-row `※` candidates. |
+| `value-shape:official--malformed_looking_source_value--u_fdb49a2113ba--u_c2b75204faf1` | `active` | `動作フレーム > 持続` | 3 | `source_confirmed_non_note_grammar_blocked` | `not_note_linkage_target` | v4 evidence confirms representative active values have no cell note markers; dot and double-hyphen grammar remains outside this review. |
+| `value-shape:official--source_specific_expression--u_fdb49a2113ba--u_c2b75204faf1` | `active` | `動作フレーム > 持続` | 44 | `structured_row_note_evidence_ambiguous` | `blocked_pending_source_review` | Active cells still mix standalone markers, bracketed note ids, and visible/hidden detail concatenation, with ambiguous representative rows. |
+| `value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100` | `startup` | `動作フレーム > 発生` | 6 | `structured_row_note_evidence_found` | `later_annotated_parser_eligible` | Representative startup suffix-marker values have a single same-row note candidate. |
+| `value-shape:official--source_specific_expression--u_fdb49a2113ba--u_4b3674d32cef` | `recovery` | `動作フレーム > 硬直` | 28 | `structured_row_note_evidence_found` | `later_annotated_parser_eligible` | Representative recovery-column values have a single same-row note candidate; `全体` remains a later total-duration/schema concern. |
+| `value-shape:official--source_specific_expression--u_c135db53355f--u_522ba9f47afb` | `block_advantage` | `硬直差 > ガード` | 6 | `structured_row_note_evidence_found` | `later_annotated_parser_eligible` | Representative block-advantage marker values have a single same-row note candidate; this is not scalar advantage calculation approval. |
+| `value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69` | `hit_advantage` | `硬直差 > ヒット` | 4 | `structured_row_note_evidence_found` | `later_annotated_parser_eligible` | Representative hit-advantage marker values have a single same-row note candidate; this is not scalar advantage calculation approval. |
 
 ## Boundary Notes
 
 - Official remains authority candidate only.
 - No current-fact authority is added.
 - No parser output or calculation-safe value is emitted.
+- `later_annotated_parser_eligible` means source-review readiness for a future
+  ExecPlan only.
 - No full source rows, raw source dumps, browser images, local paths, cookies,
   browser profiles, traces, debug dumps, answer logs, training logs, or
   private data are included.

--- a/tests/validation/validate_official_note_linkage_source_review.py
+++ b/tests/validation/validate_official_note_linkage_source_review.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import re
 import sys
+from collections import Counter
 from hashlib import sha256
 from pathlib import Path
 
@@ -13,12 +14,26 @@ MD_PATH = ROOT / "docs/source-reviews/20260524-official-note-linkage-source-revi
 COVERAGE_PATH = ROOT / "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
 
 ALLOWED_RESULTS = {
-    "source_evidence_found_acquisition_field_gap",
+    "structured_row_note_evidence_found",
+    "structured_row_note_evidence_ambiguous",
+    "structured_row_note_evidence_missing",
     "source_confirmed_non_note_grammar_blocked",
 }
 ALLOWED_ELIGIBILITY = {
+    "later_annotated_parser_eligible",
+    "blocked_pending_source_review",
     "blocked_pending_acquisition_fields",
     "not_note_linkage_target",
+}
+REQUIRED_V4_FIELDS = {
+    "official_table_rows_raw/v4",
+    "row_note_count",
+    "row_notes",
+    "row_note_extraction_status",
+    "cell_note_markers",
+    "cell_note_ids",
+    "row_note_reference_candidates",
+    "note_linkage_status",
 }
 FORBIDDEN_PATTERNS = [
     re.compile(r"(?i)(?:^|[\s\"'`])(?:/(?:home|mnt|Users)/[^\s\"'`]+)"),
@@ -66,11 +81,18 @@ def main() -> int:
         errors.append("authority_status must be review_decision_only_not_authority")
     if payload.get("total_review_records") != 9 or payload.get("review_counts", {}).get("total_review_records") != 9:
         errors.append("official note-linkage source review must contain exactly 9 records")
+    _validate_source_evidence_summary(payload.get("source_evidence_summary"), errors)
 
     records = payload.get("review_records", [])
     actual_ids = {record.get("review_item_id") for record in records}
     if actual_ids != expected_ids:
         errors.append("review_records do not match official review_required coverage records")
+
+    expected_counts = Counter(record.get("source_review_result") for record in records)
+    expected_counts.update(record.get("later_parser_eligibility") for record in records)
+    expected_counts["total_review_records"] = len(records)
+    if payload.get("review_counts") != dict(sorted(expected_counts.items())):
+        errors.append("review_counts must match source_review_result and later_parser_eligibility values")
 
     for index, record in enumerate(records):
         _validate_record(index, record, errors)
@@ -79,8 +101,19 @@ def main() -> int:
         if record.get("review_item_id", "").startswith("value-shape:official--malformed_looking_source_value"):
             if record.get("later_parser_eligibility") != "not_note_linkage_target":
                 errors.append("malformed active group must remain not_note_linkage_target")
+            if record.get("source_review_result") != "source_confirmed_non_note_grammar_blocked":
+                errors.append("malformed active group must remain source_confirmed_non_note_grammar_blocked")
+        elif record.get("source_review_result") == "structured_row_note_evidence_ambiguous":
+            if record.get("later_parser_eligibility") != "blocked_pending_source_review":
+                errors.append(f"{record.get('review_item_id')} ambiguous evidence must remain blocked_pending_source_review")
+        elif record.get("source_review_result") == "structured_row_note_evidence_missing":
+            if record.get("later_parser_eligibility") != "blocked_pending_acquisition_fields":
+                errors.append(f"{record.get('review_item_id')} missing v4 evidence must remain blocked_pending_acquisition_fields")
+        elif record.get("source_review_result") == "structured_row_note_evidence_found":
+            if record.get("later_parser_eligibility") != "later_annotated_parser_eligible":
+                errors.append(f"{record.get('review_item_id')} found evidence must only become later_annotated_parser_eligible")
         elif record.get("later_parser_eligibility") != "blocked_pending_acquisition_fields":
-            errors.append(f"{record.get('review_item_id')} must remain blocked_pending_acquisition_fields")
+            errors.append(f"{record.get('review_item_id')} has invalid source-review/eligibility combination")
 
     for path in (JSON_PATH, MD_PATH):
         text = path.read_text(encoding="utf-8")
@@ -93,6 +126,23 @@ def main() -> int:
                 errors.append(f"{path.relative_to(ROOT)} contains forbidden literal: {literal}")
 
     return _finish(errors)
+
+
+def _validate_source_evidence_summary(summary: object, errors: list[str]) -> None:
+    if not isinstance(summary, dict):
+        errors.append("source_evidence_summary must be an object")
+        return
+    expected_flags = {
+        "live_acquisition_run": False,
+        "reviewer_only_chatgpt_vlm_observation_used": False,
+        "official_table_rows_v4_seen": True,
+        "row_note_text_in_structured_table_row_artifact": True,
+        "table_cell_boundaries_seen_in_structured_table_row_artifact": True,
+        "visible_hidden_detail_fields_seen_in_structured_table_row_artifact": True,
+    }
+    for key, expected in expected_flags.items():
+        if summary.get(key) is not expected:
+            errors.append(f"source_evidence_summary.{key} must be {expected!r}")
 
 
 def _validate_record(index: int, record: dict[str, object], errors: list[str]) -> None:
@@ -115,6 +165,7 @@ def _validate_record(index: int, record: dict[str, object], errors: list[str]) -
         "source_review_id",
         "source_review_result",
         "source_role",
+        "v4_representative_evidence",
         "visible_hidden_detail_status",
     }
     missing = sorted(required - set(record))
@@ -130,6 +181,10 @@ def _validate_record(index: int, record: dict[str, object], errors: list[str]) -
         errors.append(f"review_records[{index}] has invalid later_parser_eligibility")
     if "parsed_value" in record or "current_fact_authority" in json.dumps(record, ensure_ascii=False):
         errors.append(f"review_records[{index}] must not include parsed values or authority promotion")
+    checked_fields = record.get("required_source_fields_checked")
+    if not isinstance(checked_fields, list) or not REQUIRED_V4_FIELDS.issubset(set(checked_fields)):
+        errors.append(f"review_records[{index}] must record required v4 source fields")
+    _validate_v4_evidence(index, record.get("v4_representative_evidence"), errors)
 
     examples = record.get("representative_examples")
     if not isinstance(examples, list) or not examples or len(examples) > 3:
@@ -150,6 +205,35 @@ def _validate_record(index: int, record: dict[str, object], errors: list[str]) -
         expected_hash = "sha256:" + sha256(raw_value.encode("utf-8")).hexdigest()
         if raw_hash != expected_hash:
             errors.append(f"review_records[{index}].representative_examples[{example_index}] has invalid hash")
+
+
+def _validate_v4_evidence(index: int, evidence: object, errors: list[str]) -> None:
+    if not isinstance(evidence, dict):
+        errors.append(f"review_records[{index}].v4_representative_evidence must be an object")
+        return
+    match_count = evidence.get("representative_match_count")
+    status_counts = evidence.get("note_linkage_status_counts")
+    candidate_range = evidence.get("row_note_reference_candidate_count_range")
+    if not isinstance(match_count, int) or match_count <= 0:
+        errors.append(f"review_records[{index}].v4_representative_evidence has invalid match count")
+    if not isinstance(status_counts, dict) or not status_counts:
+        errors.append(f"review_records[{index}].v4_representative_evidence must include status counts")
+    elif any(not isinstance(value, int) or value <= 0 for value in status_counts.values()):
+        errors.append(f"review_records[{index}].v4_representative_evidence has invalid status count values")
+    elif sum(status_counts.values()) != match_count:
+        errors.append(f"review_records[{index}].v4_representative_evidence status counts must sum to match count")
+    if (
+        not isinstance(candidate_range, list)
+        or len(candidate_range) != 2
+        or not all(isinstance(value, int) and value >= 0 for value in candidate_range)
+        or candidate_range[0] > candidate_range[1]
+    ):
+        errors.append(f"review_records[{index}].v4_representative_evidence has invalid candidate count range")
+    for key in ("cell_note_markers_present", "cell_note_ids_present", "row_note_text_structured"):
+        if not isinstance(evidence.get(key), bool):
+            errors.append(f"review_records[{index}].v4_representative_evidence.{key} must be boolean")
+    if not evidence.get("visible_hidden_detail_evidence"):
+        errors.append(f"review_records[{index}].v4_representative_evidence.visible_hidden_detail_evidence is required")
 
 
 def _finish(errors: list[str]) -> int:


### PR DESCRIPTION
## Summary
- update official note-linkage source-review summary from v4 row-note evidence
- classify 4 records as structured row-note evidence found and 4 as ambiguous, while keeping non-note active grammar blocked
- strengthen the focused validator around allowed v4 statuses, required v4 fields, and blocked ambiguous cases

## Boundaries
- no parser/schema/classifier/calculator/retrieval/answer/export/runtime behavior changes
- no calculation-safe, numeric authority, or current-fact authority promotion
- no raw HTML, full rows, screenshots, .local artifacts, local paths, cookies, profiles, traces, debug dumps, logs, or private data committed

## Validation
- git diff --check
- git diff --cached --check
- uv lock --check
- PYTHONPATH=src uv run --locked python tests/validation/validate_official_note_linkage_source_review.py
- PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.source_acquisition validate-report docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md
- PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.source_acquisition validate-artifacts docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md
- PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
- PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
