### PR TITLE
Implement annotated numeric candidate consumer guard

### DIFF
--- a/data/validator-audits/20260523-validator-test-fact-source-audit.json
+++ b/data/validator-audits/20260523-validator-test-fact-source-audit.json
@@ -25,6 +25,19 @@
     },
     {
       "evidence_class": "synthetic_contract",
+      "file": "tests/test_current_fact_guards.py",
+      "limitations": [
+        "uses synthetic scalar/non-scalar fixtures; does not prove source truth or calculation correctness"
+      ],
+      "primary_evidence": [
+        "annotated numeric candidate consumer guard implementation ExecPlan",
+        "frame range consumer guard ExecPlan",
+        "annotated numeric candidate consumer guard ExecPlan"
+      ],
+      "status": "accepted_with_limits"
+    },
+    {
+      "evidence_class": "synthetic_contract",
       "file": "tests/test_source_acquisition.py",
       "limitations": [
         "uses synthetic HTML for parser and guard behavior",
@@ -96,6 +109,19 @@
         "AGENTS.md",
         "clean-slate ExecPlans",
         "current-fact JSON Schema artifacts ExecPlan"
+      ],
+      "status": "accepted_with_limits"
+    },
+    {
+      "evidence_class": "artifact_consistency",
+      "file": "tests/validation/validate_current_fact_consumer_guards.py",
+      "limitations": [
+        "checks guard behavior against synthetic fixtures and parsed-value coverage statuses; does not prove calculation safety or source truth"
+      ],
+      "primary_evidence": [
+        "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+        "annotated numeric candidate consumer guard implementation ExecPlan",
+        "frame range consumer guard ExecPlan"
       ],
       "status": "accepted_with_limits"
     },

--- a/docs/execplans/2026-05-24-annotated-numeric-candidate-consumer-guard-implementation.md
+++ b/docs/execplans/2026-05-24-annotated-numeric-candidate-consumer-guard-implementation.md
@@ -1,6 +1,6 @@
 # Annotated Numeric Candidate Consumer Guard Implementation
 
-Status: Drafted for review.
+Status: Implemented; validation pending.
 
 ## Purpose
 
@@ -14,9 +14,9 @@ The immediate trigger is PR #346, which added
 This implementation plan also covers the earlier `frame_range` guard contract
 from PR #335 because both shapes are parsed but not scalar calculation-safe.
 
-This ExecPlan is docs-only. It does not implement runtime, retrieval, answer,
-export, calculator, parser, classifier, schema, generated artifact, live
-acquisition, or SymPy changes.
+The planning PR for this ExecPlan was docs-only. The implementation slice
+must not implement runtime, retrieval, answer, export, calculator, parser,
+classifier, schema, generated artifact, live acquisition, or SymPy changes.
 
 ## Inputs
 
@@ -76,13 +76,13 @@ Included for future implementation planning:
 
 Excluded:
 
-- No runtime behavior changes in this docs-only PR.
+- No runtime behavior changes in this implementation slice.
 - No retrieval implementation.
 - No answer behavior changes.
 - No normalized export implementation.
 - No calculator implementation.
-- No parser or classifier changes in this docs-only PR.
-- No schema changes in this docs-only PR.
+- No parser or classifier changes in this implementation slice.
+- No schema changes in this implementation slice.
 - No generated artifact changes.
 - No SymPy logic.
 - No live acquisition.
@@ -270,15 +270,15 @@ and block `※-10` remain blocked until a later plan provides:
 - The ExecPlan requires future consumer artifacts to carry
   `calculation_input_status`.
 - The ExecPlan keeps parser/classifier/schema/generated artifact changes out
-  of this docs-only PR.
+  of this implementation slice.
 - The ExecPlan keeps calculator/retrieval/answer/export/runtime implementation
-  out of this docs-only PR.
+  out of this implementation slice.
 - The ExecPlan keeps SymPy and live acquisition out of scope.
 - Validation commands pass.
 
 ## Files / Interfaces
 
-This docs-only planning unit changes only:
+The reviewed docs-only planning unit changed only:
 
 - `docs/execplans/2026-05-24-annotated-numeric-candidate-consumer-guard-implementation.md`
 
@@ -288,6 +288,8 @@ Future implementation may touch only after this plan is reviewed:
 - focused unit tests under `tests/`;
 - a focused guard validator under `tests/validation/`;
 - focused synthetic fixtures under `tests/fixtures/current-facts/` if needed;
+- validator audit summary artifacts when new test or validation files are
+  added;
 - this ExecPlan progress/decision log.
 
 Future implementation must not touch parser/classifier/schema/generated
@@ -322,7 +324,28 @@ git status --short --branch
 - [x] (2026-05-24 JST) Validation passed: `git diff --check`,
   `uv lock --check`, clean-slate validator, parsed-value classifier coverage
   validator, and `git status --short --branch`.
-- [ ] Complete review before implementation approval.
+- [x] (2026-05-24 JST) Completed mandatory review for PR #348 with no
+  blocking findings.
+- [x] (2026-05-24 JST) PR #348 was marked ready and merged with normal merge
+  commit `bd0a79a75f34b1b28d4e93fc4eb3d3a8d5697c05`.
+- [x] (2026-05-24 JST) Local `main` was fast-forwarded to `origin/main` at
+  commit `bd0a79a75f34b1b28d4e93fc4eb3d3a8d5697c05`; main CI passed in run
+  `26363790775`.
+- [x] (2026-05-24 JST) Created implementation branch
+  `impl/annotated-numeric-candidate-consumer-guard`.
+- [x] (2026-05-24 JST) Added `current_fact_guards.is_scalar_calculation_input`
+  with closed scalar-kind and calculation-status checks.
+- [x] (2026-05-24 JST) Added focused unit tests and a focused validator for
+  annotated candidate, frame range, review-required, and not-numeric-authority
+  rejection cases.
+- [x] (2026-05-24 JST) Updated validator audit summary artifacts because new
+  test and validation files must be covered by the audit validator.
+- [x] (2026-05-24 JST) Final implementation validation passed:
+  `git diff --check`, `git diff --cached --check`, `uv lock --check`,
+  unittest discovery, clean-slate validator, parsed-value classifier coverage
+  validator, current-fact consumer guard validator, validator audit, all
+  validation scripts, and `git status --short --branch`.
+- [ ] Complete implementation review.
 
 ## Decision Log
 
@@ -348,19 +371,35 @@ git status --short --branch
   Rationale: This plan defines rejection and routing behavior, not arithmetic.
   Date/Author: 2026-05-24 / Codex
 
+- Decision: Put the helper in `src/sf6_knowledge_coach/current_fact_guards.py`.
+  Rationale: Current-fact consumers can import it without coupling consumer
+  safety back into the raw parser/classifier module.
+  Date/Author: 2026-05-24 / Codex
+
+- Decision: Use `eligible_only_after_domain_source_and_unit_checks` as the
+  only synthetic scalar-accepted status in the first helper implementation.
+  Rationale: Existing classifier policy already uses this as the scalar
+  candidate status before later domain/source/unit checks; this does not
+  promote any production value to calculation-safe authority.
+  Date/Author: 2026-05-24 / Codex
+
+- Decision: Update validator audit artifacts with the new test and validator
+  files.
+  Rationale: The CI validation inventory requires every `tests/test_*.py` and
+  `tests/validation/validate_*.py` file to declare its evidence boundary.
+  Date/Author: 2026-05-24 / Codex
+
 ## Deviations
 
 - None.
 
 ## Remaining Risks
 
-- Guard implementation remains future work until a reviewed implementation PR
-  lands.
-- The exact helper module name and accepted scalar status set must be fixed in
-  implementation review.
+- Guard implementation is added but remains review pending.
 - Existing `current_facts.py` still reads legacy raw export data and does not
   yet expose parsed-value-backed lookup.
-- Future consumers could bypass the helper unless validators require it.
+- Future consumers could bypass the helper unless future surface-specific
+  validators require it.
 - Same-grammar annotated raw-value expansion remains blocked pending an
   Issue #343-style supplemental double-check gate.
 
@@ -371,6 +410,9 @@ git status --short --branch
 | Consumer guard implementation plan | Drafted docs-only plan for future helper/tests/validators that reject non-scalar parsed values in scalar contexts | `docs/execplans/2026-05-24-annotated-numeric-candidate-consumer-guard-implementation.md` | `git diff --check`; `uv lock --check`; clean-slate validator; parsed-value classifier validator; `git status --short --branch` | Passed | None | Review pending | Future implementation still required |
 | Current surface inventory | Identified `current_facts.py`, `answering.py`, current-fact schemas/fixtures, and future export/retrieval/calculator surfaces | This ExecPlan only | Diff/status review | Passed | None | Implementation review must confirm exact touched files | Existing lookup remains legacy raw export |
 | Scope exclusions | No runtime/retrieval/answer/export/calculator/parser/classifier/schema/generated artifact/SymPy/live acquisition changes added | This ExecPlan only | Diff/status review | Passed | None | Future implementation ExecPlan required | Guard bypass remains possible until implemented |
+| Guard helper | Added `is_scalar_calculation_input` with closed scalar-kind/status checks | `src/sf6_knowledge_coach/current_fact_guards.py` | Unit tests; focused guard validator | Passed | None | Review pending | Future consumers still need to call the helper |
+| Guard tests and validator | Added focused unit tests and validator coverage for accepted synthetic scalar and rejected annotated/frame-range/review-required/not-authority cases | `tests/test_current_fact_guards.py`; `tests/validation/validate_current_fact_consumer_guards.py` | unittest; new guard validator | Passed | None | Review pending | Synthetic scalar fixture does not prove production authority |
+| Validator audit update | Added audit entries for the new test and validator files | `data/validator-audits/20260523-validator-test-fact-source-audit.json`; `docs/validator-audits/20260523-validator-test-fact-source-audit.md` | validator audit | Passed | None | Review pending | Audit proves evidence boundary only |
 
 ## Next Reviewer Prompt
 
@@ -378,23 +420,33 @@ git status --short --branch
 Review docs/execplans/2026-05-24-annotated-numeric-candidate-consumer-guard-implementation.md.
 
 Check:
-- PR diff contains exactly one docs-only ExecPlan file.
-- It plans implementation of deterministic guard helpers/validators only.
+- PR diff stays within the approved implementation files: guard helper,
+  focused tests, focused validator, validator audit update, and ExecPlan
+  progress updates.
 - It does not implement runtime/retrieval/answer/export/calculator/parser/classifier/schema/generated artifact changes.
-- It covers both annotated_numeric_candidate and frame_range as non-scalar parsed values.
-- It requires calculation_input_status to carry forward.
-- It plans rejection fixtures for annotated_candidate_not_calculation_safe, parsed_range_not_single_value_calculation_safe, review_required values with no parsed_value, and not_numeric_authority values.
-- It does not promote any value to calculation-safe, numeric authority, or current-fact authority.
+- `is_scalar_calculation_input` rejects annotated_numeric_candidate and
+  frame_range in scalar contexts.
+- It requires calculation_input_status before scalar acceptance.
+- It rejects annotated_candidate_not_calculation_safe,
+  parsed_range_not_single_value_calculation_safe, review_required values with
+  no parsed_value, and not_numeric_authority values.
+- The accepted scalar fixture is synthetic and does not promote any production
+  value to calculation-safe, numeric authority, or current-fact authority.
+- Validator audit updates are scoped to the new test and validator files.
 - It keeps SymPy and live acquisition out of scope.
 - Issue #343 double-check remains required for future raw-value expansion.
 
 Run:
 - git diff --check
+- git diff --cached --check
 - uv lock --check
+- PYTHONPATH=src uv run --locked python -m unittest discover -s tests
 - PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
 - PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_validator_test_audit.py
 - git status --short --branch
 
 Return blocking findings first, validation results, PLAN deviations,
-remaining risks, and whether docs-only stage/commit is approved.
+remaining risks, and whether implementation is stage-ready.
 ```

--- a/docs/validator-audits/20260523-validator-test-fact-source-audit.md
+++ b/docs/validator-audits/20260523-validator-test-fact-source-audit.md
@@ -15,12 +15,14 @@ privacy/security boundary.
 | File | Evidence class | Status | Limitation |
 | --- | --- | --- | --- |
 | `tests/test_cli.py` | source-derived | accepted with limits | JP 5LP smoke only; not full roster validation |
+| `tests/test_current_fact_guards.py` | synthetic contract | accepted with limits | scalar/non-scalar guard fixtures only; no source truth or calculation correctness |
 | `tests/test_source_acquisition.py` | synthetic contract | accepted with limits | synthetic HTML tests parser/guard behavior, not live source truth |
 | `tests/test_supercombo_field_mapping.py` | policy-derived | accepted with limits | mapping counts are reviewed policy output, not live SuperCombo proof |
 | `tests/test_value_shape_disposition.py` | artifact consistency | accepted with limits | disposition coverage is not parse semantics |
 | `tests/test_parsed_value_classifier.py` | policy-derived | accepted with limits | parser/classifier behavior is policy-derived and not calculation correctness |
 | `tests/test_value_shape_inventory.py` | source-derived | accepted with limits | representative shape checks are not parser semantics |
 | `tests/validation/validate_clean_slate.py` | governance boundary | accepted with limits | repo shape only |
+| `tests/validation/validate_current_fact_consumer_guards.py` | artifact consistency | accepted with limits | guard behavior against synthetic fixtures and coverage statuses only |
 | `tests/validation/validate_current_fact_schemas.py` | synthetic contract | accepted with limits | schema and fixture contracts only; no parser/source truth |
 | `tests/validation/validate_official_note_linkage_source_review.py` | source-derived | accepted with limits | source-review summary; full row-note context remains ignored local evidence |
 | `tests/validation/validate_parsed_value_classifier.py` | artifact consistency | accepted with limits | coverage artifact, mechanics anchors, and schema-compatible samples only |

--- a/src/sf6_knowledge_coach/current_fact_guards.py
+++ b/src/sf6_knowledge_coach/current_fact_guards.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+SCALAR_CALCULATION_INPUT_STATUSES = frozenset(
+    {
+        "eligible_only_after_domain_source_and_unit_checks",
+    }
+)
+
+SCALAR_CALCULATION_KINDS = frozenset(
+    {
+        "decimal",
+        "gauge_amount",
+        "integer",
+        "percent",
+        "signed_frame",
+    }
+)
+
+NON_SCALAR_OR_BLOCKED_CALCULATION_STATUSES = frozenset(
+    {
+        "annotated_candidate_not_calculation_safe",
+        "enum_only_not_arithmetic",
+        "not_numeric_authority",
+        "out_of_scope_not_emitted",
+        "parsed_range_not_single_value_calculation_safe",
+        "raw_preserved_not_calculation",
+        "review_required_not_calculation_safe",
+    }
+)
+
+NON_SCALAR_PARSED_VALUE_KINDS = frozenset(
+    {
+        "annotated_numeric_candidate",
+        "enum_token",
+        "frame_range",
+        "ordered_pair",
+        "raw_note",
+    }
+)
+
+
+def is_scalar_calculation_input(
+    parsed_value: object | None,
+    calculation_input_status: str | None,
+) -> bool:
+    if not isinstance(parsed_value, Mapping):
+        return False
+    kind = parsed_value.get("kind")
+    if not isinstance(kind, str):
+        return False
+    if kind in NON_SCALAR_PARSED_VALUE_KINDS:
+        return False
+    if calculation_input_status in NON_SCALAR_OR_BLOCKED_CALCULATION_STATUSES:
+        return False
+    if calculation_input_status not in SCALAR_CALCULATION_INPUT_STATUSES:
+        return False
+    return kind in SCALAR_CALCULATION_KINDS

--- a/tests/test_current_fact_guards.py
+++ b/tests/test_current_fact_guards.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import unittest
+
+from sf6_knowledge_coach.current_fact_guards import is_scalar_calculation_input
+
+
+ELIGIBLE_STATUS = "eligible_only_after_domain_source_and_unit_checks"
+
+
+class CurrentFactGuardTests(unittest.TestCase):
+    def test_accepted_scalar_contract_fixtures_require_scalar_kind_and_status(self) -> None:
+        self.assertTrue(
+            is_scalar_calculation_input(
+                {"kind": "signed_frame", "unit": "frame", "value": -2},
+                ELIGIBLE_STATUS,
+            )
+        )
+        self.assertTrue(
+            is_scalar_calculation_input(
+                {"kind": "integer", "unit": "damage", "value": 500},
+                ELIGIBLE_STATUS,
+            )
+        )
+
+    def test_scalar_shapes_without_eligible_status_are_rejected(self) -> None:
+        parsed_value = {"kind": "signed_frame", "unit": "frame", "value": -2}
+        for status in (None, "", "review_required_not_calculation_safe", "not_numeric_authority"):
+            with self.subTest(status=status):
+                self.assertFalse(is_scalar_calculation_input(parsed_value, status))
+
+    def test_annotated_numeric_candidate_is_not_scalar_even_with_nested_value(self) -> None:
+        parsed_value = {
+            "kind": "annotated_numeric_candidate",
+            "numeric_candidate": {
+                "candidate_type": "signed_frame",
+                "unit": "frame",
+                "value": -4,
+            },
+        }
+        self.assertFalse(
+            is_scalar_calculation_input(
+                parsed_value,
+                "annotated_candidate_not_calculation_safe",
+            )
+        )
+        self.assertFalse(is_scalar_calculation_input(parsed_value, ELIGIBLE_STATUS))
+
+    def test_frame_range_and_ordered_pair_are_not_scalar_calculation_inputs(self) -> None:
+        self.assertFalse(
+            is_scalar_calculation_input(
+                {"kind": "frame_range", "unit": "frame", "start": -12, "end": -1},
+                "parsed_range_not_single_value_calculation_safe",
+            )
+        )
+        self.assertFalse(
+            is_scalar_calculation_input(
+                {"kind": "ordered_pair", "labels": ["throw_range", "hurtbox"], "unit": "distance", "values": [0.8, 0.33]},
+                "not_numeric_authority",
+            )
+        )
+
+    def test_blocked_or_malformed_values_are_not_scalar_calculation_inputs(self) -> None:
+        self.assertFalse(is_scalar_calculation_input(None, "review_required_not_calculation_safe"))
+        self.assertFalse(is_scalar_calculation_input({}, ELIGIBLE_STATUS))
+        self.assertFalse(is_scalar_calculation_input({"value": -2}, ELIGIBLE_STATUS))
+        self.assertFalse(is_scalar_calculation_input({"kind": "unknown", "value": 1}, ELIGIBLE_STATUS))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/validate_current_fact_consumer_guards.py
+++ b/tests/validation/validate_current_fact_consumer_guards.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from sf6_knowledge_coach.current_fact_guards import is_scalar_calculation_input
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COVERAGE_PATH = ROOT / "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+ELIGIBLE_STATUS = "eligible_only_after_domain_source_and_unit_checks"
+
+
+def main() -> int:
+    errors: list[str] = []
+    if not COVERAGE_PATH.exists():
+        errors.append(f"Missing {COVERAGE_PATH.relative_to(ROOT)}")
+        return _finish(errors)
+
+    coverage = json.loads(COVERAGE_PATH.read_text(encoding="utf-8"))
+    _validate_synthetic_contract_fixtures(errors)
+    _validate_coverage_status_guards(coverage, errors)
+    return _finish(errors)
+
+
+def _validate_synthetic_contract_fixtures(errors: list[str]) -> None:
+    accepted = [
+        ({"kind": "signed_frame", "unit": "frame", "value": -2}, ELIGIBLE_STATUS),
+        ({"kind": "integer", "unit": "damage", "value": 500}, ELIGIBLE_STATUS),
+    ]
+    for parsed_value, status in accepted:
+        if not is_scalar_calculation_input(parsed_value, status):
+            errors.append(f"synthetic scalar fixture should be accepted: {parsed_value['kind']}")
+
+    rejected = [
+        (
+            {
+                "kind": "annotated_numeric_candidate",
+                "numeric_candidate": {
+                    "candidate_type": "signed_frame",
+                    "unit": "frame",
+                    "value": -4,
+                },
+            },
+            "annotated_candidate_not_calculation_safe",
+        ),
+        (
+            {"kind": "frame_range", "unit": "frame", "start": -12, "end": -1},
+            "parsed_range_not_single_value_calculation_safe",
+        ),
+        (None, "review_required_not_calculation_safe"),
+        ({"kind": "signed_frame", "unit": "frame", "value": -2}, None),
+        ({"kind": "integer", "unit": "damage", "value": 500}, "review_required_not_calculation_safe"),
+        (
+            {
+                "kind": "ordered_pair",
+                "labels": ["throw_range", "hurtbox"],
+                "unit": "distance",
+                "values": [0.8, 0.33],
+            },
+            "not_numeric_authority",
+        ),
+    ]
+    for parsed_value, status in rejected:
+        if is_scalar_calculation_input(parsed_value, status):
+            errors.append(f"non-scalar or blocked fixture should be rejected: {parsed_value!r} / {status!r}")
+
+
+def _validate_coverage_status_guards(coverage: dict[str, Any], errors: list[str]) -> None:
+    records = coverage.get("coverage_records", [])
+    if not isinstance(records, list):
+        errors.append("coverage_records must be a list")
+        return
+
+    annotated_records = [
+        record for record in records
+        if isinstance(record, dict)
+        and record.get("calculation_input_status") == "annotated_candidate_not_calculation_safe"
+    ]
+    if len(annotated_records) != 3:
+        errors.append("expected exactly 3 annotated non-scalar coverage records")
+    for record in annotated_records:
+        _validate_annotated_record(record, errors)
+
+    range_records = [
+        record for record in records
+        if isinstance(record, dict)
+        and record.get("calculation_input_status") == "parsed_range_not_single_value_calculation_safe"
+    ]
+    if len(range_records) != 2:
+        errors.append("expected exactly 2 frame_range non-scalar coverage records")
+    for record in range_records:
+        parsed_value = {"kind": "frame_range", "unit": "frame", "start": -12, "end": -1}
+        if is_scalar_calculation_input(parsed_value, record.get("calculation_input_status")):
+            errors.append(f"{record.get('review_item_id')} frame_range must be rejected by scalar guard")
+
+    blocked_records = [
+        record for record in records
+        if isinstance(record, dict)
+        and record.get("calculation_input_status") == "review_required_not_calculation_safe"
+    ]
+    if not blocked_records:
+        errors.append("expected review_required_not_calculation_safe coverage records")
+    for record in blocked_records:
+        if is_scalar_calculation_input(None, record.get("calculation_input_status")):
+            errors.append(f"{record.get('review_item_id')} review_required value must be rejected by scalar guard")
+
+    non_authority_records = [
+        record for record in records
+        if isinstance(record, dict)
+        and record.get("calculation_input_status") == "not_numeric_authority"
+    ]
+    if len(non_authority_records) != 1:
+        errors.append("expected exactly 1 not_numeric_authority coverage record")
+    for record in non_authority_records:
+        parsed_value = {
+            "kind": "ordered_pair",
+            "labels": ["throw_range", "hurtbox"],
+            "unit": "distance",
+            "values": [0.8, 0.33],
+        }
+        if is_scalar_calculation_input(parsed_value, record.get("calculation_input_status")):
+            errors.append(f"{record.get('review_item_id')} non-authority value must be rejected")
+
+
+def _validate_annotated_record(record: dict[str, Any], errors: list[str]) -> None:
+    variants = record.get("raw_value_variant_coverage", [])
+    if not isinstance(variants, list) or not variants:
+        errors.append(f"{record.get('review_item_id')} must include raw-value variant coverage")
+        return
+    parsed_variants = [
+        variant for variant in variants
+        if isinstance(variant, dict)
+        and variant.get("classifier_decision") == "parsed_numeric_structured"
+    ]
+    if not parsed_variants:
+        errors.append(f"{record.get('review_item_id')} must include parsed annotated variants")
+    for variant in parsed_variants:
+        if variant.get("parsed_value_kind") != "annotated_numeric_candidate":
+            errors.append(f"{record.get('review_item_id')} parsed variant must remain annotated_numeric_candidate")
+        parsed_value = {
+            "kind": "annotated_numeric_candidate",
+            "numeric_candidate": {
+                "candidate_type": "signed_frame",
+                "unit": "frame",
+                "value": -4,
+            },
+        }
+        if is_scalar_calculation_input(parsed_value, variant.get("calculation_input_status")):
+            errors.append(f"{record.get('review_item_id')} annotated candidate must be rejected by scalar guard")
+
+
+def _finish(errors: list[str]) -> int:
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("Current-fact consumer guard validation OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add `is_scalar_calculation_input` guard helper for future parsed-value consumers.
- Add focused unit tests and validation script covering annotated candidates, frame ranges, review-required values, and not-numeric-authority values.
- Update validator audit artifacts and ExecPlan progress.

## Scope
- No parser/classifier/schema/generated artifact/retrieval/answer/export/calculator/SymPy/live acquisition changes.
- Accepted scalar examples are synthetic contract fixtures only, not production authority promotion.

## Validation
- `git diff --check`
- `git diff --cached --check`
- `uv lock --check`
- `PYTHONPATH=src uv run --locked python -m unittest discover -s tests`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py`
- `PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_validator_test_audit.py`
- all `tests/validation/validate_*.py`

PLAN deviations: none.

Remaining risks: future consumers still need to call the helper or satisfy equivalent validators; current_facts.py still reads legacy raw export data; same-grammar raw-value expansion still needs Issue #343-style supplemental double-check.