### PR TITLE
Implement current-fact source-record input schema

### DIFF
--- a/contracts/current-facts/current_fact_source_record_input.schema.json
+++ b/contracts/current-facts/current_fact_source_record_input.schema.json
@@ -1,0 +1,250 @@
+{
+  "$id": "https://sf6-knowledge-coach.local/schemas/current-facts/current_fact_source_record_input.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "artifact_schema_version": { "const": "current_fact_source_record_input/v1" },
+    "authority_boundary": {
+      "additionalProperties": false,
+      "properties": {
+        "official": { "const": "authority_candidate_only" },
+        "supercombo": { "const": "enrichment_or_cross_reference_only" }
+      },
+      "required": ["official", "supercombo"],
+      "type": "object"
+    },
+    "generated_from": {
+      "items": { "$ref": "#/$defs/public_artifact_path" },
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "records": {
+      "items": { "$ref": "#/$defs/source_record" },
+      "minItems": 1,
+      "type": "array"
+    },
+    "run_id": {
+      "pattern": "^[0-9]{8}T[0-9]{6}Z$",
+      "type": "string"
+    },
+    "source_record_boundary": {
+      "additionalProperties": false,
+      "properties": {
+        "blocked_records": { "const": "excluded_to_classifier_or_source_review" },
+        "legacy_raw_exports": { "const": "excluded_as_source_input" },
+        "local_source_payloads": { "const": "excluded_from_public_artifact" },
+        "lookup_ready_records": { "const": "parsed_value_only" },
+        "reviewer_observations": { "const": "observation_candidate_only_not_authority" },
+        "supercombo": { "const": "enrichment_or_cross_reference_only" }
+      },
+      "required": [
+        "blocked_records",
+        "legacy_raw_exports",
+        "local_source_payloads",
+        "lookup_ready_records",
+        "reviewer_observations",
+        "supercombo"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "artifact_schema_version",
+    "authority_boundary",
+    "generated_from",
+    "records",
+    "run_id",
+    "source_record_boundary"
+  ],
+  "$defs": {
+    "identity_key": {
+      "pattern": "^[a-z0-9][a-z0-9_.:-]*$",
+      "type": "string"
+    },
+    "public_artifact_path": {
+      "allOf": [
+        {
+          "pattern": "^(data|docs|contracts)/[A-Za-z0-9_.:/-]+$",
+          "type": "string"
+        },
+        {
+          "not": { "pattern": "^data/exports/" }
+        },
+        {
+          "not": { "pattern": "(^|/)\\.local(/|$)" }
+        }
+      ]
+    },
+    "source_record": {
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "current_fact_record": {
+                "properties": {
+                  "calculation_input_status": {
+                    "const": "annotated_candidate_not_calculation_safe"
+                  }
+                },
+                "required": ["calculation_input_status"]
+              }
+            },
+            "required": ["current_fact_record"]
+          },
+          "then": {
+            "properties": {
+              "current_fact_record": {
+                "properties": {
+                  "parsed_value": {
+                    "properties": {
+                      "kind": { "const": "annotated_numeric_candidate" }
+                    },
+                    "required": ["kind"],
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "current_fact_record": {
+                "properties": {
+                  "calculation_input_status": {
+                    "const": "parsed_range_not_single_value_calculation_safe"
+                  }
+                },
+                "required": ["calculation_input_status"]
+              }
+            },
+            "required": ["current_fact_record"]
+          },
+          "then": {
+            "properties": {
+              "current_fact_record": {
+                "properties": {
+                  "parsed_value": {
+                    "properties": {
+                      "kind": { "const": "frame_range" }
+                    },
+                    "required": ["kind"],
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "current_fact_record": {
+                "properties": {
+                  "source_name": { "const": "supercombo" }
+                },
+                "required": ["source_name"]
+              }
+            },
+            "required": ["current_fact_record"]
+          },
+          "then": {
+            "properties": {
+              "current_fact_record": {
+                "properties": {
+                  "calculation_input_status": {
+                    "not": {
+                      "const": "eligible_only_after_domain_source_and_unit_checks"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "properties": {
+        "current_fact_record": {
+          "allOf": [
+            {
+              "$ref": "https://sf6-knowledge-coach.local/schemas/current-facts/current_fact_record.schema.json"
+            },
+            {
+              "required": ["parsed_value"],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "calculation_input_status": {
+                  "not": {
+                    "enum": [
+                      "review_required_not_calculation_safe",
+                      "out_of_scope_not_emitted"
+                    ]
+                  }
+                },
+                "evidence": {
+                  "properties": {
+                    "public_reference": {
+                      "$ref": "#/$defs/public_artifact_path"
+                    }
+                  },
+                  "type": "object"
+                },
+                "raw_value": {
+                  "not": {
+                    "pattern": "<html|</html|<!doctype|<table|</table|<tr|</tr|<td|</td|<th|</th"
+                  }
+                }
+              },
+              "type": "object"
+            }
+          ]
+        },
+        "raw_value_length": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "raw_value_sha256": {
+          "pattern": "^[a-f0-9]{64}$",
+          "type": "string"
+        },
+        "source_cell_key": { "$ref": "#/$defs/identity_key" },
+        "source_cell_order": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "source_header_path": {
+          "items": { "type": "string" },
+          "minItems": 1,
+          "type": "array"
+        },
+        "source_record_id": { "$ref": "#/$defs/identity_key" },
+        "source_row_key": { "$ref": "#/$defs/identity_key" },
+        "source_row_order": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "source_value_key": { "$ref": "#/$defs/identity_key" }
+      },
+      "required": [
+        "current_fact_record",
+        "raw_value_length",
+        "raw_value_sha256",
+        "source_cell_key",
+        "source_cell_order",
+        "source_header_path",
+        "source_record_id",
+        "source_row_key",
+        "source_row_order",
+        "source_value_key"
+      ],
+      "type": "object"
+    }
+  },
+  "title": "Current-fact source-record input artifact",
+  "type": "object"
+}

--- a/data/validator-audits/20260523-validator-test-fact-source-audit.json
+++ b/data/validator-audits/20260523-validator-test-fact-source-audit.json
@@ -108,7 +108,8 @@
         "docs/PLAN.md",
         "AGENTS.md",
         "clean-slate ExecPlans",
-        "current-fact JSON Schema artifacts ExecPlan"
+        "current-fact JSON Schema artifacts ExecPlan",
+        "current-fact source-record input artifact ExecPlan"
       ],
       "status": "accepted_with_limits"
     },
@@ -122,6 +123,19 @@
         "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
         "annotated numeric candidate consumer guard implementation ExecPlan",
         "frame range consumer guard ExecPlan"
+      ],
+      "status": "accepted_with_limits"
+    },
+    {
+      "evidence_class": "synthetic_contract",
+      "file": "tests/validation/validate_current_fact_source_records.py",
+      "limitations": [
+        "checks source-record schema, fixture contracts, and source-boundary guard mutations; does not produce production source records or prove source truth"
+      ],
+      "primary_evidence": [
+        "contracts/current-facts/current_fact_source_record_input.schema.json",
+        "tests/fixtures/current-facts/source-records",
+        "current-fact source-record input artifact ExecPlan"
       ],
       "status": "accepted_with_limits"
     },

--- a/docs/execplans/2026-05-25-current-fact-source-record-input-artifact.md
+++ b/docs/execplans/2026-05-25-current-fact-source-record-input-artifact.md
@@ -1,13 +1,15 @@
 # Current-Fact Source-Record Input Artifact
 
-Status: Drafted for review; validation passed.
+Status: Implemented; validation passed.
 
 ## Purpose
 
 Define the reviewed row/move/cell-level source-record input artifact required
 before production `current_fact_export/v2` generation.
 
-This plan is docs-only. It does not implement source-record extraction,
+The original planning PR was docs-only. This implementation follow-up is
+limited to the schema, fixtures, focused validator, validator audit update, and
+this ExecPlan progress update. It does not implement source-record extraction,
 generator code, generated artifacts, runtime lookup, answer behavior,
 parser/classifier behavior, retrieval, calculators, SymPy logic, or live
 acquisition.
@@ -427,15 +429,22 @@ Intended future sequence:
 
 ## Files / Interfaces
 
-This docs-only plan changes only:
+The original docs-only plan changed only:
 
 - `docs/execplans/2026-05-25-current-fact-source-record-input-artifact.md`
 
-Future implementation plans may touch, after review:
+This schema/fixtures/validators implementation touches only:
 
 - `contracts/current-facts/current_fact_source_record_input.schema.json`;
 - focused source-record fixtures under `tests/fixtures/current-facts/`;
-- focused validators under `tests/validation/`;
+- `tests/validation/validate_current_fact_source_records.py`;
+- `tests/validation/validate_clean_slate.py`, limited to approving the new
+  contract file in the clean-slate contract inventory;
+- validator audit artifacts;
+- this ExecPlan.
+
+Future implementation plans may touch, after review:
+
 - source-record generation code only if a later ExecPlan approves it;
 - `data/current-facts/source-records/` and
   `docs/current-facts/source-records/` artifacts only after schema/validator
@@ -450,11 +459,15 @@ Run from repository root:
 
 ```bash
 git diff --check
+git diff --cached --check
 uv lock --check
+PYTHONPATH=src uv run --locked python -m unittest discover -s tests
 PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
 PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py
 PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py
 PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_validator_test_audit.py
 git status --short --branch
 ```
 
@@ -475,7 +488,33 @@ git status --short --branch
   `uv lock --check`, clean-slate validator, current-fact schema validator,
   current-fact consumer guard validator, parsed-value classifier coverage
   validator, and `git status --short --branch`.
-- [ ] Complete mandatory review.
+- [x] (2026-05-25 JST) PR #356 mandatory review passed and was merged with
+  normal merge commit `ef57790964e4bf31a39788532b76d587b0d9a734`.
+- [x] (2026-05-25 JST) Created branch
+  `impl/current-fact-source-record-input-schema` from updated `main`.
+- [x] (2026-05-25 JST) Implemented
+  `current_fact_source_record_input/v1` schema with reviewed public
+  `generated_from`, source-record identity, nested lookup-ready
+  current-fact-record payloads, parsed-value-only admission, no
+  review-required/out-of-scope lookup records, no SuperCombo scalar authority,
+  no flattened annotated candidates, and no collapsed frame ranges.
+- [x] (2026-05-25 JST) Added focused source-record fixtures for valid scalar,
+  annotated candidate, and frame-range records plus invalid legacy-source,
+  review-required, flattened annotated, collapsed range, and SuperCombo scalar
+  authority cases.
+- [x] (2026-05-25 JST) Added focused source-record validator covering schema,
+  fixture, semantic identity, public source-boundary, privacy mutation, guard,
+  and authority checks.
+- [x] (2026-05-25 JST) Updated validator audit artifacts for the new focused
+  validator.
+- [x] (2026-05-25 JST) Updated clean-slate contract inventory to recognize
+  `contracts/current-facts/current_fact_source_record_input.schema.json`.
+- [x] (2026-05-25 JST) Full implementation validation passed: `git diff
+  --check`, `git diff --cached --check`, `uv lock --check`, unittest,
+  clean-slate validator, current-fact schema validator, current-fact consumer
+  guard validator, parsed-value classifier validator, source-record validator,
+  validator audit validator, and `git status --short --branch`.
+- [ ] Complete implementation mandatory review.
 
 ## Decision Log
 
@@ -511,79 +550,104 @@ git status --short --branch
   Rationale: Source-record input is evidence/status plumbing, not arithmetic.
   Date/Author: 2026-05-25 / Codex
 
+- Decision: Model source-record identity as sidecar fields around a nested
+  `current_fact_record` payload.
+  Rationale: The input artifact needs row/cell/value identity, while the
+  final `current_fact_export/v2` records must remain compatible with the
+  existing current-fact record schema.
+  Date/Author: 2026-05-25 / Codex
+
+- Decision: Keep raw-source privacy checks partly semantic instead of encoding
+  every forbidden reviewer-support term into JSON Schema.
+  Rationale: The schema handles structural public paths and legacy raw export
+  rejection; the focused validator can check reviewer-only paths, raw source
+  markers, hash/length, and cross-field identity without adding noisy public
+  schema strings.
+  Date/Author: 2026-05-25 / Codex
+
+- Decision: Update the clean-slate contract inventory for the new schema file.
+  Rationale: Adding an approved contract file is a repository-shape change;
+  the governance validator must recognize it without broadening unrelated
+  paths.
+  Date/Author: 2026-05-25 / Codex
+
 ## Deviations
 
 - None.
 
 ## Remaining Risks
 
-- Exact source-record schema field names need implementation review.
+- Exact source-record schema field names still need mandatory review.
 - A production source-record artifact still does not exist.
 - The first production source-record artifact may have limited coverage because
   it admits only records with reviewed `parsed_value`.
 - Runtime lookup remains legacy raw export backed.
 - Export generator, lookup parity, rollback criteria, and legacy raw export
   retirement remain future work.
+- Source-record generation code is not implemented.
 
 ## Completion Review Table
 
 | PLAN item | Implementation | Changed files | Validation command | Result | Deviation | Incomplete | Risk |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Docs-only source-record plan | Drafted source-record input artifact plan, path/schema direction, input boundaries, identity requirements, admission rules, carry-forward rules, validators, and retirement boundary | `docs/execplans/2026-05-25-current-fact-source-record-input-artifact.md` | `git diff --check`; `uv lock --check`; clean-slate validator; current-fact schema validator; current-fact guard validator; parsed-value classifier validator; `git status --short --branch` | Passed | None | Review pending | Production source-record artifact missing |
-| Artifact path/schema direction | Planned `data/current-facts/source-records/<run_id>-current-fact-source-records.json`, optional Markdown summary, and future `current_fact_source_record_input/v1` schema | This ExecPlan only | Diff/status review | Passed | None | Review pending | Schema implementation still future work |
-| Parsed-value-only admission | Required lookup-ready source records to include `parsed_value` and top-level `calculation_input_status`; blocked no-parsed records remain in classifier/source-review artifacts | This ExecPlan only | Diff/status review | Passed | None | Review pending | Coverage limited by parsed-value availability |
-| Guard/privacy/source boundary | Required no flattened annotated candidates, no collapsed frame ranges, reviewed public evidence only, and privacy/source-boundary validators | This ExecPlan only | Diff/status review | Passed | None | Review pending | Validator implementation still future work |
-| Runtime/generator exclusion | Kept current-fact export generation, runtime lookup, answers, retrieval, calculators, SymPy, live acquisition, and parser/classifier expansion out of scope | This ExecPlan only | Diff/status review | Passed | None | Review pending | Runtime remains legacy raw backed |
+| Docs-only source-record plan | Drafted source-record input artifact plan, path/schema direction, input boundaries, identity requirements, admission rules, carry-forward rules, validators, and retirement boundary | `docs/execplans/2026-05-25-current-fact-source-record-input-artifact.md` | `git diff --check`; `uv lock --check`; clean-slate validator; current-fact schema validator; current-fact guard validator; parsed-value classifier validator; `git status --short --branch` | Passed | None | Review complete via PR #356 | Production source-record artifact missing |
+| Source-record schema | Added `current_fact_source_record_input/v1` schema with reviewed public source paths, source-record sidecar identity, nested current-fact payloads, parsed-value-only lookup-ready records, and non-scalar guard conditions | `contracts/current-facts/current_fact_source_record_input.schema.json` | Source-record validator; current-fact schema validator | Passed | None | Review pending | Field names need mandatory review |
+| Source-record fixtures | Added focused valid and invalid fixture artifacts for scalar, annotated candidate, frame range, legacy source, review-required, flattened annotated, collapsed range, and SuperCombo scalar authority cases | `tests/fixtures/current-facts/source-records/**` | Source-record validator; current-fact schema validator | Passed | None | Review pending | Synthetic fixtures do not prove source truth |
+| Focused source-record validator | Added validator for schema validity, valid/invalid fixtures, hash/length identity, header/evidence carry-forward, public source boundary, privacy mutations, guard behavior, and SuperCombo scalar rejection | `tests/validation/validate_current_fact_source_records.py` | Source-record validator; validator audit | Passed | None | Review pending | Production artifact validation remains future work |
+| Clean-slate contract inventory | Added the new source-record schema file to the approved contracts inventory | `tests/validation/validate_clean_slate.py` | Clean-slate validator; validator audit | Passed | None | Review pending | Governance whitelist only; no runtime behavior |
+| Validator audit | Added evidence-boundary audit entry for the new focused validator | `data/validator-audits/20260523-validator-test-fact-source-audit.json`; `docs/validator-audits/20260523-validator-test-fact-source-audit.md` | Validator audit validator | Passed | None | Review pending | Audit is boundary metadata only |
+| Parsed-value-only admission | Required lookup-ready source records to include `parsed_value` and top-level `calculation_input_status`; blocked no-parsed records remain in classifier/source-review artifacts | Schema, fixtures, validator, this ExecPlan | Source-record validator | Passed | None | Review pending | Coverage limited by parsed-value availability |
+| Guard/privacy/source boundary | Required no flattened annotated candidates, no collapsed frame ranges, reviewed public evidence only, and privacy/source-boundary validators | Schema, fixtures, validator, this ExecPlan | Source-record validator; current-fact guard validator | Passed | None | Review pending | Future generators must call equivalent checks |
+| Runtime/generator exclusion | Kept current-fact export generation, runtime lookup, answers, retrieval, calculators, SymPy, live acquisition, and parser/classifier expansion out of scope | No runtime/generator files changed | Diff/status review | Passed | None | Review pending | Runtime remains legacy raw backed |
 
 ## Next Reviewer Prompt
 
 ```text
-Review docs/execplans/2026-05-25-current-fact-source-record-input-artifact.md.
+Review the source-record input schema/fixtures/validators implementation.
 
 Check:
-- PR diff contains exactly one ExecPlan file.
-- Plan is docs-only and does not implement source-record extraction,
-  generator code, generated artifacts, runtime lookup, answer behavior,
-  parser/classifier behavior, retrieval, calculator, SymPy, or live
-  acquisition.
-- Artifact path is
-  data/current-facts/source-records/<run_id>-current-fact-source-records.json
-  with optional docs/current-facts/source-records/<run_id>-current-fact-source-records.md.
-- Future schema/version direction is
-  contracts/current-facts/current_fact_source_record_input.schema.json with
-  artifact_schema_version current_fact_source_record_input/v1.
-- Allowed inputs are reviewed public artifacts only.
-- Excluded inputs include legacy data/exports/<character>/official_raw.json,
-  .local, raw HTML, screenshots/VLM as authority, private data, and SuperCombo
-  numeric authority.
-- Row/move/cell identity requirements are defined without publishing full raw
-  rows or raw HTML.
-- Required fields include character_slug, move_id, field_key,
-  display_label_ja, raw_value, parsed_value, value_shape, source_name,
-  source_role, source_family, source_label, source_header_path, evidence,
-  authority_status, and calculation_input_status.
-- Lookup-ready source records are parsed-value-only.
-- Blocked/review-required records remain in classifier/source-review artifacts
-  unless a later plan approves a separate metadata artifact.
-- Source/evidence/authority/status carry-forward rules do not promote
+- PR diff is limited to source-record schema, focused fixtures, focused
+  validator, clean-slate contract inventory update, validator audit artifacts,
+  and this ExecPlan.
+- `current_fact_source_record_input.schema.json` defines
+  `current_fact_source_record_input/v1`.
+- Generated source paths and evidence paths reject legacy
+  `data/exports/*`, `.local`, reviewer-only paths, local paths, raw-source
+  markers, and private/debug/log paths through schema or focused validator.
+- Lookup-ready source records carry nested current-fact payloads with
+  `parsed_value` and top-level `calculation_input_status`.
+- Blocked/review-required and out-of-scope records are rejected from
+  lookup-ready source-record fixtures.
+- Source-record identity fields preserve row/cell/value identity without full
+  raw rows or raw HTML.
+- `raw_value` is preserved exactly and hash/length validation matches it.
+- Source/evidence/header fields carry forward consistently and do not promote
   authority.
-- Privacy/source-boundary validators are evidence-first.
-- Guard checks require no flattened annotated_numeric_candidate and no
-  collapsed frame_range.
-- Issue #343 screenshot plus ChatGPT/VLM double-check gate remains required
-  for new value semantics decisions.
-- Legacy raw export retirement boundary is preserved.
+- `annotated_numeric_candidate` is not flattened.
+- `frame_range` is not collapsed.
+- SuperCombo scalar calculation authority is rejected.
+- No production source-record artifact is generated under
+  `data/current-facts/source-records/`.
+- No current-fact export artifact is generated under `data/current-facts/`.
+- No source-record extraction, export generator, runtime lookup,
+  `current_facts.py`, `answering.py`, parser/classifier expansion, retrieval,
+  answer, calculator, SymPy, or live acquisition changes are included.
+- Validator audit updates are evidence-first and boundary-based.
 
 Run:
 - git status --short --branch
 - git show --name-status --oneline --no-renames HEAD
 - git diff --check origin/main...HEAD
+- git diff --cached --check
 - uv lock --check
+- PYTHONPATH=src uv run --locked python -m unittest discover -s tests
 - PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
 - PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py
 - PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py
 - PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_validator_test_audit.py
 
 Return blocking findings first, validation results, PLAN deviations,
-remaining risks, and whether docs-only stage/commit is approved.
+remaining risks, and whether the implementation is stage-ready.
 ```

--- a/docs/validator-audits/20260523-validator-test-fact-source-audit.md
+++ b/docs/validator-audits/20260523-validator-test-fact-source-audit.md
@@ -21,8 +21,9 @@ privacy/security boundary.
 | `tests/test_value_shape_disposition.py` | artifact consistency | accepted with limits | disposition coverage is not parse semantics |
 | `tests/test_parsed_value_classifier.py` | policy-derived | accepted with limits | parser/classifier behavior is policy-derived and not calculation correctness |
 | `tests/test_value_shape_inventory.py` | source-derived | accepted with limits | representative shape checks are not parser semantics |
-| `tests/validation/validate_clean_slate.py` | governance boundary | accepted with limits | repo shape only |
+| `tests/validation/validate_clean_slate.py` | governance boundary | accepted with limits | repo shape and approved contract file inventory only |
 | `tests/validation/validate_current_fact_consumer_guards.py` | artifact consistency | accepted with limits | guard behavior against synthetic fixtures and coverage statuses only |
+| `tests/validation/validate_current_fact_source_records.py` | synthetic contract | accepted with limits | source-record schema, fixture contracts, and source-boundary guard mutations only; no production source records or source truth |
 | `tests/validation/validate_current_fact_schemas.py` | synthetic contract | accepted with limits | schema and fixture contracts only; no parser/source truth |
 | `tests/validation/validate_official_note_linkage_source_review.py` | source-derived | accepted with limits | source-review summary; full row-note context remains ignored local evidence |
 | `tests/validation/validate_parsed_value_classifier.py` | artifact consistency | accepted with limits | coverage artifact, mechanics anchors, and schema-compatible samples only |

--- a/tests/fixtures/current-facts/source-records/invalid/current_fact_source_record_input_collapsed_frame_range.json
+++ b/tests/fixtures/current-facts/source-records/invalid/current_fact_source_record_input_collapsed_frame_range.json
@@ -1,0 +1,66 @@
+{
+  "artifact_schema_version": "current_fact_source_record_input/v1",
+  "authority_boundary": {
+    "official": "authority_candidate_only",
+    "supercombo": "enrichment_or_cross_reference_only"
+  },
+  "generated_from": [
+    "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+  ],
+  "records": [
+    {
+      "current_fact_record": {
+        "authority_status": "authority_candidate",
+        "calculation_input_status": "parsed_range_not_single_value_calculation_safe",
+        "character_slug": "jp",
+        "display_label_ja": "持続",
+        "evidence": {
+          "evidence_basis": "value_shape_policy",
+          "public_reference": "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+          "run_id": "20260521T025403Z",
+          "source_header_path": ["動作フレーム", "持続"],
+          "source_label": "持続",
+          "source_name": "official",
+          "source_role": "authority_candidate"
+        },
+        "field_key": "active",
+        "move_id": "jp_001_5lp",
+        "parsed_value": {
+          "kind": "signed_frame",
+          "unit": "frame",
+          "value": 6
+        },
+        "raw_value": "6-8",
+        "record_id": "official:jp:jp_001_5lp:active",
+        "source_family": "timing",
+        "source_header_path": ["動作フレーム", "持続"],
+        "source_label": "持続",
+        "source_name": "official",
+        "source_role": "authority_candidate",
+        "value_shape": {
+          "classes": ["range"],
+          "classifier_status": "parsed",
+          "parser_rule_id": "frame_range.v1"
+        }
+      },
+      "raw_value_length": 3,
+      "raw_value_sha256": "742595dc2605b1b9ded786a8b24f3ec0fddb44d49a77bb7186d3090411fb4e9f",
+      "source_cell_key": "official:jp:jp_001_5lp:active:cell",
+      "source_cell_order": 2,
+      "source_header_path": ["動作フレーム", "持続"],
+      "source_record_id": "source-record:official:jp:jp_001_5lp:active",
+      "source_row_key": "official:jp:jp_001_5lp",
+      "source_row_order": 1,
+      "source_value_key": "official:jp:jp_001_5lp:active:value-1"
+    }
+  ],
+  "run_id": "20260521T025403Z",
+  "source_record_boundary": {
+    "blocked_records": "excluded_to_classifier_or_source_review",
+    "legacy_raw_exports": "excluded_as_source_input",
+    "local_source_payloads": "excluded_from_public_artifact",
+    "lookup_ready_records": "parsed_value_only",
+    "reviewer_observations": "observation_candidate_only_not_authority",
+    "supercombo": "enrichment_or_cross_reference_only"
+  }
+}

--- a/tests/fixtures/current-facts/source-records/invalid/current_fact_source_record_input_flattened_annotated_candidate.json
+++ b/tests/fixtures/current-facts/source-records/invalid/current_fact_source_record_input_flattened_annotated_candidate.json
@@ -1,0 +1,66 @@
+{
+  "artifact_schema_version": "current_fact_source_record_input/v1",
+  "authority_boundary": {
+    "official": "authority_candidate_only",
+    "supercombo": "enrichment_or_cross_reference_only"
+  },
+  "generated_from": [
+    "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+  ],
+  "records": [
+    {
+      "current_fact_record": {
+        "authority_status": "authority_candidate",
+        "calculation_input_status": "annotated_candidate_not_calculation_safe",
+        "character_slug": "jp",
+        "display_label_ja": "ガード硬直差",
+        "evidence": {
+          "evidence_basis": "value_shape_policy",
+          "public_reference": "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+          "run_id": "20260521T025403Z",
+          "source_header_path": ["硬直差", "ガード"],
+          "source_label": "ガード",
+          "source_name": "official",
+          "source_role": "authority_candidate"
+        },
+        "field_key": "block_advantage",
+        "move_id": "jp_001_5lk",
+        "parsed_value": {
+          "kind": "signed_frame",
+          "unit": "frame",
+          "value": -4
+        },
+        "raw_value": "※-4",
+        "record_id": "official:jp:jp_001_5lk:block_advantage:annotated",
+        "source_family": "advantage",
+        "source_header_path": ["硬直差", "ガード"],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate",
+        "value_shape": {
+          "classes": ["note_prefixed", "signed_frame"],
+          "classifier_status": "parsed",
+          "parser_rule_id": "annotated_numeric_candidate.official_note_marker.v1"
+        }
+      },
+      "raw_value_length": 3,
+      "raw_value_sha256": "b5112d05eab37a8ef2062523ba1cce640a8350c6cba7ef40bf66072550f3609c",
+      "source_cell_key": "official:jp:jp_001_5lk:block_advantage:cell",
+      "source_cell_order": 4,
+      "source_header_path": ["硬直差", "ガード"],
+      "source_record_id": "source-record:official:jp:jp_001_5lk:block_advantage:annotated",
+      "source_row_key": "official:jp:jp_001_5lk",
+      "source_row_order": 2,
+      "source_value_key": "official:jp:jp_001_5lk:block_advantage:value-1"
+    }
+  ],
+  "run_id": "20260521T025403Z",
+  "source_record_boundary": {
+    "blocked_records": "excluded_to_classifier_or_source_review",
+    "legacy_raw_exports": "excluded_as_source_input",
+    "local_source_payloads": "excluded_from_public_artifact",
+    "lookup_ready_records": "parsed_value_only",
+    "reviewer_observations": "observation_candidate_only_not_authority",
+    "supercombo": "enrichment_or_cross_reference_only"
+  }
+}

--- a/tests/fixtures/current-facts/source-records/invalid/current_fact_source_record_input_legacy_generated_from.json
+++ b/tests/fixtures/current-facts/source-records/invalid/current_fact_source_record_input_legacy_generated_from.json
@@ -1,0 +1,66 @@
+{
+  "artifact_schema_version": "current_fact_source_record_input/v1",
+  "authority_boundary": {
+    "official": "authority_candidate_only",
+    "supercombo": "enrichment_or_cross_reference_only"
+  },
+  "generated_from": [
+    "data/exports/jp/official_raw.json"
+  ],
+  "records": [
+    {
+      "current_fact_record": {
+        "authority_status": "authority_candidate",
+        "calculation_input_status": "eligible_only_after_domain_source_and_unit_checks",
+        "character_slug": "jp",
+        "display_label_ja": "ガード硬直差",
+        "evidence": {
+          "evidence_basis": "value_shape_policy",
+          "public_reference": "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+          "run_id": "20260521T025403Z",
+          "source_header_path": ["硬直差", "ガード"],
+          "source_label": "ガード",
+          "source_name": "official",
+          "source_role": "authority_candidate"
+        },
+        "field_key": "block_advantage",
+        "move_id": "jp_001_5lp",
+        "parsed_value": {
+          "kind": "signed_frame",
+          "unit": "frame",
+          "value": -2
+        },
+        "raw_value": "-2",
+        "record_id": "official:jp:jp_001_5lp:block_advantage",
+        "source_family": "advantage",
+        "source_header_path": ["硬直差", "ガード"],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate",
+        "value_shape": {
+          "classes": ["signed_frame"],
+          "classifier_status": "parsed",
+          "parser_rule_id": "signed_frame.v1"
+        }
+      },
+      "raw_value_length": 2,
+      "raw_value_sha256": "cf3bae39dd692048a8bf961182e6a34dfd323eeb0748e162eaf055107f1cb873",
+      "source_cell_key": "official:jp:jp_001_5lp:block_advantage:cell",
+      "source_cell_order": 4,
+      "source_header_path": ["硬直差", "ガード"],
+      "source_record_id": "source-record:official:jp:jp_001_5lp:block_advantage",
+      "source_row_key": "official:jp:jp_001_5lp",
+      "source_row_order": 1,
+      "source_value_key": "official:jp:jp_001_5lp:block_advantage:value-1"
+    }
+  ],
+  "run_id": "20260521T025403Z",
+  "source_record_boundary": {
+    "blocked_records": "excluded_to_classifier_or_source_review",
+    "legacy_raw_exports": "excluded_as_source_input",
+    "local_source_payloads": "excluded_from_public_artifact",
+    "lookup_ready_records": "parsed_value_only",
+    "reviewer_observations": "observation_candidate_only_not_authority",
+    "supercombo": "enrichment_or_cross_reference_only"
+  }
+}

--- a/tests/fixtures/current-facts/source-records/invalid/current_fact_source_record_input_review_required_record.json
+++ b/tests/fixtures/current-facts/source-records/invalid/current_fact_source_record_input_review_required_record.json
@@ -1,0 +1,61 @@
+{
+  "artifact_schema_version": "current_fact_source_record_input/v1",
+  "authority_boundary": {
+    "official": "authority_candidate_only",
+    "supercombo": "enrichment_or_cross_reference_only"
+  },
+  "generated_from": [
+    "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+  ],
+  "records": [
+    {
+      "current_fact_record": {
+        "authority_status": "authority_candidate",
+        "calculation_input_status": "review_required_not_calculation_safe",
+        "character_slug": "jp",
+        "display_label_ja": "コンボ補正",
+        "evidence": {
+          "evidence_basis": "value_shape_policy",
+          "public_reference": "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+          "run_id": "20260521T025403Z",
+          "source_header_path": ["コンボ補正"],
+          "source_label": "コンボ補正",
+          "source_name": "official",
+          "source_role": "authority_candidate"
+        },
+        "field_key": "combo_scaling",
+        "move_id": "jp_001_5lp",
+        "raw_value": "始動補正20%",
+        "record_id": "official:jp:jp_001_5lp:combo_scaling:review_required",
+        "source_family": "scaling",
+        "source_header_path": ["コンボ補正"],
+        "source_label": "コンボ補正",
+        "source_name": "official",
+        "source_role": "authority_candidate",
+        "value_shape": {
+          "classes": ["percent_expression", "prose"],
+          "classifier_status": "review_required",
+          "review_item_id": "value-shape:official--unclassified_expression--combo-scaling"
+        }
+      },
+      "raw_value_length": 7,
+      "raw_value_sha256": "93aa1eb1357636c07557682963b2ba8e51f4ef4f333ea3875c14eee83c94438d",
+      "source_cell_key": "official:jp:jp_001_5lp:combo_scaling:cell",
+      "source_cell_order": 7,
+      "source_header_path": ["コンボ補正"],
+      "source_record_id": "source-record:official:jp:jp_001_5lp:combo_scaling:review_required",
+      "source_row_key": "official:jp:jp_001_5lp",
+      "source_row_order": 1,
+      "source_value_key": "official:jp:jp_001_5lp:combo_scaling:value-1"
+    }
+  ],
+  "run_id": "20260521T025403Z",
+  "source_record_boundary": {
+    "blocked_records": "excluded_to_classifier_or_source_review",
+    "legacy_raw_exports": "excluded_as_source_input",
+    "local_source_payloads": "excluded_from_public_artifact",
+    "lookup_ready_records": "parsed_value_only",
+    "reviewer_observations": "observation_candidate_only_not_authority",
+    "supercombo": "enrichment_or_cross_reference_only"
+  }
+}

--- a/tests/fixtures/current-facts/source-records/invalid/current_fact_source_record_input_supercombo_scalar_authority.json
+++ b/tests/fixtures/current-facts/source-records/invalid/current_fact_source_record_input_supercombo_scalar_authority.json
@@ -1,0 +1,66 @@
+{
+  "artifact_schema_version": "current_fact_source_record_input/v1",
+  "authority_boundary": {
+    "official": "authority_candidate_only",
+    "supercombo": "enrichment_or_cross_reference_only"
+  },
+  "generated_from": [
+    "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+  ],
+  "records": [
+    {
+      "current_fact_record": {
+        "authority_status": "cross_reference_candidate",
+        "calculation_input_status": "eligible_only_after_domain_source_and_unit_checks",
+        "character_slug": "jp",
+        "display_label_ja": "SuperCombo ガード硬直差",
+        "evidence": {
+          "evidence_basis": "value_shape_policy",
+          "public_reference": "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+          "run_id": "20260521T025403Z",
+          "source_header_path": ["Special Moves", "Block Advantage"],
+          "source_label": "Block Advantage",
+          "source_name": "supercombo",
+          "source_role": "cross_reference_candidate"
+        },
+        "field_key": "block_advantage",
+        "move_id": "synthetic:supercombo:example_special",
+        "parsed_value": {
+          "kind": "signed_frame",
+          "unit": "frame",
+          "value": -4
+        },
+        "raw_value": "-4",
+        "record_id": "synthetic:supercombo:example_special:block_advantage",
+        "source_family": "advantage",
+        "source_header_path": ["Special Moves", "Block Advantage"],
+        "source_label": "Block Advantage",
+        "source_name": "supercombo",
+        "source_role": "cross_reference_candidate",
+        "value_shape": {
+          "classes": ["signed_frame"],
+          "classifier_status": "parsed",
+          "parser_rule_id": "signed_frame.v1"
+        }
+      },
+      "raw_value_length": 2,
+      "raw_value_sha256": "e5e0093f285a4fb94c3fcc2ad7fd04edd10d429ccda87a9aa5e4718efadf182e",
+      "source_cell_key": "supercombo:jp:example_special:block_advantage:cell",
+      "source_cell_order": 3,
+      "source_header_path": ["Special Moves", "Block Advantage"],
+      "source_record_id": "source-record:supercombo:jp:example_special:block_advantage",
+      "source_row_key": "supercombo:jp:example_special",
+      "source_row_order": 1,
+      "source_value_key": "supercombo:jp:example_special:block_advantage:value-1"
+    }
+  ],
+  "run_id": "20260521T025403Z",
+  "source_record_boundary": {
+    "blocked_records": "excluded_to_classifier_or_source_review",
+    "legacy_raw_exports": "excluded_as_source_input",
+    "local_source_payloads": "excluded_from_public_artifact",
+    "lookup_ready_records": "parsed_value_only",
+    "reviewer_observations": "observation_candidate_only_not_authority",
+    "supercombo": "enrichment_or_cross_reference_only"
+  }
+}

--- a/tests/fixtures/current-facts/source-records/valid/current_fact_source_record_input_minimal.json
+++ b/tests/fixtures/current-facts/source-records/valid/current_fact_source_record_input_minimal.json
@@ -1,0 +1,69 @@
+{
+  "artifact_schema_version": "current_fact_source_record_input/v1",
+  "authority_boundary": {
+    "official": "authority_candidate_only",
+    "supercombo": "enrichment_or_cross_reference_only"
+  },
+  "generated_from": [
+    "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+    "docs/source-reviews/20260524-official-note-linkage-source-review.md",
+    "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md",
+    "contracts/current-facts/current_fact_record.schema.json"
+  ],
+  "records": [
+    {
+      "current_fact_record": {
+        "authority_status": "authority_candidate",
+        "calculation_input_status": "eligible_only_after_domain_source_and_unit_checks",
+        "character_slug": "jp",
+        "display_label_ja": "ガード硬直差",
+        "evidence": {
+          "evidence_basis": "value_shape_policy",
+          "public_reference": "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+          "run_id": "20260521T025403Z",
+          "source_header_path": ["硬直差", "ガード"],
+          "source_label": "ガード",
+          "source_name": "official",
+          "source_role": "authority_candidate"
+        },
+        "field_key": "block_advantage",
+        "move_id": "jp_001_5lp",
+        "parsed_value": {
+          "kind": "signed_frame",
+          "unit": "frame",
+          "value": -2
+        },
+        "raw_value": "-2",
+        "record_id": "official:jp:jp_001_5lp:block_advantage",
+        "source_family": "advantage",
+        "source_header_path": ["硬直差", "ガード"],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate",
+        "value_shape": {
+          "classes": ["signed_frame"],
+          "classifier_status": "parsed",
+          "parser_rule_id": "signed_frame.v1"
+        }
+      },
+      "raw_value_length": 2,
+      "raw_value_sha256": "cf3bae39dd692048a8bf961182e6a34dfd323eeb0748e162eaf055107f1cb873",
+      "source_cell_key": "official:jp:jp_001_5lp:block_advantage:cell",
+      "source_cell_order": 4,
+      "source_header_path": ["硬直差", "ガード"],
+      "source_record_id": "source-record:official:jp:jp_001_5lp:block_advantage",
+      "source_row_key": "official:jp:jp_001_5lp",
+      "source_row_order": 1,
+      "source_value_key": "official:jp:jp_001_5lp:block_advantage:value-1"
+    }
+  ],
+  "run_id": "20260521T025403Z",
+  "source_record_boundary": {
+    "blocked_records": "excluded_to_classifier_or_source_review",
+    "legacy_raw_exports": "excluded_as_source_input",
+    "local_source_payloads": "excluded_from_public_artifact",
+    "lookup_ready_records": "parsed_value_only",
+    "reviewer_observations": "observation_candidate_only_not_authority",
+    "supercombo": "enrichment_or_cross_reference_only"
+  }
+}

--- a/tests/fixtures/current-facts/source-records/valid/current_fact_source_record_input_non_scalar_values.json
+++ b/tests/fixtures/current-facts/source-records/valid/current_fact_source_record_input_non_scalar_values.json
@@ -1,0 +1,135 @@
+{
+  "artifact_schema_version": "current_fact_source_record_input/v1",
+  "authority_boundary": {
+    "official": "authority_candidate_only",
+    "supercombo": "enrichment_or_cross_reference_only"
+  },
+  "generated_from": [
+    "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+    "data/source-reviews/20260524-official-note-linkage-source-review-summary.json",
+    "docs/source-reviews/20260524-official-note-linkage-source-review.md"
+  ],
+  "records": [
+    {
+      "current_fact_record": {
+        "authority_status": "authority_candidate",
+        "calculation_input_status": "annotated_candidate_not_calculation_safe",
+        "character_slug": "jp",
+        "display_label_ja": "ガード硬直差",
+        "evidence": {
+          "evidence_basis": "value_shape_policy",
+          "public_reference": "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+          "run_id": "20260521T025403Z",
+          "source_header_path": ["硬直差", "ガード"],
+          "source_label": "ガード",
+          "source_name": "official",
+          "source_role": "authority_candidate"
+        },
+        "field_key": "block_advantage",
+        "move_id": "jp_001_5lk",
+        "parsed_value": {
+          "annotation": {
+            "marker_placement": "prefix",
+            "note_id": null,
+            "note_linkage_status": "same_row_note_candidates_available",
+            "note_marker": "※",
+            "note_scope": "row_block_advantage_condition",
+            "note_text_status": "structured_row_note_text_found",
+            "row_note_candidate_count": 1
+          },
+          "calculation": {
+            "calculation_input_status": "annotated_candidate_not_calculation_safe",
+            "reason": "condition_bound_by_official_note"
+          },
+          "kind": "annotated_numeric_candidate",
+          "numeric_candidate": {
+            "candidate_type": "signed_frame",
+            "unit": "frame",
+            "value": -4
+          },
+          "source_context": {
+            "review_item_id": "value-shape:official--unclassified_expression--annotated-block",
+            "source_column_header_path": ["硬直差", "ガード"],
+            "source_review_id": "source-review:official-note-linkage-v4"
+          }
+        },
+        "raw_value": "※-4",
+        "record_id": "official:jp:jp_001_5lk:block_advantage:annotated",
+        "source_family": "advantage",
+        "source_header_path": ["硬直差", "ガード"],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate",
+        "value_shape": {
+          "classes": ["note_prefixed", "signed_frame"],
+          "classifier_status": "parsed",
+          "parser_rule_id": "annotated_numeric_candidate.official_note_marker.v1"
+        }
+      },
+      "raw_value_length": 3,
+      "raw_value_sha256": "b5112d05eab37a8ef2062523ba1cce640a8350c6cba7ef40bf66072550f3609c",
+      "source_cell_key": "official:jp:jp_001_5lk:block_advantage:cell",
+      "source_cell_order": 4,
+      "source_header_path": ["硬直差", "ガード"],
+      "source_record_id": "source-record:official:jp:jp_001_5lk:block_advantage:annotated",
+      "source_row_key": "official:jp:jp_001_5lk",
+      "source_row_order": 2,
+      "source_value_key": "official:jp:jp_001_5lk:block_advantage:value-1"
+    },
+    {
+      "current_fact_record": {
+        "authority_status": "authority_candidate",
+        "calculation_input_status": "parsed_range_not_single_value_calculation_safe",
+        "character_slug": "jp",
+        "display_label_ja": "持続",
+        "evidence": {
+          "evidence_basis": "value_shape_policy",
+          "public_reference": "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+          "run_id": "20260521T025403Z",
+          "source_header_path": ["動作フレーム", "持続"],
+          "source_label": "持続",
+          "source_name": "official",
+          "source_role": "authority_candidate"
+        },
+        "field_key": "active",
+        "move_id": "jp_001_5lp",
+        "parsed_value": {
+          "end": 8,
+          "kind": "frame_range",
+          "start": 6,
+          "unit": "frame"
+        },
+        "raw_value": "6-8",
+        "record_id": "official:jp:jp_001_5lp:active",
+        "source_family": "timing",
+        "source_header_path": ["動作フレーム", "持続"],
+        "source_label": "持続",
+        "source_name": "official",
+        "source_role": "authority_candidate",
+        "value_shape": {
+          "classes": ["range"],
+          "classifier_status": "parsed",
+          "parser_rule_id": "frame_range.v1"
+        }
+      },
+      "raw_value_length": 3,
+      "raw_value_sha256": "742595dc2605b1b9ded786a8b24f3ec0fddb44d49a77bb7186d3090411fb4e9f",
+      "source_cell_key": "official:jp:jp_001_5lp:active:cell",
+      "source_cell_order": 2,
+      "source_header_path": ["動作フレーム", "持続"],
+      "source_record_id": "source-record:official:jp:jp_001_5lp:active",
+      "source_row_key": "official:jp:jp_001_5lp",
+      "source_row_order": 1,
+      "source_value_key": "official:jp:jp_001_5lp:active:value-1"
+    }
+  ],
+  "run_id": "20260521T025403Z",
+  "source_record_boundary": {
+    "blocked_records": "excluded_to_classifier_or_source_review",
+    "legacy_raw_exports": "excluded_as_source_input",
+    "local_source_payloads": "excluded_from_public_artifact",
+    "lookup_ready_records": "parsed_value_only",
+    "reviewer_observations": "observation_candidate_only_not_authority",
+    "supercombo": "enrichment_or_cross_reference_only"
+  }
+}

--- a/tests/validation/validate_clean_slate.py
+++ b/tests/validation/validate_clean_slate.py
@@ -44,6 +44,7 @@ ALLOWED_CONTRACT_PATHS = {
     "contracts/current-facts",
     "contracts/current-facts/current_fact_export.schema.json",
     "contracts/current-facts/current_fact_record.schema.json",
+    "contracts/current-facts/current_fact_source_record_input.schema.json",
     "contracts/current-facts/parsed_value.schema.json",
     "contracts/current-facts/source_reference.schema.json",
     "contracts/current-facts/value_shape.schema.json",

--- a/tests/validation/validate_current_fact_source_records.py
+++ b/tests/validation/validate_current_fact_source_records.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+
+from sf6_knowledge_coach.current_fact_guards import is_scalar_calculation_input
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_DIR = ROOT / "contracts/current-facts"
+FIXTURE_DIR = ROOT / "tests/fixtures/current-facts/source-records"
+SOURCE_RECORD_SCHEMA_PATH = SCHEMA_DIR / "current_fact_source_record_input.schema.json"
+SOURCE_RECORD_SCHEMA_ID = (
+    "https://sf6-knowledge-coach.local/schemas/current-facts/current_fact_source_record_input.schema.json"
+)
+SCHEMA_FILES = [
+    "parsed_value.schema.json",
+    "value_shape.schema.json",
+    "source_reference.schema.json",
+    "current_fact_record.schema.json",
+    "current_fact_source_record_input.schema.json",
+]
+LOOKUP_READY_BLOCKED_STATUSES = {
+    "review_required_not_calculation_safe",
+    "out_of_scope_not_emitted",
+}
+FORBIDDEN_PUBLIC_PATTERNS = [
+    re.compile(r"(?i)(?:^|[\s\"'`])(?:/[a-z0-9_.-]+)+"),
+    re.compile(r"(?i)(?:^|[\s\"'`(])[A-Z]:[\\/]"),
+    re.compile(r"(?i)\.local(?:/|\\)"),
+    re.compile(r"(?i)\b(?:cookie|authorization|bearer|token|password|secret)\b"),
+    re.compile(r"(?i)<html|</html|<!doctype|<table|</table|<tr|</tr|<td|</td|<th|</th"),
+    re.compile(r"(?i)\b(?:screenshot|chatgpt|vlm|trace|debug dump|answer[-_ ]?log|training[-_ ]?log|private[-_ ]?vault)\b"),
+]
+FORBIDDEN_SOURCE_PATH_TERMS = (
+    "data/exports/",
+    ".local/",
+    "screenshot",
+    "chatgpt",
+    "vlm",
+    "raw-html",
+    "raw_html",
+    "full-row",
+    "full_raw",
+    "cookie",
+    "profile",
+    "trace",
+    "debug",
+    "private",
+)
+
+
+def main() -> int:
+    errors: list[str] = []
+    schemas = _load_schemas(errors)
+    if errors:
+        return _finish(errors)
+
+    registry = Registry().with_resources(
+        (schema["$id"], Resource.from_contents(schema)) for schema in schemas.values()
+    )
+    for path, schema in schemas.items():
+        try:
+            Draft202012Validator.check_schema(schema)
+        except Exception as exc:  # pragma: no cover - exact exception type is not important here
+            errors.append(f"{path.relative_to(ROOT)} is not a valid Draft 2020-12 schema: {exc}")
+
+    validator = Draft202012Validator(schemas[SOURCE_RECORD_SCHEMA_PATH], registry=registry)
+    _validate_schema_contract(schemas[SOURCE_RECORD_SCHEMA_PATH], errors)
+    valid_payloads = _validate_valid_fixtures(validator, errors)
+    _validate_invalid_fixtures(validator, errors)
+    _validate_synthetic_boundary_rejections(validator, valid_payloads, errors)
+    _scan_valid_public_fixtures(errors)
+    return _finish(errors)
+
+
+def _load_schemas(errors: list[str]) -> dict[Path, dict[str, Any]]:
+    schemas: dict[Path, dict[str, Any]] = {}
+    for name in SCHEMA_FILES:
+        path = SCHEMA_DIR / name
+        if not path.exists():
+            errors.append(f"Missing {path.relative_to(ROOT)}")
+            continue
+        schemas[path] = json.loads(path.read_text(encoding="utf-8"))
+        if schemas[path].get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+            errors.append(f"{path.relative_to(ROOT)} must use JSON Schema Draft 2020-12")
+    return schemas
+
+
+def _validate_schema_contract(schema: dict[str, Any], errors: list[str]) -> None:
+    version = schema.get("properties", {}).get("artifact_schema_version", {}).get("const")
+    if version != "current_fact_source_record_input/v1":
+        errors.append("source-record input schema must use current_fact_source_record_input/v1")
+    generated_from = schema.get("properties", {}).get("generated_from", {})
+    if generated_from.get("minItems") != 1 or not generated_from.get("uniqueItems"):
+        errors.append("source-record input schema must require non-empty unique generated_from paths")
+    records = schema.get("properties", {}).get("records", {})
+    if records.get("minItems") != 1:
+        errors.append("source-record input schema must require at least one lookup-ready record")
+
+
+def _validate_valid_fixtures(
+    validator: Draft202012Validator,
+    errors: list[str],
+) -> dict[Path, dict[str, Any]]:
+    payloads: dict[Path, dict[str, Any]] = {}
+    fixtures = sorted((FIXTURE_DIR / "valid").glob("*.json"))
+    if not fixtures:
+        errors.append(f"Missing valid source-record fixtures under {(FIXTURE_DIR / 'valid').relative_to(ROOT)}")
+    for path in fixtures:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payloads[path] = payload
+        failures = _schema_errors(validator, payload)
+        semantic_failures = _semantic_errors(payload)
+        if failures or semantic_failures:
+            message = failures[0] if failures else semantic_failures[0]
+            errors.append(f"{path.relative_to(ROOT)} should be valid: {message}")
+    return payloads
+
+
+def _validate_invalid_fixtures(validator: Draft202012Validator, errors: list[str]) -> None:
+    fixtures = sorted((FIXTURE_DIR / "invalid").glob("*.json"))
+    if not fixtures:
+        errors.append(f"Missing invalid source-record fixtures under {(FIXTURE_DIR / 'invalid').relative_to(ROOT)}")
+    for path in fixtures:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not _schema_errors(validator, payload) and not _semantic_errors(payload):
+            errors.append(f"{path.relative_to(ROOT)} should be rejected")
+
+
+def _validate_synthetic_boundary_rejections(
+    validator: Draft202012Validator,
+    valid_payloads: dict[Path, dict[str, Any]],
+    errors: list[str],
+) -> None:
+    if not valid_payloads:
+        return
+    base = copy.deepcopy(next(iter(valid_payloads.values())))
+    mutations = {
+        "legacy generated_from": lambda payload: payload.update(
+            {"generated_from": ["data/exports/jp/official_raw.json"]}
+        ),
+        "local generated_from": lambda payload: payload.update(
+            {"generated_from": ["docs/.local/source-records.json"]}
+        ),
+        "image reviewer path": lambda payload: payload.update(
+            {"generated_from": ["docs/current-facts/source-records/value-screenshot.png"]}
+        ),
+        "vlm observation path": lambda payload: payload.update(
+            {"generated_from": ["docs/current-facts/source-records/chatgpt-vlm-observation.md"]}
+        ),
+        "legacy evidence path": lambda payload: _first_record(payload)["current_fact_record"]["evidence"].update(
+            {"public_reference": "data/exports/jp/official_raw.json"}
+        ),
+        "local absolute evidence path": lambda payload: _first_record(payload)["current_fact_record"]["evidence"].update(
+            {"public_reference": "/mnt/e/github/SF6-skills/.local/source.json"}
+        ),
+        "raw html value": lambda payload: _first_record(payload)["current_fact_record"].update(
+            {"raw_value": "<table></table>"}
+        ),
+        "hash mismatch": lambda payload: _first_record(payload).update(
+            {"raw_value_sha256": "0" * 64}
+        ),
+        "header mismatch": lambda payload: _first_record(payload).update(
+            {"source_header_path": ["mismatched", "header"]}
+        ),
+    }
+    for label, mutate in mutations.items():
+        payload = copy.deepcopy(base)
+        mutate(payload)
+        if not _schema_errors(validator, payload) and not _semantic_errors(payload):
+            errors.append(f"synthetic source-record boundary mutation should be rejected: {label}")
+
+
+def _schema_errors(validator: Draft202012Validator, payload: dict[str, Any]) -> list[str]:
+    failures = sorted(validator.iter_errors(payload), key=lambda error: list(error.path))
+    return [failure.message for failure in failures]
+
+
+def _semantic_errors(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for path in payload.get("generated_from", []):
+        _validate_public_source_path(path, "generated_from", errors)
+    for index, source_record in enumerate(payload.get("records", [])):
+        if not isinstance(source_record, dict):
+            errors.append(f"records[{index}] must be an object")
+            continue
+        current_fact = source_record.get("current_fact_record", {})
+        if not isinstance(current_fact, dict):
+            errors.append(f"records[{index}].current_fact_record must be an object")
+            continue
+        _validate_record_identity(index, source_record, current_fact, errors)
+        _validate_record_source_boundary(index, current_fact, errors)
+        _validate_record_guard_boundary(index, current_fact, errors)
+    return errors
+
+
+def _validate_public_source_path(path: Any, context: str, errors: list[str]) -> None:
+    if not isinstance(path, str):
+        errors.append(f"{context} path must be a string")
+        return
+    lowered = path.lower()
+    if re.search(r"(^|[\s\"'`])(?:/[a-z0-9_.-]+)+", path, flags=re.IGNORECASE):
+        errors.append(f"{context} must not contain a local absolute path")
+    for term in FORBIDDEN_SOURCE_PATH_TERMS:
+        if term in lowered:
+            errors.append(f"{context} must not reference forbidden source input: {path}")
+            return
+
+
+def _validate_record_identity(
+    index: int,
+    source_record: dict[str, Any],
+    current_fact: dict[str, Any],
+    errors: list[str],
+) -> None:
+    raw_value = current_fact.get("raw_value")
+    if isinstance(raw_value, str):
+        expected_hash = hashlib.sha256(raw_value.encode("utf-8")).hexdigest()
+        if source_record.get("raw_value_sha256") != expected_hash:
+            errors.append(f"records[{index}] raw_value_sha256 does not match raw_value")
+        if source_record.get("raw_value_length") != len(raw_value):
+            errors.append(f"records[{index}] raw_value_length does not match raw_value")
+    if source_record.get("source_header_path") != current_fact.get("source_header_path"):
+        errors.append(f"records[{index}] source_header_path must match current_fact_record.source_header_path")
+    evidence = current_fact.get("evidence", {})
+    if isinstance(evidence, dict):
+        if evidence.get("source_header_path") != current_fact.get("source_header_path"):
+            errors.append(f"records[{index}] evidence.source_header_path must match current_fact_record.source_header_path")
+        for field in ("source_name", "source_role", "source_label"):
+            if evidence.get(field) != current_fact.get(field):
+                errors.append(f"records[{index}] evidence.{field} must match current_fact_record.{field}")
+
+
+def _validate_record_source_boundary(index: int, current_fact: dict[str, Any], errors: list[str]) -> None:
+    evidence = current_fact.get("evidence", {})
+    if isinstance(evidence, dict):
+        _validate_public_source_path(evidence.get("public_reference"), f"records[{index}].evidence.public_reference", errors)
+        if evidence.get("evidence_basis") == "official_raw_snapshot":
+            errors.append(f"records[{index}] must not use official_raw_snapshot as source-record evidence")
+    status = current_fact.get("calculation_input_status")
+    if status in LOOKUP_READY_BLOCKED_STATUSES:
+        errors.append(f"records[{index}] blocked status is not lookup-ready: {status}")
+    if "parsed_value" not in current_fact:
+        errors.append(f"records[{index}] lookup-ready source record must include parsed_value")
+    if current_fact.get("value_shape", {}).get("classifier_status") == "review_required":
+        errors.append(f"records[{index}] review_required value_shape is not lookup-ready")
+    if current_fact.get("source_name") == "supercombo" and status == "eligible_only_after_domain_source_and_unit_checks":
+        errors.append(f"records[{index}] SuperCombo value must not be scalar calculation authority")
+
+
+def _validate_record_guard_boundary(index: int, current_fact: dict[str, Any], errors: list[str]) -> None:
+    parsed_value = current_fact.get("parsed_value")
+    status = current_fact.get("calculation_input_status")
+    parsed_kind = parsed_value.get("kind") if isinstance(parsed_value, dict) else None
+    if status == "annotated_candidate_not_calculation_safe" and parsed_kind != "annotated_numeric_candidate":
+        errors.append(f"records[{index}] annotated status must keep annotated_numeric_candidate wrapper")
+    if parsed_kind == "annotated_numeric_candidate" and status != "annotated_candidate_not_calculation_safe":
+        errors.append(f"records[{index}] annotated_numeric_candidate must carry annotated non-calculation status")
+    if status == "parsed_range_not_single_value_calculation_safe" and parsed_kind != "frame_range":
+        errors.append(f"records[{index}] range status must keep frame_range wrapper")
+    if parsed_kind == "frame_range" and status != "parsed_range_not_single_value_calculation_safe":
+        errors.append(f"records[{index}] frame_range must carry non-scalar range status")
+    if parsed_kind in {"annotated_numeric_candidate", "frame_range"}:
+        if is_scalar_calculation_input(parsed_value, status):
+            errors.append(f"records[{index}] non-scalar parsed value must be rejected by scalar guard")
+
+
+def _scan_valid_public_fixtures(errors: list[str]) -> None:
+    for path in sorted((FIXTURE_DIR / "valid").glob("*.json")):
+        text = path.read_text(encoding="utf-8")
+        for pattern in FORBIDDEN_PUBLIC_PATTERNS:
+            if pattern.search(text):
+                errors.append(f"{path.relative_to(ROOT)} contains forbidden public content")
+                break
+
+
+def _first_record(payload: dict[str, Any]) -> dict[str, Any]:
+    return payload["records"][0]
+
+
+def _finish(errors: list[str]) -> int:
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("Current-fact source-record validation OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds the `current_fact_source_record_input/v1` schema for reviewed source-record input artifacts.
- Adds focused source-record fixtures and a validator for parsed-value-only admission, public source boundaries, row/cell/value identity, guard behavior, and authority boundaries.
- Updates clean-slate contract inventory, validator audit artifacts, and the ExecPlan progress/completion table.

## Boundaries

- No production source-record artifact under `data/current-facts/source-records/`.
- No current-fact export artifact under `data/current-facts/`.
- No export generator, runtime lookup switch, `current_facts.py`, `answering.py`, parser/classifier behavior, retrieval, answer, calculator, SymPy, or live acquisition changes.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `uv lock --check`
- `PYTHONPATH=src uv run --locked python -m unittest discover -s tests`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py`
- `PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_validator_test_audit.py`
