### PR TITLE
Implement current-fact calculation status schema

### DIFF
--- a/contracts/current-facts/current_fact_export.schema.json
+++ b/contracts/current-facts/current_fact_export.schema.json
@@ -3,7 +3,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {
-    "artifact_schema_version": { "const": "current_fact_export/v1" },
+    "artifact_schema_version": { "const": "current_fact_export/v2" },
     "authority_boundary": {
       "additionalProperties": false,
       "properties": {
@@ -15,6 +15,7 @@
     },
     "generated_from": {
       "items": {
+        "not": { "pattern": "^data/exports/" },
         "pattern": "^(data|docs|contracts)/[A-Za-z0-9_.:/-]+$",
         "type": "string"
       },
@@ -24,7 +25,15 @@
     },
     "records": {
       "items": {
-        "$ref": "https://sf6-knowledge-coach.local/schemas/current-facts/current_fact_record.schema.json"
+        "allOf": [
+          {
+            "$ref": "https://sf6-knowledge-coach.local/schemas/current-facts/current_fact_record.schema.json"
+          },
+          {
+            "required": ["parsed_value"],
+            "type": "object"
+          }
+        ]
       },
       "minItems": 1,
       "type": "array"

--- a/contracts/current-facts/current_fact_record.schema.json
+++ b/contracts/current-facts/current_fact_record.schema.json
@@ -44,6 +44,18 @@
         "not_authority"
       ]
     },
+    "calculation_input_status": {
+      "enum": [
+        "eligible_only_after_domain_source_and_unit_checks",
+        "annotated_candidate_not_calculation_safe",
+        "parsed_range_not_single_value_calculation_safe",
+        "review_required_not_calculation_safe",
+        "enum_only_not_arithmetic",
+        "raw_preserved_not_calculation",
+        "not_numeric_authority",
+        "out_of_scope_not_emitted"
+      ]
+    },
     "character_slug": {
       "pattern": "^[a-z0-9_]+$",
       "type": "string"
@@ -106,6 +118,7 @@
   },
   "required": [
     "authority_status",
+    "calculation_input_status",
     "character_slug",
     "display_label_ja",
     "evidence",

--- a/docs/execplans/2026-05-25-current-fact-calculation-status-schema.md
+++ b/docs/execplans/2026-05-25-current-fact-calculation-status-schema.md
@@ -1,6 +1,6 @@
 # Current-Fact Calculation Status Schema
 
-Status: Drafted for review; validation passed.
+Status: Implemented; validation passed.
 
 ## Purpose
 
@@ -316,11 +316,11 @@ Recommended next sequence:
 
 ## Files / Interfaces
 
-This docs-only plan changes only:
+The reviewed docs-only planning PR changed only:
 
 - `docs/execplans/2026-05-25-current-fact-calculation-status-schema.md`
 
-Future implementation plans may touch, after review:
+This implementation may touch only:
 
 - `contracts/current-facts/current_fact_record.schema.json`;
 - `contracts/current-facts/current_fact_export.schema.json`;
@@ -331,7 +331,7 @@ Future implementation plans may touch, after review:
 - current-fact consumer guard validators;
 - validator audit artifacts if new or changed test/validator files require it.
 
-This plan does not authorize export generation or runtime changes.
+This implementation does not authorize export generation or runtime changes.
 
 ## Validation Commands
 
@@ -356,7 +356,35 @@ git status --short --branch
 - [x] (2026-05-25 JST) Validation passed: `git diff --check`,
   `uv lock --check`, clean-slate validator, parsed-value classifier coverage
   validator, and `git status --short --branch`.
-- [ ] Complete mandatory review.
+- [x] (2026-05-25 JST) Completed mandatory review for the docs-only PR #353
+  with no blocking findings.
+- [x] (2026-05-25 JST) PR #353 was marked ready and merged with normal merge
+  commit `b8ca11b89399fb87da2470a1c4ccd90a1b421a0b`; local `main` was
+  fast-forwarded to `origin/main`.
+- [x] (2026-05-25 JST) Created implementation branch
+  `impl/current-fact-calculation-status-schema`.
+- [x] (2026-05-25 JST) Added top-level required
+  `calculation_input_status` to `current_fact_record.schema.json` with the
+  approved closed eight-value enum.
+- [x] (2026-05-25 JST) Bumped current-fact export artifact version to
+  `current_fact_export/v2` and required lookup-ready export records to include
+  `parsed_value`.
+- [x] (2026-05-25 JST) Updated current-fact record/export fixtures with
+  status values, v2 export version, and invalid fixtures for unknown status,
+  legacy raw `generated_from`, and review-required/no-parsed-value export
+  records.
+- [x] (2026-05-25 JST) Updated focused schema and consumer guard validators
+  for the closed status enum, v2 export version, invalid export fixtures, and
+  coverage/status compatibility.
+- [x] (2026-05-25 JST) Updated parsed-value classifier compatibility
+  validation so current-fact-compatible sample records include top-level
+  `calculation_input_status` from `ClassificationResult`.
+- [x] (2026-05-25 JST) Final implementation validation passed:
+  `git diff --check`, `git diff --cached --check`, `uv lock --check`,
+  unittest discovery, clean-slate validator, all validation scripts,
+  parsed-value classifier coverage validator, and `git status --short
+  --branch`.
+- [ ] Complete implementation review.
 
 ## Decision Log
 
@@ -388,16 +416,26 @@ git status --short --branch
   arithmetic.
   Date/Author: 2026-05-25 / Codex
 
+- Decision: Require `parsed_value` from `current_fact_export/v2.records[]`
+  while keeping record-shape fixtures able to represent review-required
+  records.
+  Rationale: This keeps lookup-ready exports parsed-value-only without
+  deleting useful record-level schema fixtures for blocked values.
+  Date/Author: 2026-05-25 / Codex
+
+- Decision: Reject legacy raw export paths in `generated_from` at schema level.
+  Rationale: The replacement export must not depend on the technical-debt raw
+  export surface it is intended to retire.
+  Date/Author: 2026-05-25 / Codex
+
 ## Deviations
 
 - None.
 
 ## Remaining Risks
 
-- The future schema implementation will need to update existing valid fixtures
-  to include `calculation_input_status`.
-- Existing review-required/no-parsed-value fixtures may need directory or
-  validator separation from lookup-ready export fixtures.
+- Existing review-required/no-parsed-value record-shape fixtures remain valid
+  only outside lookup-ready export fixtures.
 - The first export may have limited coverage because lookup-ready records
   require reviewed `parsed_value`.
 - Runtime lookup helper, export generator, parity validator, rollback
@@ -412,6 +450,10 @@ git status --short --branch
 | Closed status enum | Listed eight closed status values aligned with current guard and classifier coverage | This ExecPlan only | Diff/status review | Passed | None | Future schema validator update required | Enum drift if classifier policy changes |
 | Export record admission | Chose parsed-value-only first lookup-ready export and excluded review-required/no-parsed-value records | This ExecPlan only | Diff/status review | Passed | None | Future export validator required | Limited first-export coverage |
 | Scope exclusions | Kept schema/export/runtime/parser/classifier/retrieval/calculator/SymPy/live acquisition implementation out of scope | This ExecPlan only | Diff/status review | Passed | None | Review pending | None for docs-only PR |
+| Current-fact record schema | Added required top-level `calculation_input_status` with the approved eight-value closed enum | `contracts/current-facts/current_fact_record.schema.json` | current-fact schema validator | Passed | None | Review pending | Future enum changes require an ExecPlan |
+| Current-fact export schema | Bumped export artifact const to `current_fact_export/v2`, required `parsed_value` in export records, and rejected legacy raw `generated_from` paths | `contracts/current-facts/current_fact_export.schema.json` | current-fact schema validator | Passed | None | Review pending | Runtime export generator still absent |
+| Fixtures | Updated record/export fixtures for required statuses and added invalid fixtures for unknown status, no parsed value in export, and legacy raw generated_from | `tests/fixtures/current-facts/**` | current-fact schema validator | Passed | None | Review pending | First lookup-ready export coverage remains limited |
+| Validators | Updated schema, guard, and parsed-value classifier compatibility validators for status enum, v2 export, export invalid fixtures, classifier status compatibility, and top-level status in current-fact-compatible sample records | `tests/validation/validate_current_fact_schemas.py`; `tests/validation/validate_current_fact_consumer_guards.py`; `tests/validation/validate_parsed_value_classifier.py` | schema validator; guard validator; parsed-value classifier validator; all validation scripts; validator audit | Passed | None | Review pending | Validators cover contracts, not runtime lookup |
 
 ## Next Reviewer Prompt
 

--- a/tests/fixtures/current-facts/exports/invalid/current_fact_export_legacy_raw_generated_from.json
+++ b/tests/fixtures/current-facts/exports/invalid/current_fact_export_legacy_raw_generated_from.json
@@ -5,8 +5,7 @@
     "supercombo": "enrichment_or_cross_reference_only"
   },
   "generated_from": [
-    "data/value-shape-inventories/20260521T025403Z-latest-source-value-shape-summary.json",
-    "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-and-enum-policy.json"
+    "data/exports/jp/official_raw.json"
   ],
   "records": [
     {

--- a/tests/fixtures/current-facts/exports/invalid/current_fact_export_review_required_no_parsed_value.json
+++ b/tests/fixtures/current-facts/exports/invalid/current_fact_export_review_required_no_parsed_value.json
@@ -1,0 +1,42 @@
+{
+  "artifact_schema_version": "current_fact_export/v2",
+  "authority_boundary": {
+    "official": "authority_candidate_only",
+    "supercombo": "enrichment_or_cross_reference_only"
+  },
+  "generated_from": [
+    "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+  ],
+  "records": [
+    {
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "review_required_not_calculation_safe",
+      "character_slug": "jp",
+      "display_label_ja": "コンボ補正値",
+      "evidence": {
+        "evidence_basis": "value_shape_policy",
+        "public_reference": "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": ["コンボ補正値"],
+        "source_label": "コンボ補正値",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "combo_scaling",
+      "move_id": "jp_001_5lp",
+      "raw_value": "※即時補正10%",
+      "record_id": "official:jp:jp_001_5lp:combo_scaling:review_required",
+      "source_family": "scaling",
+      "source_header_path": ["コンボ補正値"],
+      "source_label": "コンボ補正値",
+      "source_name": "official",
+      "source_role": "authority_candidate",
+      "value_shape": {
+        "classes": ["note_prefixed", "percent_expression"],
+        "classifier_status": "review_required",
+        "review_item_id": "value-shape:official--source_specific_expression--u_55d872f6091a"
+      }
+    }
+  ],
+  "run_id": "20260521T025403Z"
+}

--- a/tests/fixtures/current-facts/records/invalid/source_family_uses_source_identity.json
+++ b/tests/fixtures/current-facts/records/invalid/source_family_uses_source_identity.json
@@ -1,5 +1,6 @@
 {
   "authority_status": "authority_candidate",
+  "calculation_input_status": "raw_preserved_not_calculation",
   "character_slug": "jp",
   "display_label_ja": "ガード硬直差",
   "evidence": {

--- a/tests/fixtures/current-facts/records/invalid/supercombo_numeric_authority.json
+++ b/tests/fixtures/current-facts/records/invalid/supercombo_numeric_authority.json
@@ -1,5 +1,6 @@
 {
   "authority_status": "authority_candidate",
+  "calculation_input_status": "not_numeric_authority",
   "character_slug": "jp",
   "display_label_ja": "SuperCombo ガード硬直差",
   "evidence": {

--- a/tests/fixtures/current-facts/records/invalid/unknown_calculation_input_status.json
+++ b/tests/fixtures/current-facts/records/invalid/unknown_calculation_input_status.json
@@ -1,11 +1,11 @@
 {
   "authority_status": "authority_candidate",
-  "calculation_input_status": "eligible_only_after_domain_source_and_unit_checks",
+  "calculation_input_status": "unknown_status",
   "character_slug": "jp",
   "display_label_ja": "ガード硬直差",
   "evidence": {
-    "evidence_basis": "official_raw_snapshot",
-    "public_reference": "data/exports/jp/official_raw.json",
+    "evidence_basis": "value_shape_policy",
+    "public_reference": "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
     "run_id": "20260521T025403Z",
     "source_header_path": ["硬直差", "ガード"],
     "source_label": "ガード",
@@ -20,7 +20,7 @@
     "value": -2
   },
   "raw_value": "-2",
-  "record_id": "official:jp:jp_001_5lp:block_advantage",
+  "record_id": "official:jp:jp_001_5lp:block_advantage:unknown_status",
   "source_family": "advantage",
   "source_header_path": ["硬直差", "ガード"],
   "source_label": "ガード",

--- a/tests/fixtures/current-facts/records/valid/official_active_frame_range.json
+++ b/tests/fixtures/current-facts/records/valid/official_active_frame_range.json
@@ -1,5 +1,6 @@
 {
   "authority_status": "authority_candidate",
+  "calculation_input_status": "parsed_range_not_single_value_calculation_safe",
   "character_slug": "jp",
   "display_label_ja": "持続",
   "evidence": {

--- a/tests/fixtures/current-facts/records/valid/official_cancel_enum_classified.json
+++ b/tests/fixtures/current-facts/records/valid/official_cancel_enum_classified.json
@@ -1,5 +1,6 @@
 {
   "authority_status": "authority_candidate",
+  "calculation_input_status": "enum_only_not_arithmetic",
   "character_slug": "jp",
   "display_label_ja": "キャンセル",
   "evidence": {

--- a/tests/fixtures/current-facts/records/valid/official_combo_scaling_review_required.json
+++ b/tests/fixtures/current-facts/records/valid/official_combo_scaling_review_required.json
@@ -1,5 +1,6 @@
 {
   "authority_status": "authority_candidate",
+  "calculation_input_status": "review_required_not_calculation_safe",
   "character_slug": "jp",
   "display_label_ja": "コンボ補正値",
   "evidence": {

--- a/tests/fixtures/current-facts/records/valid/official_move_name_raw_preserved.json
+++ b/tests/fixtures/current-facts/records/valid/official_move_name_raw_preserved.json
@@ -1,5 +1,6 @@
 {
   "authority_status": "authority_candidate",
+  "calculation_input_status": "raw_preserved_not_calculation",
   "character_slug": "jp",
   "display_label_ja": "技名",
   "evidence": {

--- a/tests/fixtures/current-facts/records/valid/supercombo_block_advantage_cross_reference.json
+++ b/tests/fixtures/current-facts/records/valid/supercombo_block_advantage_cross_reference.json
@@ -1,5 +1,6 @@
 {
   "authority_status": "cross_reference_candidate",
+  "calculation_input_status": "not_numeric_authority",
   "character_slug": "jp",
   "display_label_ja": "SuperCombo ガード硬直差",
   "evidence": {

--- a/tests/fixtures/current-facts/records/valid/supercombo_throw_range_hurtbox_ordered_pair.json
+++ b/tests/fixtures/current-facts/records/valid/supercombo_throw_range_hurtbox_ordered_pair.json
@@ -1,5 +1,6 @@
 {
   "authority_status": "enrichment_candidate",
+  "calculation_input_status": "not_numeric_authority",
   "character_slug": "jp",
   "display_label_ja": "SuperCombo Throw Range / Hurtbox",
   "evidence": {

--- a/tests/fixtures/current-facts/records/valid/supercombo_throw_range_hurtbox_review_required.json
+++ b/tests/fixtures/current-facts/records/valid/supercombo_throw_range_hurtbox_review_required.json
@@ -1,5 +1,6 @@
 {
   "authority_status": "enrichment_candidate",
+  "calculation_input_status": "review_required_not_calculation_safe",
   "character_slug": "jp",
   "display_label_ja": "SuperCombo 投げ範囲 / やられ判定",
   "evidence": {

--- a/tests/validation/validate_current_fact_consumer_guards.py
+++ b/tests/validation/validate_current_fact_consumer_guards.py
@@ -5,12 +5,26 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from sf6_knowledge_coach.current_fact_guards import is_scalar_calculation_input
+from sf6_knowledge_coach.current_fact_guards import (
+    NON_SCALAR_OR_BLOCKED_CALCULATION_STATUSES,
+    SCALAR_CALCULATION_INPUT_STATUSES,
+    is_scalar_calculation_input,
+)
 
 
 ROOT = Path(__file__).resolve().parents[2]
 COVERAGE_PATH = ROOT / "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
 ELIGIBLE_STATUS = "eligible_only_after_domain_source_and_unit_checks"
+APPROVED_STATUSES = {
+    ELIGIBLE_STATUS,
+    "annotated_candidate_not_calculation_safe",
+    "parsed_range_not_single_value_calculation_safe",
+    "review_required_not_calculation_safe",
+    "enum_only_not_arithmetic",
+    "raw_preserved_not_calculation",
+    "not_numeric_authority",
+    "out_of_scope_not_emitted",
+}
 
 
 def main() -> int:
@@ -20,9 +34,17 @@ def main() -> int:
         return _finish(errors)
 
     coverage = json.loads(COVERAGE_PATH.read_text(encoding="utf-8"))
+    _validate_guard_status_sets(errors)
     _validate_synthetic_contract_fixtures(errors)
     _validate_coverage_status_guards(coverage, errors)
     return _finish(errors)
+
+
+def _validate_guard_status_sets(errors: list[str]) -> None:
+    if set(SCALAR_CALCULATION_INPUT_STATUSES) != {ELIGIBLE_STATUS}:
+        errors.append("scalar calculation input status set must contain only the approved eligible status")
+    if set(NON_SCALAR_OR_BLOCKED_CALCULATION_STATUSES) != APPROVED_STATUSES - {ELIGIBLE_STATUS}:
+        errors.append("non-scalar or blocked calculation status set does not match approved schema statuses")
 
 
 def _validate_synthetic_contract_fixtures(errors: list[str]) -> None:
@@ -33,6 +55,11 @@ def _validate_synthetic_contract_fixtures(errors: list[str]) -> None:
     for parsed_value, status in accepted:
         if not is_scalar_calculation_input(parsed_value, status):
             errors.append(f"synthetic scalar fixture should be accepted: {parsed_value['kind']}")
+
+    scalar_value = {"kind": "signed_frame", "unit": "frame", "value": -2}
+    for status in sorted(APPROVED_STATUSES - {ELIGIBLE_STATUS}):
+        if is_scalar_calculation_input(scalar_value, status):
+            errors.append(f"blocked status should reject scalar fixture: {status}")
 
     rejected = [
         (
@@ -73,6 +100,15 @@ def _validate_coverage_status_guards(coverage: dict[str, Any], errors: list[str]
     if not isinstance(records, list):
         errors.append("coverage_records must be a list")
         return
+
+    coverage_statuses = {
+        record.get("calculation_input_status")
+        for record in records
+        if isinstance(record, dict)
+    }
+    unknown_statuses = coverage_statuses - APPROVED_STATUSES
+    if unknown_statuses:
+        errors.append(f"coverage contains unknown calculation_input_status values: {sorted(unknown_statuses)}")
 
     annotated_records = [
         record for record in records

--- a/tests/validation/validate_current_fact_schemas.py
+++ b/tests/validation/validate_current_fact_schemas.py
@@ -22,6 +22,16 @@ SCHEMA_FILES = [
     "current_fact_record.schema.json",
     "current_fact_export.schema.json",
 ]
+CALCULATION_INPUT_STATUSES = {
+    "eligible_only_after_domain_source_and_unit_checks",
+    "annotated_candidate_not_calculation_safe",
+    "parsed_range_not_single_value_calculation_safe",
+    "review_required_not_calculation_safe",
+    "enum_only_not_arithmetic",
+    "raw_preserved_not_calculation",
+    "not_numeric_authority",
+    "out_of_scope_not_emitted",
+}
 FORBIDDEN_PUBLIC_PATTERNS = [
     re.compile(r"(?i)(?:^|[\s\"'`])(?:/[a-z0-9_.-]+)+"),
     re.compile(r"(?i)(?:^|[\s\"'`(])[A-Z]:[\\/]"),
@@ -48,9 +58,11 @@ def main() -> int:
 
     record_validator = Draft202012Validator(schemas[SCHEMA_DIR / "current_fact_record.schema.json"], registry=registry)
     export_validator = Draft202012Validator(schemas[SCHEMA_DIR / "current_fact_export.schema.json"], registry=registry)
+    _validate_status_schema_contract(schemas, errors)
     _validate_valid_fixtures(record_validator, FIXTURE_DIR / "records/valid", errors)
     _validate_invalid_fixtures(record_validator, FIXTURE_DIR / "records/invalid", errors)
     _validate_valid_fixtures(export_validator, FIXTURE_DIR / "exports/valid", errors)
+    _validate_invalid_fixtures(export_validator, FIXTURE_DIR / "exports/invalid", errors)
     _scan_public_files([*schemas, *FIXTURE_DIR.rglob("*.json")], errors)
     return _finish(errors)
 
@@ -66,6 +78,19 @@ def _load_schemas(errors: list[str]) -> dict[Path, dict[str, Any]]:
         if schemas[path].get("$schema") != "https://json-schema.org/draft/2020-12/schema":
             errors.append(f"{path.relative_to(ROOT)} must use JSON Schema Draft 2020-12")
     return schemas
+
+
+def _validate_status_schema_contract(schemas: dict[Path, dict[str, Any]], errors: list[str]) -> None:
+    record_schema = schemas[SCHEMA_DIR / "current_fact_record.schema.json"]
+    export_schema = schemas[SCHEMA_DIR / "current_fact_export.schema.json"]
+    status_property = record_schema.get("properties", {}).get("calculation_input_status", {})
+    if set(status_property.get("enum", [])) != CALCULATION_INPUT_STATUSES:
+        errors.append("current_fact_record.schema.json calculation_input_status enum does not match approved statuses")
+    if "calculation_input_status" not in record_schema.get("required", []):
+        errors.append("current_fact_record.schema.json must require calculation_input_status")
+    version = export_schema.get("properties", {}).get("artifact_schema_version", {}).get("const")
+    if version != "current_fact_export/v2":
+        errors.append("current_fact_export.schema.json must use artifact_schema_version current_fact_export/v2")
 
 
 def _validate_valid_fixtures(validator: Draft202012Validator, directory: Path, errors: list[str]) -> None:

--- a/tests/validation/validate_parsed_value_classifier.py
+++ b/tests/validation/validate_parsed_value_classifier.py
@@ -366,6 +366,7 @@ def _record(
 ) -> dict[str, Any]:
     payload = {
         "authority_status": authority_status,
+        "calculation_input_status": result.calculation_input_status,
         "character_slug": character_slug,
         "display_label_ja": display_label_ja,
         "evidence": {


### PR DESCRIPTION
## Summary
- Add required top-level `calculation_input_status` to current-fact records with the approved closed eight-value enum.
- Bump current-fact export schema to `current_fact_export/v2`, require `parsed_value` in lookup-ready export records, and reject legacy raw export paths in `generated_from`.
- Update current-fact fixtures and focused validators, including parsed-value classifier compatibility records, to carry the status field.

## Validation
- git diff --check
- git diff --cached --check
- uv lock --check
- PYTHONPATH=src uv run --locked python -m unittest discover -s tests
- for f in tests/validation/validate_*.py; do PYTHONPATH=src uv run --locked python "$f" || exit $?; done
- PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate

## Scope
- Schema/status carrier implementation only.
- No export generator, generated current-fact export artifact, runtime lookup switch, current_facts.py/answering.py changes, parser/classifier behavior change, retrieval/answer/calculator/SymPy/live acquisition changes.