### PR TITLE
Document debt retirement rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,15 @@ Before implementing:
 
 Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
 
+## Debt Retirement / 負債退役
+
+- Treat old raw exports, alias fixtures, obsolete validator assumptions, and
+  unused data surfaces as deletion candidates unless their current dependency
+  and replacement blocker are explicit.
+- Keep new code and validators small, evidence-bounded, and easy to delete.
+- When debt is found, record it immediately in Issue #343 or the relevant
+  ExecPlan Risks/Decision Log, and raise it as a next PR candidate.
+
 ## 3. Surgical Changes
 
 **Touch only what you must. Clean up only your own mess.**


### PR DESCRIPTION
## Summary
- Add an AGENTS.md debt retirement guideline for old raw exports, alias fixtures, obsolete validator assumptions, and unused data surfaces.
- Require current dependency and replacement blocker to be explicit before retaining these surfaces.
- Direct future agents to record debt in Issue #343 or the relevant ExecPlan and raise follow-up PR candidates.

## Validation
- git diff --check
- git diff --cached --check
- uv lock --check
- PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
- PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate

## Scope
- Docs-only AGENTS.md change.
- No runtime, schema, generated artifact, parser/classifier, export, retrieval, answer, calculator, SymPy, or acquisition changes.