### PR TITLE
Implement current-fact export generator fixture contract

### DIFF
--- a/data/validator-audits/20260523-validator-test-fact-source-audit.json
+++ b/data/validator-audits/20260523-validator-test-fact-source-audit.json
@@ -25,6 +25,20 @@
     },
     {
       "evidence_class": "synthetic_contract",
+      "file": "tests/test_current_fact_export_generator.py",
+      "limitations": [
+        "uses source-record synthetic fixtures; does not generate production exports or prove source truth"
+      ],
+      "primary_evidence": [
+        "contracts/current-facts/current_fact_export.schema.json",
+        "contracts/current-facts/current_fact_source_record_input.schema.json",
+        "tests/fixtures/current-facts/source-records",
+        "current-fact export generator fixture-contract implementation ExecPlan"
+      ],
+      "status": "accepted_with_limits"
+    },
+    {
+      "evidence_class": "synthetic_contract",
       "file": "tests/test_current_fact_guards.py",
       "limitations": [
         "uses synthetic scalar/non-scalar fixtures; does not prove source truth or calculation correctness"
@@ -110,6 +124,20 @@
         "clean-slate ExecPlans",
         "current-fact JSON Schema artifacts ExecPlan",
         "current-fact source-record input artifact ExecPlan"
+      ],
+      "status": "accepted_with_limits"
+    },
+    {
+      "evidence_class": "artifact_consistency",
+      "file": "tests/validation/validate_current_fact_export_generator.py",
+      "limitations": [
+        "checks fixture-contract generator output, guard boundaries, and no production artifact paths; does not prove source truth"
+      ],
+      "primary_evidence": [
+        "contracts/current-facts/current_fact_export.schema.json",
+        "contracts/current-facts/current_fact_source_record_input.schema.json",
+        "tests/fixtures/current-facts/source-records",
+        "current-fact export generator fixture-contract implementation ExecPlan"
       ],
       "status": "accepted_with_limits"
     },

--- a/docs/execplans/2026-05-25-current-fact-export-generator-fixture-contract-implementation.md
+++ b/docs/execplans/2026-05-25-current-fact-export-generator-fixture-contract-implementation.md
@@ -1,15 +1,16 @@
 # Current-Fact Export Generator Fixture-Contract Implementation
 
-Status: Drafted for review; validation passed.
+Status: Implemented; validation passed.
 
 ## Purpose
 
 Plan the first deterministic current-fact export generator implementation
 slice as fixture-contract only.
 
-This plan implements generator behavior against reviewed synthetic
-source-record input fixtures and current-fact schemas. It must not create a
-production source-record artifact, a production current-fact export artifact,
+The original planning PR was docs-only. This implementation follow-up adds
+the fixture-contract generator helper, focused tests, focused validator,
+validator audit updates, and this ExecPlan progress update. It does not create
+a production source-record artifact, a production current-fact export artifact,
 or any runtime lookup behavior.
 
 ## Inputs
@@ -306,20 +307,23 @@ Before any production artifact PR:
 
 ## Files / Interfaces
 
-This docs-only plan changes only:
+The original docs-only plan changed only:
 
 - `docs/execplans/2026-05-25-current-fact-export-generator-fixture-contract-implementation.md`
 
-Future implementation may touch, after review:
+This fixture-contract implementation touches only:
 
 - `src/sf6_knowledge_coach/current_fact_export_generator.py`;
-- focused unit tests under `tests/`;
+- `tests/test_current_fact_export_generator.py`;
 - `tests/validation/validate_current_fact_export_generator.py`;
-- optional synthetic generator fixtures under `tests/fixtures/current-facts/`;
-- validator audit artifacts if new tests/validators require audit entries;
+- validator audit artifacts;
 - this ExecPlan progress/completion table.
 
-Future implementation must not touch:
+Future implementation may touch, after review:
+
+- optional synthetic generator fixtures under `tests/fixtures/current-facts/`.
+
+This implementation must not touch:
 
 - `data/current-facts/` production artifacts;
 - `docs/current-facts/` production summaries;
@@ -335,12 +339,16 @@ Run from repository root:
 
 ```bash
 git diff --check
+git diff --cached --check
 uv lock --check
+PYTHONPATH=src uv run --locked python -m unittest discover -s tests
 PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
 PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py
 PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py
 PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py
 PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_export_generator.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_validator_test_audit.py
 git status --short --branch
 ```
 
@@ -362,7 +370,37 @@ git status --short --branch
   `uv lock --check`, clean-slate validator, current-fact schema validator,
   current-fact source-record validator, current-fact consumer guard validator,
   parsed-value classifier validator, and `git status --short --branch`.
-- [ ] Complete mandatory review.
+- [x] (2026-05-25 JST) PR #358 mandatory review passed and was merged with
+  normal merge commit `323b56c3952ed39b9cea038b66689fce10701e58`.
+- [x] (2026-05-25 JST) Local `main` was fast-forwarded to `origin/main` at
+  `323b56c3952ed39b9cea038b66689fce10701e58`; main CI passed in run
+  `26378555283`.
+- [x] (2026-05-25 JST) Created branch
+  `impl/current-fact-export-generator-fixture-contract`.
+- [x] (2026-05-25 JST) Added
+  `src/sf6_knowledge_coach/current_fact_export_generator.py` with in-memory
+  source-record input validation, deterministic transformation to
+  `current_fact_export/v2`, output validation, guard checks, authority checks,
+  and public source-boundary checks.
+- [x] (2026-05-25 JST) Added focused unit tests for minimal export
+  generation, sidecar field stripping, non-scalar wrapper preservation,
+  deterministic ordering, invalid fixture rejection, flattened annotated
+  candidate rejection, collapsed frame-range rejection, and legacy
+  `generated_from` rejection.
+- [x] (2026-05-25 JST) Added focused generator validator for fixture-contract
+  output, invalid fixture rejection, synthetic export boundary mutations, and
+  absence of production artifacts under `data/current-facts/` and
+  `docs/current-facts/`.
+- [x] (2026-05-25 JST) Updated validator audit artifacts for the new focused
+  unit test and validator.
+- [x] (2026-05-25 JST) Full implementation validation passed: `git diff
+  --check`, `git diff --cached --check`, `uv lock --check`, unittest,
+  clean-slate validator, current-fact schema validator, current-fact
+  source-record validator, current-fact consumer guard validator,
+  parsed-value classifier validator, current-fact export generator validator,
+  validator audit validator, `git status --short --branch`, and production
+  artifact path check.
+- [ ] Complete implementation mandatory review.
 
 ## Decision Log
 
@@ -394,6 +432,18 @@ git status --short --branch
   no arithmetic.
   Date/Author: 2026-05-25 / Codex
 
+- Decision: Validate source-record and export payloads in the helper before
+  returning output.
+  Rationale: The fixture-contract helper is the future production transform
+  core; keeping schema, guard, authority, and source-boundary checks in the
+  helper makes later file-writing wrappers harder to misuse.
+  Date/Author: 2026-05-25 / Codex
+
+- Decision: Do not add a CLI or file writer.
+  Rationale: This slice proves in-memory transformation only. File IO and
+  production artifact paths remain blocked until source-record artifact review.
+  Date/Author: 2026-05-25 / Codex
+
 ## Deviations
 
 - None.
@@ -408,43 +458,51 @@ git status --short --branch
 - Fixture-contract tests do not prove source truth.
 - Future production generator wrappers will need file IO, parity, rollback,
   and artifact review plans.
+- Validator/test coverage is synthetic contract coverage and does not prove
+  source truth.
 
 ## Completion Review Table
 
 | PLAN item | Implementation | Changed files | Validation command | Result | Deviation | Incomplete | Risk |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Docs-only fixture-contract generator plan | Drafted plan for in-memory current-fact export generator implementation from source-record fixtures | `docs/execplans/2026-05-25-current-fact-export-generator-fixture-contract-implementation.md` | `git diff --check`; `uv lock --check`; clean-slate validator; current-fact schema validator; source-record validator; consumer guard validator; parsed-value classifier validator; `git status --short --branch` | Passed | None | Review pending | Production artifact generation remains blocked |
-| Input/output boundary | Planned source-record fixture inputs and in-memory `current_fact_export/v2` payload outputs only | This ExecPlan only | Diff/status review | Passed | None | Review pending | No production source-record artifact exists |
-| Guard/authority/privacy behavior | Planned schema, guard, authority, generated_from, privacy, and deterministic ordering checks | This ExecPlan only | Diff/status review | Passed | None | Review pending | Future generator implementation still pending |
-| Runtime exclusion | Kept `current_facts.py`, `answering.py`, retrieval, answer, calculator, SymPy, source acquisition, live acquisition, and parser/classifier behavior out of scope | This ExecPlan only | Diff/status review | Passed | None | Review pending | Runtime remains legacy raw backed |
+| Docs-only fixture-contract generator plan | Drafted plan for in-memory current-fact export generator implementation from source-record fixtures | `docs/execplans/2026-05-25-current-fact-export-generator-fixture-contract-implementation.md` | `git diff --check`; `uv lock --check`; clean-slate validator; current-fact schema validator; source-record validator; consumer guard validator; parsed-value classifier validator; `git status --short --branch` | Passed | None | Review complete via PR #358 | Production artifact generation remains blocked |
+| Generator helper | Added in-memory source-record-to-export helper with source-record validation, sidecar stripping, deterministic ordering, v2 output construction, output validation, guard checks, authority checks, and source-boundary checks | `src/sf6_knowledge_coach/current_fact_export_generator.py` | Unit tests; export generator validator | Passed | None | Review pending | Future file-writing wrapper still blocked |
+| Unit tests | Added focused tests for successful fixture generation, non-scalar wrapper preservation, deterministic ordering, invalid source fixture rejection, flattened annotated rejection, collapsed range rejection, and legacy generated_from rejection | `tests/test_current_fact_export_generator.py` | Unittest | Passed | None | Review pending | Synthetic fixtures do not prove source truth |
+| Focused validator | Added fixture-contract validator for valid fixture outputs, invalid fixture rejection, synthetic output boundary mutations, and absence of production artifacts | `tests/validation/validate_current_fact_export_generator.py` | Export generator validator; validator audit | Passed | None | Review pending | Production artifact validation remains future work |
+| Validator audit | Added evidence-boundary audit entries for the new unit test and focused validator | `data/validator-audits/20260523-validator-test-fact-source-audit.json`; `docs/validator-audits/20260523-validator-test-fact-source-audit.md` | Validator audit validator | Passed | None | Review pending | Audit is boundary metadata only |
+| Input/output boundary | Implemented source-record fixture inputs and in-memory `current_fact_export/v2` payload outputs only | Generator helper, tests, validator, this ExecPlan | Unit tests; export generator validator; production artifact path check | Passed | None | Review pending | No production source-record artifact exists |
+| Guard/authority/privacy behavior | Implemented schema, guard, authority, generated_from, privacy, and deterministic ordering checks for fixture-contract output | Generator helper, tests, validator, this ExecPlan | Unit tests; export generator validator; current-fact guard validator | Passed | None | Review pending | Future generators must preserve equivalent checks |
+| Runtime exclusion | Kept `current_facts.py`, `answering.py`, retrieval, answer, calculator, SymPy, source acquisition, live acquisition, and parser/classifier behavior out of scope | No runtime/parser/source-acquisition files changed | Diff/status review | Passed | None | Review pending | Runtime remains legacy raw backed |
 
 ## Next Reviewer Prompt
 
 ```text
-Review docs/execplans/2026-05-25-current-fact-export-generator-fixture-contract-implementation.md.
+Review the fixture-contract current-fact export generator implementation.
 
 Check:
-- PR diff contains exactly one ExecPlan file.
-- Plan is docs-only and plans fixture-contract generator implementation only.
+- PR diff is limited to generator helper, focused unit test, focused
+  validator, validator audit artifacts, and this ExecPlan.
+- Generator accepts source-record fixture payloads and returns
+  `current_fact_export/v2` payloads in memory.
 - No production source-record artifact under data/current-facts/source-records/
-  is planned or generated.
+  is generated.
 - No production current-fact export artifact under data/current-facts/ is
-  planned or generated.
-- Future implementation consumes only source-record fixtures and current-fact
-  schemas.
-- Future implementation emits only in-memory or temporary test
-  current_fact_export/v2 payloads.
-- The plan requires source-record schema validation before transformation.
-- The plan strips source-record sidecar identity fields from export records.
-- The plan preserves raw_value, parsed_value, value_shape, source fields,
-  authority_status, evidence, and calculation_input_status.
-- The plan requires deterministic ordering.
-- The plan rejects legacy data/exports/*, .local, raw HTML, screenshots/VLM as
+  generated.
+- Implementation consumes only source-record fixtures and current-fact schemas.
+- Implementation emits only in-memory current_fact_export/v2 payloads.
+- Source-record schema validation happens before transformation.
+- Export schema validation happens before returning output.
+- Source-record sidecar identity fields are stripped from export records.
+- raw_value, parsed_value, value_shape, source fields,
+  authority_status, evidence, and calculation_input_status are preserved.
+- Output ordering is deterministic by source, character, move, field, and
+  record ID.
+- Generator rejects legacy data/exports/*, .local, raw HTML, screenshots/VLM as
   authority, local paths, private data, and SuperCombo numeric authority.
-- The plan requires no flattened annotated_numeric_candidate.
-- The plan requires no collapsed frame_range.
-- The plan requires guard, authority, schema, privacy, and validator-audit
-  checks.
+- annotated_numeric_candidate is not flattened.
+- frame_range is not collapsed.
+- Guard, authority, schema, privacy, and validator-audit checks are included.
+- No CLI or file writer is added.
 - Runtime lookup, current_facts.py, answering.py, parser/classifier behavior,
   retrieval, answer, calculator, SymPy, source acquisition, and live
   acquisition remain excluded.
@@ -453,13 +511,17 @@ Run:
 - git status --short --branch
 - git show --name-status --oneline --no-renames HEAD
 - git diff --check origin/main...HEAD
+- git diff --cached --check
 - uv lock --check
+- PYTHONPATH=src uv run --locked python -m unittest discover -s tests
 - PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
 - PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py
 - PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py
 - PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py
 - PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_export_generator.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_validator_test_audit.py
 
 Return blocking findings first, validation results, PLAN deviations,
-remaining risks, and whether docs-only stage/commit is approved.
+remaining risks, and whether the implementation is stage-ready.
 ```

--- a/docs/validator-audits/20260523-validator-test-fact-source-audit.md
+++ b/docs/validator-audits/20260523-validator-test-fact-source-audit.md
@@ -15,6 +15,7 @@ privacy/security boundary.
 | File | Evidence class | Status | Limitation |
 | --- | --- | --- | --- |
 | `tests/test_cli.py` | source-derived | accepted with limits | JP 5LP smoke only; not full roster validation |
+| `tests/test_current_fact_export_generator.py` | synthetic contract | accepted with limits | source-record synthetic fixtures only; no production exports or source truth |
 | `tests/test_current_fact_guards.py` | synthetic contract | accepted with limits | scalar/non-scalar guard fixtures only; no source truth or calculation correctness |
 | `tests/test_source_acquisition.py` | synthetic contract | accepted with limits | synthetic HTML tests parser/guard behavior, not live source truth |
 | `tests/test_supercombo_field_mapping.py` | policy-derived | accepted with limits | mapping counts are reviewed policy output, not live SuperCombo proof |
@@ -22,6 +23,7 @@ privacy/security boundary.
 | `tests/test_parsed_value_classifier.py` | policy-derived | accepted with limits | parser/classifier behavior is policy-derived and not calculation correctness |
 | `tests/test_value_shape_inventory.py` | source-derived | accepted with limits | representative shape checks are not parser semantics |
 | `tests/validation/validate_clean_slate.py` | governance boundary | accepted with limits | repo shape and approved contract file inventory only |
+| `tests/validation/validate_current_fact_export_generator.py` | artifact consistency | accepted with limits | fixture-contract generator output, guard boundaries, and no production artifact paths only |
 | `tests/validation/validate_current_fact_consumer_guards.py` | artifact consistency | accepted with limits | guard behavior against synthetic fixtures and coverage statuses only |
 | `tests/validation/validate_current_fact_source_records.py` | synthetic contract | accepted with limits | source-record schema, fixture contracts, and source-boundary guard mutations only; no production source records or source truth |
 | `tests/validation/validate_current_fact_schemas.py` | synthetic contract | accepted with limits | schema and fixture contracts only; no parser/source truth |

--- a/src/sf6_knowledge_coach/current_fact_export_generator.py
+++ b/src/sf6_knowledge_coach/current_fact_export_generator.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+
+from sf6_knowledge_coach.current_fact_guards import is_scalar_calculation_input
+from sf6_knowledge_coach.paths import repo_root
+
+
+SCHEMA_DIR = repo_root() / "contracts/current-facts"
+SOURCE_RECORD_SCHEMA_PATH = SCHEMA_DIR / "current_fact_source_record_input.schema.json"
+EXPORT_SCHEMA_PATH = SCHEMA_DIR / "current_fact_export.schema.json"
+SCHEMA_FILES = (
+    "parsed_value.schema.json",
+    "value_shape.schema.json",
+    "source_reference.schema.json",
+    "current_fact_record.schema.json",
+    "current_fact_export.schema.json",
+    "current_fact_source_record_input.schema.json",
+)
+BLOCKED_LOOKUP_STATUSES = frozenset(
+    {
+        "review_required_not_calculation_safe",
+        "out_of_scope_not_emitted",
+    }
+)
+SOURCE_RECORD_ONLY_FIELDS = frozenset(
+    {
+        "raw_value_length",
+        "raw_value_sha256",
+        "source_cell_key",
+        "source_cell_order",
+        "source_record_id",
+        "source_row_key",
+        "source_row_order",
+        "source_value_key",
+    }
+)
+FORBIDDEN_PUBLIC_PATH_TERMS = (
+    "data/exports/",
+    ".local/",
+    "screenshot",
+    "chatgpt",
+    "vlm",
+    "raw-html",
+    "raw_html",
+    "full-row",
+    "full_raw",
+    "cookie",
+    "profile",
+    "trace",
+    "debug",
+    "private",
+)
+FORBIDDEN_TEXT_PATTERNS = (
+    re.compile(r"(?i)(?:^|[\s\"'`])(?:/[a-z0-9_.-]+)+"),
+    re.compile(r"(?i)(?:^|[\s\"'`(])[A-Z]:[\\/]"),
+    re.compile(r"(?i)<html|</html|<!doctype|<table|</table|<tr|</tr|<td|</td|<th|</th"),
+    re.compile(r"(?i)\b(?:cookie|authorization|bearer|token|password|secret)\b"),
+    re.compile(r"(?i)\b(?:screenshot|chatgpt|vlm|trace|debug dump|answer[-_ ]?log|training[-_ ]?log|private[-_ ]?vault)\b"),
+)
+
+
+class CurrentFactExportGeneratorError(ValueError):
+    """Raised when source-record input cannot build a valid current-fact export."""
+
+
+def build_current_fact_export(source_record_payload: Mapping[str, Any]) -> dict[str, Any]:
+    errors = validate_source_record_payload(source_record_payload)
+    if errors:
+        raise CurrentFactExportGeneratorError(_format_errors("invalid source-record input", errors))
+
+    records = [
+        copy.deepcopy(source_record["current_fact_record"])
+        for source_record in source_record_payload["records"]
+    ]
+    export_payload = {
+        "artifact_schema_version": "current_fact_export/v2",
+        "authority_boundary": copy.deepcopy(source_record_payload["authority_boundary"]),
+        "generated_from": sorted(source_record_payload["generated_from"]),
+        "records": sorted(records, key=_record_sort_key),
+        "run_id": source_record_payload["run_id"],
+    }
+
+    export_errors = validate_current_fact_export_payload(export_payload)
+    if export_errors:
+        raise CurrentFactExportGeneratorError(_format_errors("invalid generated current-fact export", export_errors))
+    return export_payload
+
+
+def validate_source_record_payload(source_record_payload: Mapping[str, Any]) -> list[str]:
+    schema_errors = _schema_errors(_source_record_validator(), source_record_payload)
+    semantic_errors = _source_record_semantic_errors(source_record_payload)
+    return [*schema_errors, *semantic_errors]
+
+
+def validate_current_fact_export_payload(export_payload: Mapping[str, Any]) -> list[str]:
+    schema_errors = _schema_errors(_export_validator(), export_payload)
+    semantic_errors = _export_semantic_errors(export_payload)
+    return [*schema_errors, *semantic_errors]
+
+
+def _record_sort_key(record: Mapping[str, Any]) -> tuple[str, str, str, str, str]:
+    move_id = record.get("move_id")
+    return (
+        str(record.get("source_name", "")),
+        str(record.get("character_slug", "")),
+        "" if move_id is None else str(move_id),
+        str(record.get("field_key", "")),
+        str(record.get("record_id", "")),
+    )
+
+
+def _source_record_validator() -> Draft202012Validator:
+    schemas = _load_schemas()
+    registry = _schema_registry(schemas)
+    return Draft202012Validator(schemas[SOURCE_RECORD_SCHEMA_PATH], registry=registry)
+
+
+def _export_validator() -> Draft202012Validator:
+    schemas = _load_schemas()
+    registry = _schema_registry(schemas)
+    return Draft202012Validator(schemas[EXPORT_SCHEMA_PATH], registry=registry)
+
+
+def _load_schemas() -> dict[Path, dict[str, Any]]:
+    return {
+        SCHEMA_DIR / name: json.loads((SCHEMA_DIR / name).read_text(encoding="utf-8"))
+        for name in SCHEMA_FILES
+    }
+
+
+def _schema_registry(schemas: Mapping[Path, Mapping[str, Any]]) -> Registry:
+    return Registry().with_resources(
+        (schema["$id"], Resource.from_contents(schema)) for schema in schemas.values()
+    )
+
+
+def _schema_errors(validator: Draft202012Validator, payload: Mapping[str, Any]) -> list[str]:
+    failures = sorted(validator.iter_errors(payload), key=lambda error: list(error.path))
+    return [failure.message for failure in failures]
+
+
+def _source_record_semantic_errors(payload: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for path in payload.get("generated_from", []):
+        _validate_public_path(path, "generated_from", errors)
+    for index, source_record in enumerate(payload.get("records", [])):
+        if not isinstance(source_record, Mapping):
+            errors.append(f"records[{index}] must be an object")
+            continue
+        current_fact = source_record.get("current_fact_record")
+        if not isinstance(current_fact, Mapping):
+            errors.append(f"records[{index}].current_fact_record must be an object")
+            continue
+        _validate_source_record_identity(index, source_record, current_fact, errors)
+        _validate_current_fact_record(index, current_fact, errors)
+    return errors
+
+
+def _export_semantic_errors(payload: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for path in payload.get("generated_from", []):
+        _validate_public_path(path, "generated_from", errors)
+    for index, record in enumerate(payload.get("records", [])):
+        if not isinstance(record, Mapping):
+            errors.append(f"records[{index}] must be an object")
+            continue
+        leaked_fields = sorted(SOURCE_RECORD_ONLY_FIELDS & set(record))
+        if leaked_fields:
+            errors.append(f"records[{index}] leaked source-record sidecar fields: {leaked_fields}")
+        _validate_current_fact_record(index, record, errors)
+    return errors
+
+
+def _validate_current_fact_record(index: int, record: Mapping[str, Any], errors: list[str]) -> None:
+    status = record.get("calculation_input_status")
+    parsed_value = record.get("parsed_value")
+    parsed_kind = parsed_value.get("kind") if isinstance(parsed_value, Mapping) else None
+    if "parsed_value" not in record:
+        errors.append(f"records[{index}] lookup-ready record must include parsed_value")
+    if status in BLOCKED_LOOKUP_STATUSES:
+        errors.append(f"records[{index}] blocked status is not lookup-ready: {status}")
+    if record.get("source_name") == "official" and record.get("authority_status") != "authority_candidate":
+        errors.append(f"records[{index}] official record must remain authority_candidate")
+    if record.get("source_name") == "supercombo" and status == "eligible_only_after_domain_source_and_unit_checks":
+        errors.append(f"records[{index}] SuperCombo value must not be scalar calculation authority")
+    if status == "annotated_candidate_not_calculation_safe" and parsed_kind != "annotated_numeric_candidate":
+        errors.append(f"records[{index}] annotated status must keep annotated_numeric_candidate wrapper")
+    if parsed_kind == "annotated_numeric_candidate" and status != "annotated_candidate_not_calculation_safe":
+        errors.append(f"records[{index}] annotated_numeric_candidate must carry annotated non-calculation status")
+    if status == "parsed_range_not_single_value_calculation_safe" and parsed_kind != "frame_range":
+        errors.append(f"records[{index}] range status must keep frame_range wrapper")
+    if parsed_kind == "frame_range" and status != "parsed_range_not_single_value_calculation_safe":
+        errors.append(f"records[{index}] frame_range must carry non-scalar range status")
+    if parsed_kind in {"annotated_numeric_candidate", "frame_range"}:
+        if is_scalar_calculation_input(parsed_value, status):
+            errors.append(f"records[{index}] non-scalar parsed value must be rejected by scalar guard")
+    evidence = record.get("evidence")
+    if isinstance(evidence, Mapping):
+        _validate_public_path(evidence.get("public_reference"), f"records[{index}].evidence.public_reference", errors)
+    _scan_public_value(record.get("raw_value"), f"records[{index}].raw_value", errors)
+
+
+def _validate_source_record_identity(
+    index: int,
+    source_record: Mapping[str, Any],
+    current_fact: Mapping[str, Any],
+    errors: list[str],
+) -> None:
+    raw_value = current_fact.get("raw_value")
+    if isinstance(raw_value, str):
+        expected_hash = hashlib.sha256(raw_value.encode("utf-8")).hexdigest()
+        if source_record.get("raw_value_sha256") != expected_hash:
+            errors.append(f"records[{index}] raw_value_sha256 does not match raw_value")
+        if source_record.get("raw_value_length") != len(raw_value):
+            errors.append(f"records[{index}] raw_value_length does not match raw_value")
+    if source_record.get("source_header_path") != current_fact.get("source_header_path"):
+        errors.append(f"records[{index}] source_header_path must match current_fact_record.source_header_path")
+    evidence = current_fact.get("evidence")
+    if isinstance(evidence, Mapping):
+        if evidence.get("source_header_path") != current_fact.get("source_header_path"):
+            errors.append(f"records[{index}] evidence.source_header_path must match current_fact_record.source_header_path")
+        for field in ("source_name", "source_role", "source_label"):
+            if evidence.get(field) != current_fact.get(field):
+                errors.append(f"records[{index}] evidence.{field} must match current_fact_record.{field}")
+
+
+def _validate_public_path(path: object, context: str, errors: list[str]) -> None:
+    if not isinstance(path, str):
+        errors.append(f"{context} path must be a string")
+        return
+    lowered = path.lower()
+    for term in FORBIDDEN_PUBLIC_PATH_TERMS:
+        if term in lowered:
+            errors.append(f"{context} must not reference forbidden source input: {path}")
+            return
+    _scan_public_value(path, context, errors)
+
+
+def _scan_public_value(value: object, context: str, errors: list[str]) -> None:
+    if not isinstance(value, str):
+        return
+    for pattern in FORBIDDEN_TEXT_PATTERNS:
+        if pattern.search(value):
+            errors.append(f"{context} contains forbidden public content")
+            return
+
+
+def _format_errors(prefix: str, errors: list[str]) -> str:
+    return f"{prefix}: " + "; ".join(errors)

--- a/tests/test_current_fact_export_generator.py
+++ b/tests/test_current_fact_export_generator.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import copy
+import json
+import unittest
+from pathlib import Path
+
+from sf6_knowledge_coach.current_fact_export_generator import (
+    CurrentFactExportGeneratorError,
+    build_current_fact_export,
+    validate_current_fact_export_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_RECORD_FIXTURE_DIR = ROOT / "tests/fixtures/current-facts/source-records"
+SOURCE_RECORD_ONLY_FIELDS = {
+    "raw_value_length",
+    "raw_value_sha256",
+    "source_cell_key",
+    "source_cell_order",
+    "source_record_id",
+    "source_row_key",
+    "source_row_order",
+    "source_value_key",
+}
+
+
+def _fixture(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class CurrentFactExportGeneratorTests(unittest.TestCase):
+    def test_builds_current_fact_export_from_minimal_source_record_fixture(self) -> None:
+        source_payload = _fixture(SOURCE_RECORD_FIXTURE_DIR / "valid/current_fact_source_record_input_minimal.json")
+
+        export_payload = build_current_fact_export(source_payload)
+
+        self.assertEqual(export_payload["artifact_schema_version"], "current_fact_export/v2")
+        self.assertEqual(export_payload["run_id"], source_payload["run_id"])
+        self.assertEqual(export_payload["authority_boundary"], source_payload["authority_boundary"])
+        self.assertEqual(export_payload["generated_from"], sorted(source_payload["generated_from"]))
+        self.assertEqual(len(export_payload["records"]), 1)
+        self.assertEqual(validate_current_fact_export_payload(export_payload), [])
+
+    def test_source_record_sidecar_fields_do_not_leak_into_export_records(self) -> None:
+        source_payload = _fixture(SOURCE_RECORD_FIXTURE_DIR / "valid/current_fact_source_record_input_minimal.json")
+
+        export_payload = build_current_fact_export(source_payload)
+
+        for record in export_payload["records"]:
+            self.assertFalse(SOURCE_RECORD_ONLY_FIELDS & set(record))
+
+    def test_non_scalar_parsed_values_remain_wrapped(self) -> None:
+        source_payload = _fixture(SOURCE_RECORD_FIXTURE_DIR / "valid/current_fact_source_record_input_non_scalar_values.json")
+
+        export_payload = build_current_fact_export(source_payload)
+        parsed_by_status = {
+            record["calculation_input_status"]: record["parsed_value"]
+            for record in export_payload["records"]
+        }
+
+        self.assertEqual(
+            parsed_by_status["annotated_candidate_not_calculation_safe"]["kind"],
+            "annotated_numeric_candidate",
+        )
+        self.assertIn(
+            "numeric_candidate",
+            parsed_by_status["annotated_candidate_not_calculation_safe"],
+        )
+        self.assertEqual(
+            parsed_by_status["parsed_range_not_single_value_calculation_safe"]["kind"],
+            "frame_range",
+        )
+        self.assertEqual(
+            parsed_by_status["parsed_range_not_single_value_calculation_safe"],
+            {"kind": "frame_range", "unit": "frame", "start": 6, "end": 8},
+        )
+
+    def test_output_ordering_is_deterministic(self) -> None:
+        source_payload = _fixture(SOURCE_RECORD_FIXTURE_DIR / "valid/current_fact_source_record_input_non_scalar_values.json")
+        source_payload["records"] = list(reversed(source_payload["records"]))
+
+        export_payload = build_current_fact_export(source_payload)
+
+        self.assertEqual(
+            [record["field_key"] for record in export_payload["records"]],
+            ["block_advantage", "active"],
+        )
+
+    def test_invalid_source_record_fixtures_are_rejected(self) -> None:
+        for path in sorted((SOURCE_RECORD_FIXTURE_DIR / "invalid").glob("*.json")):
+            with self.subTest(path=path.name):
+                with self.assertRaises(CurrentFactExportGeneratorError):
+                    build_current_fact_export(_fixture(path))
+
+    def test_source_record_identity_mismatches_are_rejected(self) -> None:
+        source_payload = _fixture(SOURCE_RECORD_FIXTURE_DIR / "valid/current_fact_source_record_input_minimal.json")
+        source_payload["records"][0]["raw_value_sha256"] = "0" * 64
+
+        with self.assertRaises(CurrentFactExportGeneratorError):
+            build_current_fact_export(source_payload)
+
+    def test_export_validation_rejects_flattened_annotated_candidate(self) -> None:
+        source_payload = _fixture(SOURCE_RECORD_FIXTURE_DIR / "valid/current_fact_source_record_input_non_scalar_values.json")
+        export_payload = build_current_fact_export(source_payload)
+        flattened = copy.deepcopy(export_payload)
+        annotated = next(
+            record for record in flattened["records"]
+            if record["calculation_input_status"] == "annotated_candidate_not_calculation_safe"
+        )
+        annotated["parsed_value"] = {"kind": "signed_frame", "unit": "frame", "value": -4}
+
+        errors = validate_current_fact_export_payload(flattened)
+
+        self.assertTrue(any("annotated status must keep annotated_numeric_candidate" in error for error in errors))
+
+    def test_export_validation_rejects_collapsed_frame_range(self) -> None:
+        source_payload = _fixture(SOURCE_RECORD_FIXTURE_DIR / "valid/current_fact_source_record_input_non_scalar_values.json")
+        export_payload = build_current_fact_export(source_payload)
+        collapsed = copy.deepcopy(export_payload)
+        frame_range = next(
+            record for record in collapsed["records"]
+            if record["calculation_input_status"] == "parsed_range_not_single_value_calculation_safe"
+        )
+        frame_range["parsed_value"] = {"kind": "signed_frame", "unit": "frame", "value": 6}
+
+        errors = validate_current_fact_export_payload(collapsed)
+
+        self.assertTrue(any("range status must keep frame_range wrapper" in error for error in errors))
+
+    def test_export_validation_rejects_legacy_generated_from(self) -> None:
+        source_payload = _fixture(SOURCE_RECORD_FIXTURE_DIR / "valid/current_fact_source_record_input_minimal.json")
+        export_payload = build_current_fact_export(source_payload)
+        export_payload["generated_from"] = ["data/exports/jp/official_raw.json"]
+
+        errors = validate_current_fact_export_payload(export_payload)
+
+        self.assertTrue(any("data/exports" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/validate_current_fact_export_generator.py
+++ b/tests/validation/validate_current_fact_export_generator.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from sf6_knowledge_coach.current_fact_export_generator import (
+    CurrentFactExportGeneratorError,
+    build_current_fact_export,
+    validate_current_fact_export_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE_RECORD_FIXTURE_DIR = ROOT / "tests/fixtures/current-facts/source-records"
+PRODUCTION_ARTIFACT_DIRS = (
+    ROOT / "data/current-facts",
+    ROOT / "docs/current-facts",
+)
+SIDECAR_FIELDS = {
+    "raw_value_length",
+    "raw_value_sha256",
+    "source_cell_key",
+    "source_cell_order",
+    "source_record_id",
+    "source_row_key",
+    "source_row_order",
+    "source_value_key",
+}
+
+
+def main() -> int:
+    errors: list[str] = []
+    valid_payloads = _load_valid_source_record_fixtures(errors)
+    _validate_valid_fixture_generation(valid_payloads, errors)
+    _validate_invalid_fixture_rejections(errors)
+    _validate_synthetic_export_boundary_mutations(valid_payloads, errors)
+    _validate_no_production_artifacts(errors)
+    return _finish(errors)
+
+
+def _load_valid_source_record_fixtures(errors: list[str]) -> dict[Path, dict[str, Any]]:
+    valid_dir = SOURCE_RECORD_FIXTURE_DIR / "valid"
+    payloads: dict[Path, dict[str, Any]] = {}
+    for path in sorted(valid_dir.glob("*.json")):
+        payloads[path] = json.loads(path.read_text(encoding="utf-8"))
+    if not payloads:
+        errors.append(f"Missing source-record generator fixtures under {valid_dir.relative_to(ROOT)}")
+    return payloads
+
+
+def _validate_valid_fixture_generation(
+    payloads: dict[Path, dict[str, Any]],
+    errors: list[str],
+) -> None:
+    for path, source_payload in payloads.items():
+        try:
+            export_payload = build_current_fact_export(source_payload)
+        except CurrentFactExportGeneratorError as exc:
+            errors.append(f"{path.relative_to(ROOT)} should build a valid export: {exc}")
+            continue
+        export_errors = validate_current_fact_export_payload(export_payload)
+        if export_errors:
+            errors.append(f"{path.relative_to(ROOT)} generated invalid export: {export_errors[0]}")
+            continue
+        if export_payload.get("artifact_schema_version") != "current_fact_export/v2":
+            errors.append(f"{path.relative_to(ROOT)} generated wrong export schema version")
+        if export_payload.get("generated_from") != sorted(source_payload.get("generated_from", [])):
+            errors.append(f"{path.relative_to(ROOT)} generated_from must be sorted source paths")
+        _validate_records(path, export_payload.get("records", []), errors)
+
+
+def _validate_records(path: Path, records: Any, errors: list[str]) -> None:
+    if not isinstance(records, list):
+        errors.append(f"{path.relative_to(ROOT)} generated records must be a list")
+        return
+    sort_keys = [
+        (
+            record.get("source_name"),
+            record.get("character_slug"),
+            "" if record.get("move_id") is None else record.get("move_id"),
+            record.get("field_key"),
+            record.get("record_id"),
+        )
+        for record in records
+        if isinstance(record, dict)
+    ]
+    if sort_keys != sorted(sort_keys):
+        errors.append(f"{path.relative_to(ROOT)} generated records are not deterministically sorted")
+    for index, record in enumerate(records):
+        if not isinstance(record, dict):
+            errors.append(f"{path.relative_to(ROOT)} records[{index}] must be an object")
+            continue
+        leaked = sorted(SIDECAR_FIELDS & set(record))
+        if leaked:
+            errors.append(f"{path.relative_to(ROOT)} records[{index}] leaked source-record sidecar fields: {leaked}")
+        if "parsed_value" not in record:
+            errors.append(f"{path.relative_to(ROOT)} records[{index}] missing parsed_value")
+        status = record.get("calculation_input_status")
+        parsed_value = record.get("parsed_value")
+        parsed_kind = parsed_value.get("kind") if isinstance(parsed_value, dict) else None
+        if status == "annotated_candidate_not_calculation_safe" and parsed_kind != "annotated_numeric_candidate":
+            errors.append(f"{path.relative_to(ROOT)} records[{index}] flattened annotated candidate")
+        if status == "parsed_range_not_single_value_calculation_safe" and parsed_kind != "frame_range":
+            errors.append(f"{path.relative_to(ROOT)} records[{index}] collapsed frame_range")
+        if record.get("source_name") == "supercombo" and status == "eligible_only_after_domain_source_and_unit_checks":
+            errors.append(f"{path.relative_to(ROOT)} records[{index}] promoted SuperCombo numeric authority")
+
+
+def _validate_invalid_fixture_rejections(errors: list[str]) -> None:
+    invalid_dir = SOURCE_RECORD_FIXTURE_DIR / "invalid"
+    fixtures = sorted(invalid_dir.glob("*.json"))
+    if not fixtures:
+        errors.append(f"Missing invalid source-record fixtures under {invalid_dir.relative_to(ROOT)}")
+    for path in fixtures:
+        try:
+            build_current_fact_export(json.loads(path.read_text(encoding="utf-8")))
+        except CurrentFactExportGeneratorError:
+            continue
+        errors.append(f"{path.relative_to(ROOT)} should be rejected by generator")
+
+
+def _validate_synthetic_export_boundary_mutations(
+    payloads: dict[Path, dict[str, Any]],
+    errors: list[str],
+) -> None:
+    if not payloads:
+        return
+    export_payload = build_current_fact_export(next(iter(payloads.values())))
+    mutations = {
+        "legacy generated_from": lambda payload: payload.update(
+            {"generated_from": ["data/exports/jp/official_raw.json"]}
+        ),
+        "local generated_from": lambda payload: payload.update(
+            {"generated_from": ["docs/.local/current-fact-export.json"]}
+        ),
+        "screenshot generated_from": lambda payload: payload.update(
+            {"generated_from": ["docs/current-facts/value-screenshot.png"]}
+        ),
+        "sidecar leak": lambda payload: payload["records"][0].update(
+            {"source_record_id": "source-record:leak"}
+        ),
+        "raw html value": lambda payload: payload["records"][0].update(
+            {"raw_value": "<table></table>"}
+        ),
+        "supercombo scalar authority": lambda payload: payload["records"][0].update(
+            {
+                "authority_status": "cross_reference_candidate",
+                "calculation_input_status": "eligible_only_after_domain_source_and_unit_checks",
+                "source_name": "supercombo",
+                "source_role": "cross_reference_candidate",
+            }
+        ),
+    }
+    for label, mutate in mutations.items():
+        mutated = copy.deepcopy(export_payload)
+        mutate(mutated)
+        if not validate_current_fact_export_payload(mutated):
+            errors.append(f"synthetic export boundary mutation should be rejected: {label}")
+
+
+def _validate_no_production_artifacts(errors: list[str]) -> None:
+    for directory in PRODUCTION_ARTIFACT_DIRS:
+        if not directory.exists():
+            continue
+        files = sorted(path for path in directory.rglob("*") if path.is_file())
+        if files:
+            relative = [path.relative_to(ROOT).as_posix() for path in files]
+            errors.append(f"fixture-contract generator must not create production artifacts: {relative}")
+
+
+def _finish(errors: list[str]) -> int:
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("Current-fact export generator validation OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds an in-memory fixture-contract current-fact export generator helper.
- Adds focused unit tests and validator coverage for source-record fixture input, `current_fact_export/v2` output, deterministic ordering, sidecar stripping, guard/authority boundaries, and no production artifact generation.
- Updates validator audit artifacts and the implementation ExecPlan progress/completion table.

## Boundaries

- No production source-record artifact under `data/current-facts/source-records/`.
- No production current-fact export artifact under `data/current-facts/`.
- No CLI or file writer.
- No runtime lookup, `current_facts.py`, `answering.py`, parser/classifier behavior, retrieval, answer, calculator, SymPy, source acquisition, or live acquisition changes.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `uv lock --check`
- `PYTHONPATH=src uv run --locked python -m unittest discover -s tests`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py`
- `PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_export_generator.py`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_validator_test_audit.py`
- all `tests/validation/validate_*.py`
