### PR TITLE
Implement current-fact row move cell candidate schema

### DIFF
--- a/contracts/current-facts/current_fact_row_move_cell_candidate_input.schema.json
+++ b/contracts/current-facts/current_fact_row_move_cell_candidate_input.schema.json
@@ -1,0 +1,387 @@
+{
+  "$id": "https://sf6-knowledge-coach.local/schemas/current-facts/current_fact_row_move_cell_candidate_input.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "artifact_schema_version": { "const": "current_fact_row_move_cell_candidate_input/v1" },
+    "authority_boundary": {
+      "additionalProperties": false,
+      "properties": {
+        "official": { "const": "authority_candidate_only" },
+        "supercombo": { "const": "enrichment_or_cross_reference_only" }
+      },
+      "required": ["official", "supercombo"],
+      "type": "object"
+    },
+    "candidate_boundary": {
+      "additionalProperties": false,
+      "properties": {
+        "blocked_records": { "const": "excluded_to_classifier_or_source_review" },
+        "legacy_raw_exports": { "const": "excluded_as_source_input" },
+        "local_source_payloads": { "const": "excluded_from_public_artifact" },
+        "lookup_ready_candidates": { "const": "parsed_value_only" },
+        "reviewer_observations": { "const": "observation_candidate_only_not_authority" },
+        "supercombo": { "const": "enrichment_or_cross_reference_only" },
+        "synthetic_fixtures": { "const": "not_source_truth" }
+      },
+      "required": [
+        "blocked_records",
+        "legacy_raw_exports",
+        "local_source_payloads",
+        "lookup_ready_candidates",
+        "reviewer_observations",
+        "supercombo",
+        "synthetic_fixtures"
+      ],
+      "type": "object"
+    },
+    "generated_from": {
+      "items": { "$ref": "#/$defs/public_artifact_path" },
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "records": {
+      "items": { "$ref": "#/$defs/candidate_record" },
+      "minItems": 1,
+      "type": "array"
+    },
+    "run_id": {
+      "pattern": "^[0-9]{8}T[0-9]{6}Z$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "artifact_schema_version",
+    "authority_boundary",
+    "candidate_boundary",
+    "generated_from",
+    "records",
+    "run_id"
+  ],
+  "$defs": {
+    "identity_key": {
+      "pattern": "^[a-z0-9][a-z0-9_.:-]*$",
+      "type": "string"
+    },
+    "parser_rule_id": {
+      "pattern": "^[a-z0-9][a-z0-9_.-]*$",
+      "type": "string"
+    },
+    "public_artifact_path": {
+      "allOf": [
+        {
+          "pattern": "^(data|docs|contracts)/[A-Za-z0-9_.:/-]+$",
+          "type": "string"
+        },
+        {
+          "not": { "pattern": "^data/exports/" }
+        },
+        {
+          "not": { "pattern": "(^|/)\\.local(/|$)" }
+        },
+        {
+          "not": { "pattern": "(screen[-_]?shot|chat[-_]?gpt|vlm|raw[-_]?html|full[-_]?row|cook(?:ie)|prof(?:ile)|trac(?:e)|debu(?:g)|priv(?:ate)|tok(?:en))" }
+        }
+      ]
+    },
+    "public_reference_array": {
+      "items": { "$ref": "#/$defs/public_artifact_path" },
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "source_family": {
+      "enum": [
+        "advantage",
+        "attribute",
+        "cancel",
+        "damage",
+        "defense",
+        "gauge",
+        "identity",
+        "metadata",
+        "mobility",
+        "note",
+        "projectile",
+        "scaling",
+        "throw",
+        "timing",
+        "vital"
+      ]
+    },
+    "candidate_record": {
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "calculation_input_status": {
+                "const": "annotated_candidate_not_calculation_safe"
+              }
+            },
+            "required": ["calculation_input_status"]
+          },
+          "then": {
+            "properties": {
+              "parsed_value": {
+                "properties": {
+                  "kind": { "const": "annotated_numeric_candidate" }
+                },
+                "required": ["kind"],
+                "type": "object"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "parsed_value": {
+                "properties": {
+                  "kind": { "const": "annotated_numeric_candidate" }
+                },
+                "required": ["kind"],
+                "type": "object"
+              }
+            },
+            "required": ["parsed_value"]
+          },
+          "then": {
+            "properties": {
+              "calculation_input_status": {
+                "const": "annotated_candidate_not_calculation_safe"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "calculation_input_status": {
+                "const": "parsed_range_not_single_value_calculation_safe"
+              }
+            },
+            "required": ["calculation_input_status"]
+          },
+          "then": {
+            "properties": {
+              "parsed_value": {
+                "properties": {
+                  "kind": { "const": "frame_range" }
+                },
+                "required": ["kind"],
+                "type": "object"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "parsed_value": {
+                "properties": {
+                  "kind": { "const": "frame_range" }
+                },
+                "required": ["kind"],
+                "type": "object"
+              }
+            },
+            "required": ["parsed_value"]
+          },
+          "then": {
+            "properties": {
+              "calculation_input_status": {
+                "const": "parsed_range_not_single_value_calculation_safe"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "source_name": { "const": "official" }
+            },
+            "required": ["source_name"]
+          },
+          "then": {
+            "properties": {
+              "authority_status": { "const": "authority_candidate" },
+              "source_role": { "const": "authority_candidate" }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "source_name": { "const": "supercombo" }
+            },
+            "required": ["source_name"]
+          },
+          "then": {
+            "properties": {
+              "authority_status": {
+                "enum": ["cross_reference_candidate", "enrichment_candidate", "not_authority"]
+              },
+              "calculation_input_status": {
+                "not": {
+                  "const": "eligible_only_after_domain_source_and_unit_checks"
+                }
+              },
+              "source_role": {
+                "enum": ["cross_reference_candidate", "enrichment_candidate"]
+              }
+            }
+          }
+        }
+      ],
+      "properties": {
+        "acquisition_report_refs": { "$ref": "#/$defs/public_reference_array" },
+        "authority_status": {
+          "enum": [
+            "authority_candidate",
+            "cross_reference_candidate",
+            "enrichment_candidate",
+            "not_authority"
+          ]
+        },
+        "calculation_input_status": {
+          "allOf": [
+            {
+              "enum": [
+                "eligible_only_after_domain_source_and_unit_checks",
+                "annotated_candidate_not_calculation_safe",
+                "parsed_range_not_single_value_calculation_safe",
+                "review_required_not_calculation_safe",
+                "enum_only_not_arithmetic",
+                "raw_preserved_not_calculation",
+                "not_numeric_authority",
+                "out_of_scope_not_emitted"
+              ]
+            },
+            {
+              "not": {
+                "enum": [
+                  "review_required_not_calculation_safe",
+                  "out_of_scope_not_emitted"
+                ]
+              }
+            }
+          ]
+        },
+        "candidate_record_id": { "$ref": "#/$defs/identity_key" },
+        "character_slug": {
+          "pattern": "^[a-z0-9_]+$",
+          "type": "string"
+        },
+        "coverage_refs": { "$ref": "#/$defs/public_reference_array" },
+        "display_label_ja": { "type": "string" },
+        "evidence": {
+          "allOf": [
+            {
+              "$ref": "https://sf6-knowledge-coach.local/schemas/current-facts/source_reference.schema.json"
+            },
+            {
+              "properties": {
+                "public_reference": {
+                  "$ref": "#/$defs/public_artifact_path"
+                }
+              },
+              "type": "object"
+            }
+          ]
+        },
+        "field_key": {
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "type": "string"
+        },
+        "move_id": { "$ref": "#/$defs/identity_key" },
+        "parsed_value": {
+          "$ref": "https://sf6-knowledge-coach.local/schemas/current-facts/parsed_value.schema.json"
+        },
+        "parser_rule_ids": {
+          "items": { "$ref": "#/$defs/parser_rule_id" },
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "raw_value": {
+          "not": {
+            "pattern": "<[/!]?[A-Za-z]"
+          },
+          "type": "string"
+        },
+        "raw_value_length": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "raw_value_sha256": {
+          "pattern": "^[a-f0-9]{64}$",
+          "type": "string"
+        },
+        "source_cell_key": { "$ref": "#/$defs/identity_key" },
+        "source_cell_order": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "source_family": { "$ref": "#/$defs/source_family" },
+        "source_header_path": {
+          "items": { "type": "string" },
+          "minItems": 1,
+          "type": "array"
+        },
+        "source_label": { "type": "string" },
+        "source_name": { "enum": ["official", "supercombo"] },
+        "source_review_refs": { "$ref": "#/$defs/public_reference_array" },
+        "source_role": {
+          "enum": [
+            "authority_candidate",
+            "cross_reference_candidate",
+            "enrichment_candidate"
+          ]
+        },
+        "source_row_key": { "$ref": "#/$defs/identity_key" },
+        "source_row_order": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "source_value_key": { "$ref": "#/$defs/identity_key" },
+        "value_shape": {
+          "$ref": "https://sf6-knowledge-coach.local/schemas/current-facts/value_shape.schema.json"
+        }
+      },
+      "required": [
+        "acquisition_report_refs",
+        "authority_status",
+        "calculation_input_status",
+        "candidate_record_id",
+        "character_slug",
+        "coverage_refs",
+        "display_label_ja",
+        "evidence",
+        "field_key",
+        "move_id",
+        "parsed_value",
+        "parser_rule_ids",
+        "raw_value",
+        "raw_value_length",
+        "raw_value_sha256",
+        "source_cell_key",
+        "source_cell_order",
+        "source_family",
+        "source_header_path",
+        "source_label",
+        "source_name",
+        "source_review_refs",
+        "source_role",
+        "source_row_key",
+        "source_row_order",
+        "source_value_key",
+        "value_shape"
+      ],
+      "type": "object"
+    }
+  },
+  "title": "Current-fact row/move/cell candidate input artifact",
+  "type": "object"
+}

--- a/data/validator-audits/20260523-validator-test-fact-source-audit.json
+++ b/data/validator-audits/20260523-validator-test-fact-source-audit.json
@@ -142,6 +142,19 @@
       "status": "accepted_with_limits"
     },
     {
+      "evidence_class": "synthetic_contract",
+      "file": "tests/validation/validate_current_fact_row_move_cell_candidates.py",
+      "limitations": [
+        "checks row/move/cell candidate schema, synthetic fixture contracts, and source-boundary guard mutations; does not produce production candidates or prove source truth"
+      ],
+      "primary_evidence": [
+        "contracts/current-facts/current_fact_row_move_cell_candidate_input.schema.json",
+        "tests/fixtures/current-facts/candidate-inputs",
+        "current-fact row/move/cell candidate schema ExecPlan"
+      ],
+      "status": "accepted_with_limits"
+    },
+    {
       "evidence_class": "artifact_consistency",
       "file": "tests/validation/validate_current_fact_consumer_guards.py",
       "limitations": [

--- a/docs/execplans/2026-05-25-current-fact-row-move-cell-candidate-schema.md
+++ b/docs/execplans/2026-05-25-current-fact-row-move-cell-candidate-schema.md
@@ -1,6 +1,6 @@
 # Current-Fact Row/Move/Cell Candidate Schema
 
-Status: Drafted for review; validation passed.
+Status: Implemented; validation passed.
 
 ## Purpose
 
@@ -10,6 +10,10 @@ entries for `current_fact_row_move_cell_candidate_input/v1`.
 This plan follows the reviewed row/move/cell candidate input boundary. It does
 not implement candidate artifact generation and does not create production
 source-record or current-fact export artifacts.
+
+The original planning PR was docs-only. This implementation follow-up adds
+only the schema, synthetic fixtures, focused validator, validator audit
+updates, inventory compatibility updates, and this ExecPlan progress update.
 
 ## Inputs
 
@@ -52,21 +56,18 @@ focused validator, and validator audit entries.
 
 ## Scope
 
-Included in this docs-only plan:
+Included in the approved implementation slice:
 
-- define exact files for the future schema/fixture/validator implementation;
-- define the artifact schema version and high-level schema requirements;
-- define synthetic valid and invalid fixture coverage;
-- define focused validator behavior;
-- define validator audit updates;
+- add the candidate input schema;
+- add synthetic valid and invalid fixture coverage;
+- add the focused candidate validator;
+- update schema inventory/compatibility validators only as needed;
+- update validator audit artifacts;
 - preserve summary-safe, parsed-value-only, non-scalar guard, and source
   boundary rules.
 
 Excluded:
 
-- No schema implementation in this docs-only PR.
-- No fixture implementation in this docs-only PR.
-- No validator implementation in this docs-only PR.
 - No candidate artifact generation.
 - No production source-record artifact generation.
 - No production current-fact export artifact generation.
@@ -279,45 +280,44 @@ promotion, or numeric authority.
 
 ## Acceptance Criteria
 
-- The plan is docs-only.
-- The plan defines exact schema, fixture, validator, audit, and ExecPlan files
-  for the future implementation.
-- Future fixtures are synthetic contract fixtures only.
-- The plan does not authorize candidate artifact generation.
-- The plan does not authorize production source-record or current-fact export
-  artifact generation.
-- The plan rejects legacy raw exports as replacement source input.
-- The plan preserves summary-safe boundaries.
-- The plan preserves parsed-value-only admission.
-- The plan keeps review-required/no parsed-value records out of lookup-ready
-  valid fixtures.
-- The plan preserves `annotated_numeric_candidate` and `frame_range`
-  non-scalar guard boundaries.
-- The plan keeps Issue #343 double-check gate mandatory for future
-  value-handling decisions.
-- The plan does not change runtime lookup, `current_facts.py`, `answering.py`,
-  parser/classifier behavior, retrieval, answer, calculator, SymPy, source
-  acquisition, or live acquisition.
+- The implementation is limited to schema, synthetic fixtures, focused
+  validator, validator audit, inventory compatibility, and this ExecPlan
+  update.
+- Fixtures are synthetic contract fixtures only.
+- No candidate artifact is generated.
+- No production source-record or current-fact export artifact is generated.
+- Legacy raw exports are rejected as replacement source input.
+- Summary-safe boundaries are preserved.
+- Parsed-value-only admission is preserved.
+- Review-required/no parsed-value records stay out of valid lookup-ready
+  fixtures.
+- `annotated_numeric_candidate` and `frame_range` non-scalar guard boundaries
+  are preserved.
+- Issue #343 double-check gate remains mandatory for future value-handling
+  decisions.
+- Runtime lookup, `current_facts.py`, `answering.py`, parser/classifier
+  behavior, retrieval, answer, calculator, SymPy, source acquisition, and live
+  acquisition remain unchanged.
 
 ## Files / Interfaces
 
-This docs-only PR should change only:
-
-- `docs/execplans/2026-05-25-current-fact-row-move-cell-candidate-schema.md`
-
-Future implementation plans may touch the files listed in Planned Files only
-after mandatory review approval.
+This implementation PR may change only the files listed in Planned Files.
+Future artifact generation or runtime plans need separate mandatory review.
 
 ## Validation Commands
 
 ```bash
 git diff --check
+git diff --cached --check
 uv lock --check
+PYTHONPATH=src uv run --locked python -m unittest discover -s tests
 PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
 PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py
 PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py
 PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py
 PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_export_generator.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_row_move_cell_candidates.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_validator_test_audit.py
 PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
 git status --short --branch
 ```
@@ -328,6 +328,11 @@ git status --short --branch
   PR #361 merged. No implementation or generated artifact changes included.
 - 2026-05-25: Ran validation commands. They passed with only this new
   ExecPlan file untracked.
+- 2026-05-25: Implemented the contract-only schema/fixtures/validator slice.
+  Added no production candidate, source-record, or export artifacts.
+- 2026-05-25: Ran implementation validation, including unittest,
+  current-fact schema/source-record/consumer/export/candidate validators,
+  validator audit, and parsed-value classifier validation. All passed.
 
 ## Decision Log
 
@@ -339,6 +344,10 @@ git status --short --branch
   `parsed_value`.
 - 2026-05-25: Review-required/no parsed-value records belong in invalid
   fixtures and remain out of valid lookup-ready candidate fixtures.
+- 2026-05-25: Candidate fixtures are synthetic contract fixtures only and use
+  `synthetic_contract_fixture` evidence; they are not source truth.
+- 2026-05-25: The focused validator checks source-boundary mutations instead
+  of relaxing existing source-record, export, or guard validators.
 
 ## Deviations
 
@@ -358,23 +367,27 @@ git status --short --branch
 
 | PLAN item | Implementation content | Changed files | Validation command | Result | Deviation | Incomplete | Risk |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Docs-only schema/fixture/validator plan | Draft plan only | `docs/execplans/2026-05-25-current-fact-row-move-cell-candidate-schema.md` | `git diff --check` | Pass | None | Mandatory review pending | Schema implementation not started |
-| Runtime and artifact boundary | No runtime, schema, validator, or generated artifact changes | Same | `git status --short --branch` | Pass; one untracked ExecPlan file only | None | Mandatory review pending | Runtime remains legacy raw export backed |
+| Candidate schema | Added `current_fact_row_move_cell_candidate_input/v1` contract | `contracts/current-facts/current_fact_row_move_cell_candidate_input.schema.json` | `validate_current_fact_row_move_cell_candidates.py` | Pass | None | Mandatory review pending | Schema field names still need review |
+| Synthetic fixtures | Added valid/invalid candidate input fixtures only | `tests/fixtures/current-facts/candidate-inputs/**` | `validate_current_fact_row_move_cell_candidates.py` | Pass | None | Mandatory review pending | Fixtures do not prove source truth |
+| Focused validator and inventory | Added candidate validator and schema inventory compatibility updates | `tests/validation/validate_current_fact_row_move_cell_candidates.py`, `tests/validation/validate_clean_slate.py`, `tests/validation/validate_current_fact_schemas.py` | `validate_clean_slate.py`; `validate_current_fact_schemas.py`; `validate_current_fact_row_move_cell_candidates.py` | Pass | None | Mandatory review pending | Validator proves contract boundary only |
+| Validator audit | Added validator audit entry for candidate validator | `data/validator-audits/20260523-validator-test-fact-source-audit.json`, `docs/validator-audits/20260523-validator-test-fact-source-audit.md` | `validate_validator_test_audit.py` | Pass | None | Mandatory review pending | Audit is not source truth |
+| Runtime and artifact boundary | No runtime or generated artifact changes | No `data/current-facts/**` or `docs/current-facts/**` production artifacts | `git status --short --branch`; artifact path check | Pass | None | Mandatory review pending | Runtime remains legacy raw export backed |
 
 ## Next Reviewer Prompt
 
 ```text
-Review docs/execplans/2026-05-25-current-fact-row-move-cell-candidate-schema.md.
+Review implementation of docs/execplans/2026-05-25-current-fact-row-move-cell-candidate-schema.md.
 
 Check:
-- PR diff contains exactly one ExecPlan file.
-- Plan is docs-only.
-- It defines exact schema file path, fixture paths, validator path, and audit files.
-- It uses synthetic contract fixtures only.
-- It does not authorize candidate artifact generation.
-- It does not authorize production source-record artifact generation.
-- It does not authorize production current-fact export artifact generation.
-- It does not change runtime lookup, current_facts.py, answering.py, parser/classifier behavior, retrieval, answer, calculator, SymPy, source acquisition, or live acquisition.
+- PR diff contains only the approved schema, synthetic fixtures, focused validator, inventory/audit updates, and ExecPlan progress update.
+- Schema path is `contracts/current-facts/current_fact_row_move_cell_candidate_input.schema.json`.
+- Fixture paths are under `tests/fixtures/current-facts/candidate-inputs/`.
+- Validator path is `tests/validation/validate_current_fact_row_move_cell_candidates.py`.
+- Fixtures are synthetic contract fixtures only.
+- No candidate artifact generation is included.
+- No production source-record artifact generation is included.
+- No production current-fact export artifact generation is included.
+- No runtime lookup, current_facts.py, answering.py, parser/classifier behavior, retrieval, answer, calculator, SymPy, source acquisition, or live acquisition changes are included.
 - Summary-safe boundaries are preserved.
 - Legacy data/exports/*/official_raw.json is rejected as replacement source input.
 - Parsed-value-only admission is preserved.
@@ -386,13 +399,17 @@ Run:
 - git status --short --branch
 - git show --name-status --oneline --no-renames HEAD
 - git diff --check origin/main...HEAD
+- git diff --cached --check
 - uv lock --check
+- PYTHONPATH=src uv run --locked python -m unittest discover -s tests
 - PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
 - PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py
 - PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py
 - PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py
 - PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_export_generator.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_row_move_cell_candidates.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_validator_test_audit.py
 - PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
 
-Return blocking findings first, validation results, PLAN deviations, remaining risks, and whether docs-only stage/commit is approved.
+Return blocking findings first, validation results, PLAN deviations, remaining risks, and whether implementation is stage-ready.
 ```

--- a/docs/validator-audits/20260523-validator-test-fact-source-audit.md
+++ b/docs/validator-audits/20260523-validator-test-fact-source-audit.md
@@ -24,6 +24,7 @@ privacy/security boundary.
 | `tests/test_value_shape_inventory.py` | source-derived | accepted with limits | representative shape checks are not parser semantics |
 | `tests/validation/validate_clean_slate.py` | governance boundary | accepted with limits | repo shape and approved contract file inventory only |
 | `tests/validation/validate_current_fact_export_generator.py` | artifact consistency | accepted with limits | fixture-contract generator output, guard boundaries, and no production artifact paths only |
+| `tests/validation/validate_current_fact_row_move_cell_candidates.py` | synthetic contract | accepted with limits | candidate schema, synthetic fixture contracts, and source-boundary guard mutations only; no production candidates or source truth |
 | `tests/validation/validate_current_fact_consumer_guards.py` | artifact consistency | accepted with limits | guard behavior against synthetic fixtures and coverage statuses only |
 | `tests/validation/validate_current_fact_source_records.py` | synthetic contract | accepted with limits | source-record schema, fixture contracts, and source-boundary guard mutations only; no production source records or source truth |
 | `tests/validation/validate_current_fact_schemas.py` | synthetic contract | accepted with limits | schema and fixture contracts only; no parser/source truth |

--- a/tests/fixtures/current-facts/candidate-inputs/invalid/current_fact_row_move_cell_candidate_input_collapsed_frame_range.json
+++ b/tests/fixtures/current-facts/candidate-inputs/invalid/current_fact_row_move_cell_candidate_input_collapsed_frame_range.json
@@ -1,0 +1,61 @@
+{
+  "artifact_schema_version": "current_fact_row_move_cell_candidate_input/v1",
+  "authority_boundary": {
+    "official": "authority_candidate_only",
+    "supercombo": "enrichment_or_cross_reference_only"
+  },
+  "candidate_boundary": {
+    "blocked_records": "excluded_to_classifier_or_source_review",
+    "legacy_raw_exports": "excluded_as_source_input",
+    "local_source_payloads": "excluded_from_public_artifact",
+    "lookup_ready_candidates": "parsed_value_only",
+    "reviewer_observations": "observation_candidate_only_not_authority",
+    "supercombo": "enrichment_or_cross_reference_only",
+    "synthetic_fixtures": "not_source_truth"
+  },
+  "generated_from": ["data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"],
+  "records": [
+    {
+      "acquisition_report_refs": ["docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"],
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "parsed_range_not_single_value_calculation_safe",
+      "candidate_record_id": "candidate:official:jp:jp_001_5lp:active",
+      "character_slug": "jp",
+      "coverage_refs": ["data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"],
+      "display_label_ja": "持続",
+      "evidence": {
+        "evidence_basis": "synthetic_contract_fixture",
+        "public_reference": "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": ["動作フレーム", "持続"],
+        "source_label": "持続",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "active",
+      "move_id": "jp_001_5lp",
+      "parsed_value": { "kind": "signed_frame", "unit": "frame", "value": 6 },
+      "parser_rule_ids": ["frame_range.v1"],
+      "raw_value": "6-8",
+      "raw_value_length": 3,
+      "raw_value_sha256": "742595dc2605b1b9ded786a8b24f3ec0fddb44d49a77bb7186d3090411fb4e9f",
+      "source_cell_key": "official:jp:jp_001_5lp:active:cell",
+      "source_cell_order": 2,
+      "source_family": "timing",
+      "source_header_path": ["動作フレーム", "持続"],
+      "source_label": "持続",
+      "source_name": "official",
+      "source_review_refs": ["docs/source-reviews/20260524-official-note-linkage-source-review.md"],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:jp:jp_001_5lp",
+      "source_row_order": 1,
+      "source_value_key": "official:jp:jp_001_5lp:active:value-1",
+      "value_shape": {
+        "classes": ["range"],
+        "classifier_status": "parsed",
+        "parser_rule_id": "frame_range.v1"
+      }
+    }
+  ],
+  "run_id": "20260521T025403Z"
+}

--- a/tests/fixtures/current-facts/candidate-inputs/invalid/current_fact_row_move_cell_candidate_input_flattened_annotated_candidate.json
+++ b/tests/fixtures/current-facts/candidate-inputs/invalid/current_fact_row_move_cell_candidate_input_flattened_annotated_candidate.json
@@ -1,0 +1,61 @@
+{
+  "artifact_schema_version": "current_fact_row_move_cell_candidate_input/v1",
+  "authority_boundary": {
+    "official": "authority_candidate_only",
+    "supercombo": "enrichment_or_cross_reference_only"
+  },
+  "candidate_boundary": {
+    "blocked_records": "excluded_to_classifier_or_source_review",
+    "legacy_raw_exports": "excluded_as_source_input",
+    "local_source_payloads": "excluded_from_public_artifact",
+    "lookup_ready_candidates": "parsed_value_only",
+    "reviewer_observations": "observation_candidate_only_not_authority",
+    "supercombo": "enrichment_or_cross_reference_only",
+    "synthetic_fixtures": "not_source_truth"
+  },
+  "generated_from": ["data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"],
+  "records": [
+    {
+      "acquisition_report_refs": ["docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"],
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "candidate_record_id": "candidate:official:jp:jp_001_5lk:block_advantage:annotated",
+      "character_slug": "jp",
+      "coverage_refs": ["data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"],
+      "display_label_ja": "ガード硬直差",
+      "evidence": {
+        "evidence_basis": "synthetic_contract_fixture",
+        "public_reference": "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": ["硬直差", "ガード"],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "block_advantage",
+      "move_id": "jp_001_5lk",
+      "parsed_value": { "kind": "signed_frame", "unit": "frame", "value": -4 },
+      "parser_rule_ids": ["annotated_numeric_candidate.official_note_marker.v1"],
+      "raw_value": "※-4",
+      "raw_value_length": 3,
+      "raw_value_sha256": "b5112d05eab37a8ef2062523ba1cce640a8350c6cba7ef40bf66072550f3609c",
+      "source_cell_key": "official:jp:jp_001_5lk:block_advantage:cell",
+      "source_cell_order": 4,
+      "source_family": "advantage",
+      "source_header_path": ["硬直差", "ガード"],
+      "source_label": "ガード",
+      "source_name": "official",
+      "source_review_refs": ["docs/source-reviews/20260524-official-note-linkage-source-review.md"],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:jp:jp_001_5lk",
+      "source_row_order": 2,
+      "source_value_key": "official:jp:jp_001_5lk:block_advantage:value-1",
+      "value_shape": {
+        "classes": ["note_prefixed", "signed_frame"],
+        "classifier_status": "parsed",
+        "parser_rule_id": "annotated_numeric_candidate.official_note_marker.v1"
+      }
+    }
+  ],
+  "run_id": "20260521T025403Z"
+}

--- a/tests/fixtures/current-facts/candidate-inputs/invalid/current_fact_row_move_cell_candidate_input_legacy_generated_from.json
+++ b/tests/fixtures/current-facts/candidate-inputs/invalid/current_fact_row_move_cell_candidate_input_legacy_generated_from.json
@@ -1,0 +1,61 @@
+{
+  "artifact_schema_version": "current_fact_row_move_cell_candidate_input/v1",
+  "authority_boundary": {
+    "official": "authority_candidate_only",
+    "supercombo": "enrichment_or_cross_reference_only"
+  },
+  "candidate_boundary": {
+    "blocked_records": "excluded_to_classifier_or_source_review",
+    "legacy_raw_exports": "excluded_as_source_input",
+    "local_source_payloads": "excluded_from_public_artifact",
+    "lookup_ready_candidates": "parsed_value_only",
+    "reviewer_observations": "observation_candidate_only_not_authority",
+    "supercombo": "enrichment_or_cross_reference_only",
+    "synthetic_fixtures": "not_source_truth"
+  },
+  "generated_from": ["data/exports/jp/official_raw.json"],
+  "records": [
+    {
+      "acquisition_report_refs": ["docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"],
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "eligible_only_after_domain_source_and_unit_checks",
+      "candidate_record_id": "candidate:official:jp:jp_001_5lp:block_advantage",
+      "character_slug": "jp",
+      "coverage_refs": ["data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"],
+      "display_label_ja": "ガード硬直差",
+      "evidence": {
+        "evidence_basis": "synthetic_contract_fixture",
+        "public_reference": "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": ["硬直差", "ガード"],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "block_advantage",
+      "move_id": "jp_001_5lp",
+      "parsed_value": { "kind": "signed_frame", "unit": "frame", "value": -2 },
+      "parser_rule_ids": ["signed_frame.v1"],
+      "raw_value": "-2",
+      "raw_value_length": 2,
+      "raw_value_sha256": "cf3bae39dd692048a8bf961182e6a34dfd323eeb0748e162eaf055107f1cb873",
+      "source_cell_key": "official:jp:jp_001_5lp:block_advantage:cell",
+      "source_cell_order": 4,
+      "source_family": "advantage",
+      "source_header_path": ["硬直差", "ガード"],
+      "source_label": "ガード",
+      "source_name": "official",
+      "source_review_refs": ["docs/source-reviews/20260524-official-note-linkage-source-review.md"],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:jp:jp_001_5lp",
+      "source_row_order": 1,
+      "source_value_key": "official:jp:jp_001_5lp:block_advantage:value-1",
+      "value_shape": {
+        "classes": ["signed_frame"],
+        "classifier_status": "parsed",
+        "parser_rule_id": "signed_frame.v1"
+      }
+    }
+  ],
+  "run_id": "20260521T025403Z"
+}

--- a/tests/fixtures/current-facts/candidate-inputs/invalid/current_fact_row_move_cell_candidate_input_missing_parsed_value.json
+++ b/tests/fixtures/current-facts/candidate-inputs/invalid/current_fact_row_move_cell_candidate_input_missing_parsed_value.json
@@ -1,0 +1,60 @@
+{
+  "artifact_schema_version": "current_fact_row_move_cell_candidate_input/v1",
+  "authority_boundary": {
+    "official": "authority_candidate_only",
+    "supercombo": "enrichment_or_cross_reference_only"
+  },
+  "candidate_boundary": {
+    "blocked_records": "excluded_to_classifier_or_source_review",
+    "legacy_raw_exports": "excluded_as_source_input",
+    "local_source_payloads": "excluded_from_public_artifact",
+    "lookup_ready_candidates": "parsed_value_only",
+    "reviewer_observations": "observation_candidate_only_not_authority",
+    "supercombo": "enrichment_or_cross_reference_only",
+    "synthetic_fixtures": "not_source_truth"
+  },
+  "generated_from": ["data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"],
+  "records": [
+    {
+      "acquisition_report_refs": ["docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"],
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "eligible_only_after_domain_source_and_unit_checks",
+      "candidate_record_id": "candidate:official:jp:jp_001_5lp:block_advantage:missing-parsed",
+      "character_slug": "jp",
+      "coverage_refs": ["data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"],
+      "display_label_ja": "ガード硬直差",
+      "evidence": {
+        "evidence_basis": "synthetic_contract_fixture",
+        "public_reference": "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": ["硬直差", "ガード"],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "block_advantage",
+      "move_id": "jp_001_5lp",
+      "parser_rule_ids": ["signed_frame.v1"],
+      "raw_value": "-2",
+      "raw_value_length": 2,
+      "raw_value_sha256": "cf3bae39dd692048a8bf961182e6a34dfd323eeb0748e162eaf055107f1cb873",
+      "source_cell_key": "official:jp:jp_001_5lp:block_advantage:cell",
+      "source_cell_order": 4,
+      "source_family": "advantage",
+      "source_header_path": ["硬直差", "ガード"],
+      "source_label": "ガード",
+      "source_name": "official",
+      "source_review_refs": ["docs/source-reviews/20260524-official-note-linkage-source-review.md"],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:jp:jp_001_5lp",
+      "source_row_order": 1,
+      "source_value_key": "official:jp:jp_001_5lp:block_advantage:value-1",
+      "value_shape": {
+        "classes": ["signed_frame"],
+        "classifier_status": "parsed",
+        "parser_rule_id": "signed_frame.v1"
+      }
+    }
+  ],
+  "run_id": "20260521T025403Z"
+}

--- a/tests/fixtures/current-facts/candidate-inputs/invalid/current_fact_row_move_cell_candidate_input_private_or_local_reference.json
+++ b/tests/fixtures/current-facts/candidate-inputs/invalid/current_fact_row_move_cell_candidate_input_private_or_local_reference.json
@@ -1,0 +1,61 @@
+{
+  "artifact_schema_version": "current_fact_row_move_cell_candidate_input/v1",
+  "authority_boundary": {
+    "official": "authority_candidate_only",
+    "supercombo": "enrichment_or_cross_reference_only"
+  },
+  "candidate_boundary": {
+    "blocked_records": "excluded_to_classifier_or_source_review",
+    "legacy_raw_exports": "excluded_as_source_input",
+    "local_source_payloads": "excluded_from_public_artifact",
+    "lookup_ready_candidates": "parsed_value_only",
+    "reviewer_observations": "observation_candidate_only_not_authority",
+    "supercombo": "enrichment_or_cross_reference_only",
+    "synthetic_fixtures": "not_source_truth"
+  },
+  "generated_from": ["docs/.local/current-facts/candidate.json"],
+  "records": [
+    {
+      "acquisition_report_refs": ["docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"],
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "eligible_only_after_domain_source_and_unit_checks",
+      "candidate_record_id": "candidate:official:jp:jp_001_5lp:block_advantage",
+      "character_slug": "jp",
+      "coverage_refs": ["data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"],
+      "display_label_ja": "ガード硬直差",
+      "evidence": {
+        "evidence_basis": "synthetic_contract_fixture",
+        "public_reference": "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": ["硬直差", "ガード"],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "block_advantage",
+      "move_id": "jp_001_5lp",
+      "parsed_value": { "kind": "signed_frame", "unit": "frame", "value": -2 },
+      "parser_rule_ids": ["signed_frame.v1"],
+      "raw_value": "-2",
+      "raw_value_length": 2,
+      "raw_value_sha256": "cf3bae39dd692048a8bf961182e6a34dfd323eeb0748e162eaf055107f1cb873",
+      "source_cell_key": "official:jp:jp_001_5lp:block_advantage:cell",
+      "source_cell_order": 4,
+      "source_family": "advantage",
+      "source_header_path": ["硬直差", "ガード"],
+      "source_label": "ガード",
+      "source_name": "official",
+      "source_review_refs": ["docs/source-reviews/20260524-official-note-linkage-source-review.md"],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:jp:jp_001_5lp",
+      "source_row_order": 1,
+      "source_value_key": "official:jp:jp_001_5lp:block_advantage:value-1",
+      "value_shape": {
+        "classes": ["signed_frame"],
+        "classifier_status": "parsed",
+        "parser_rule_id": "signed_frame.v1"
+      }
+    }
+  ],
+  "run_id": "20260521T025403Z"
+}

--- a/tests/fixtures/current-facts/candidate-inputs/invalid/current_fact_row_move_cell_candidate_input_review_required_record.json
+++ b/tests/fixtures/current-facts/candidate-inputs/invalid/current_fact_row_move_cell_candidate_input_review_required_record.json
@@ -1,0 +1,60 @@
+{
+  "artifact_schema_version": "current_fact_row_move_cell_candidate_input/v1",
+  "authority_boundary": {
+    "official": "authority_candidate_only",
+    "supercombo": "enrichment_or_cross_reference_only"
+  },
+  "candidate_boundary": {
+    "blocked_records": "excluded_to_classifier_or_source_review",
+    "legacy_raw_exports": "excluded_as_source_input",
+    "local_source_payloads": "excluded_from_public_artifact",
+    "lookup_ready_candidates": "parsed_value_only",
+    "reviewer_observations": "observation_candidate_only_not_authority",
+    "supercombo": "enrichment_or_cross_reference_only",
+    "synthetic_fixtures": "not_source_truth"
+  },
+  "generated_from": ["data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"],
+  "records": [
+    {
+      "acquisition_report_refs": ["docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"],
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "review_required_not_calculation_safe",
+      "candidate_record_id": "candidate:official:jp:jp_001_5lp:combo_scaling:review_required",
+      "character_slug": "jp",
+      "coverage_refs": ["data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"],
+      "display_label_ja": "コンボ補正",
+      "evidence": {
+        "evidence_basis": "synthetic_contract_fixture",
+        "public_reference": "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": ["コンボ補正"],
+        "source_label": "コンボ補正",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "combo_scaling",
+      "move_id": "jp_001_5lp",
+      "parser_rule_ids": ["review_required.blocked"],
+      "raw_value": "始動補正20%",
+      "raw_value_length": 7,
+      "raw_value_sha256": "93aa1eb1357636c07557682963b2ba8e51f4ef4f333ea3875c14eee83c94438d",
+      "source_cell_key": "official:jp:jp_001_5lp:combo_scaling:cell",
+      "source_cell_order": 7,
+      "source_family": "scaling",
+      "source_header_path": ["コンボ補正"],
+      "source_label": "コンボ補正",
+      "source_name": "official",
+      "source_review_refs": ["docs/source-reviews/20260524-official-note-linkage-source-review.md"],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:jp:jp_001_5lp",
+      "source_row_order": 1,
+      "source_value_key": "official:jp:jp_001_5lp:combo_scaling:value-1",
+      "value_shape": {
+        "classes": ["percent_expression", "prose"],
+        "classifier_status": "review_required",
+        "review_item_id": "value-shape:official--unclassified_expression--combo-scaling"
+      }
+    }
+  ],
+  "run_id": "20260521T025403Z"
+}

--- a/tests/fixtures/current-facts/candidate-inputs/invalid/current_fact_row_move_cell_candidate_input_supercombo_scalar_authority.json
+++ b/tests/fixtures/current-facts/candidate-inputs/invalid/current_fact_row_move_cell_candidate_input_supercombo_scalar_authority.json
@@ -1,0 +1,61 @@
+{
+  "artifact_schema_version": "current_fact_row_move_cell_candidate_input/v1",
+  "authority_boundary": {
+    "official": "authority_candidate_only",
+    "supercombo": "enrichment_or_cross_reference_only"
+  },
+  "candidate_boundary": {
+    "blocked_records": "excluded_to_classifier_or_source_review",
+    "legacy_raw_exports": "excluded_as_source_input",
+    "local_source_payloads": "excluded_from_public_artifact",
+    "lookup_ready_candidates": "parsed_value_only",
+    "reviewer_observations": "observation_candidate_only_not_authority",
+    "supercombo": "enrichment_or_cross_reference_only",
+    "synthetic_fixtures": "not_source_truth"
+  },
+  "generated_from": ["data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"],
+  "records": [
+    {
+      "acquisition_report_refs": ["docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"],
+      "authority_status": "cross_reference_candidate",
+      "calculation_input_status": "eligible_only_after_domain_source_and_unit_checks",
+      "candidate_record_id": "candidate:supercombo:jp:example_special:block_advantage",
+      "character_slug": "jp",
+      "coverage_refs": ["data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"],
+      "display_label_ja": "SuperCombo ガード硬直差",
+      "evidence": {
+        "evidence_basis": "synthetic_contract_fixture",
+        "public_reference": "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": ["Special Moves", "Block Advantage"],
+        "source_label": "Block Advantage",
+        "source_name": "supercombo",
+        "source_role": "cross_reference_candidate"
+      },
+      "field_key": "block_advantage",
+      "move_id": "synthetic:supercombo:example_special",
+      "parsed_value": { "kind": "signed_frame", "unit": "frame", "value": -4 },
+      "parser_rule_ids": ["signed_frame.v1"],
+      "raw_value": "-4",
+      "raw_value_length": 2,
+      "raw_value_sha256": "e5e0093f285a4fb94c3fcc2ad7fd04edd10d429ccda87a9aa5e4718efadf182e",
+      "source_cell_key": "supercombo:jp:example_special:block_advantage:cell",
+      "source_cell_order": 3,
+      "source_family": "advantage",
+      "source_header_path": ["Special Moves", "Block Advantage"],
+      "source_label": "Block Advantage",
+      "source_name": "supercombo",
+      "source_review_refs": ["docs/source-reviews/20260524-official-note-linkage-source-review.md"],
+      "source_role": "cross_reference_candidate",
+      "source_row_key": "supercombo:jp:example_special",
+      "source_row_order": 1,
+      "source_value_key": "supercombo:jp:example_special:block_advantage:value-1",
+      "value_shape": {
+        "classes": ["signed_frame"],
+        "classifier_status": "parsed",
+        "parser_rule_id": "signed_frame.v1"
+      }
+    }
+  ],
+  "run_id": "20260521T025403Z"
+}

--- a/tests/fixtures/current-facts/candidate-inputs/valid/current_fact_row_move_cell_candidate_input_minimal.json
+++ b/tests/fixtures/current-facts/candidate-inputs/valid/current_fact_row_move_cell_candidate_input_minimal.json
@@ -1,0 +1,76 @@
+{
+  "artifact_schema_version": "current_fact_row_move_cell_candidate_input/v1",
+  "authority_boundary": {
+    "official": "authority_candidate_only",
+    "supercombo": "enrichment_or_cross_reference_only"
+  },
+  "candidate_boundary": {
+    "blocked_records": "excluded_to_classifier_or_source_review",
+    "legacy_raw_exports": "excluded_as_source_input",
+    "local_source_payloads": "excluded_from_public_artifact",
+    "lookup_ready_candidates": "parsed_value_only",
+    "reviewer_observations": "observation_candidate_only_not_authority",
+    "supercombo": "enrichment_or_cross_reference_only",
+    "synthetic_fixtures": "not_source_truth"
+  },
+  "generated_from": [
+    "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+    "docs/source-reviews/20260524-official-note-linkage-source-review.md",
+    "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md",
+    "contracts/current-facts/current_fact_record.schema.json"
+  ],
+  "records": [
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "eligible_only_after_domain_source_and_unit_checks",
+      "candidate_record_id": "candidate:official:jp:jp_001_5lp:block_advantage",
+      "character_slug": "jp",
+      "coverage_refs": [
+        "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+      ],
+      "display_label_ja": "ガード硬直差",
+      "evidence": {
+        "evidence_basis": "synthetic_contract_fixture",
+        "public_reference": "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": ["硬直差", "ガード"],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "block_advantage",
+      "move_id": "jp_001_5lp",
+      "parsed_value": {
+        "kind": "signed_frame",
+        "unit": "frame",
+        "value": -2
+      },
+      "parser_rule_ids": ["signed_frame.v1"],
+      "raw_value": "-2",
+      "raw_value_length": 2,
+      "raw_value_sha256": "cf3bae39dd692048a8bf961182e6a34dfd323eeb0748e162eaf055107f1cb873",
+      "source_cell_key": "official:jp:jp_001_5lp:block_advantage:cell",
+      "source_cell_order": 4,
+      "source_family": "advantage",
+      "source_header_path": ["硬直差", "ガード"],
+      "source_label": "ガード",
+      "source_name": "official",
+      "source_review_refs": [
+        "docs/source-reviews/20260524-official-note-linkage-source-review.md"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:jp:jp_001_5lp",
+      "source_row_order": 1,
+      "source_value_key": "official:jp:jp_001_5lp:block_advantage:value-1",
+      "value_shape": {
+        "classes": ["signed_frame"],
+        "classifier_status": "parsed",
+        "parser_rule_id": "signed_frame.v1"
+      }
+    }
+  ],
+  "run_id": "20260521T025403Z"
+}

--- a/tests/fixtures/current-facts/candidate-inputs/valid/current_fact_row_move_cell_candidate_input_non_scalar_values.json
+++ b/tests/fixtures/current-facts/candidate-inputs/valid/current_fact_row_move_cell_candidate_input_non_scalar_values.json
@@ -1,0 +1,148 @@
+{
+  "artifact_schema_version": "current_fact_row_move_cell_candidate_input/v1",
+  "authority_boundary": {
+    "official": "authority_candidate_only",
+    "supercombo": "enrichment_or_cross_reference_only"
+  },
+  "candidate_boundary": {
+    "blocked_records": "excluded_to_classifier_or_source_review",
+    "legacy_raw_exports": "excluded_as_source_input",
+    "local_source_payloads": "excluded_from_public_artifact",
+    "lookup_ready_candidates": "parsed_value_only",
+    "reviewer_observations": "observation_candidate_only_not_authority",
+    "supercombo": "enrichment_or_cross_reference_only",
+    "synthetic_fixtures": "not_source_truth"
+  },
+  "generated_from": [
+    "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+    "data/source-reviews/20260524-official-note-linkage-source-review-summary.json",
+    "docs/source-reviews/20260524-official-note-linkage-source-review.md"
+  ],
+  "records": [
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "candidate_record_id": "candidate:official:jp:jp_001_5lk:block_advantage:annotated",
+      "character_slug": "jp",
+      "coverage_refs": [
+        "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+      ],
+      "display_label_ja": "ガード硬直差",
+      "evidence": {
+        "evidence_basis": "synthetic_contract_fixture",
+        "public_reference": "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": ["硬直差", "ガード"],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "block_advantage",
+      "move_id": "jp_001_5lk",
+      "parsed_value": {
+        "annotation": {
+          "marker_placement": "prefix",
+          "note_id": null,
+          "note_linkage_status": "same_row_note_candidates_available",
+          "note_marker": "※",
+          "note_scope": "row_block_advantage_condition",
+          "note_text_status": "structured_row_note_text_found",
+          "row_note_candidate_count": 1
+        },
+        "calculation": {
+          "calculation_input_status": "annotated_candidate_not_calculation_safe",
+          "reason": "condition_bound_by_official_note"
+        },
+        "kind": "annotated_numeric_candidate",
+        "numeric_candidate": {
+          "candidate_type": "signed_frame",
+          "unit": "frame",
+          "value": -4
+        },
+        "source_context": {
+          "review_item_id": "value-shape:official--unclassified_expression--annotated-block",
+          "source_column_header_path": ["硬直差", "ガード"],
+          "source_review_id": "source-review:official-note-linkage-v4"
+        }
+      },
+      "parser_rule_ids": ["annotated_numeric_candidate.official_note_marker.v1"],
+      "raw_value": "※-4",
+      "raw_value_length": 3,
+      "raw_value_sha256": "b5112d05eab37a8ef2062523ba1cce640a8350c6cba7ef40bf66072550f3609c",
+      "source_cell_key": "official:jp:jp_001_5lk:block_advantage:cell",
+      "source_cell_order": 4,
+      "source_family": "advantage",
+      "source_header_path": ["硬直差", "ガード"],
+      "source_label": "ガード",
+      "source_name": "official",
+      "source_review_refs": [
+        "docs/source-reviews/20260524-official-note-linkage-source-review.md"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:jp:jp_001_5lk",
+      "source_row_order": 2,
+      "source_value_key": "official:jp:jp_001_5lk:block_advantage:value-1",
+      "value_shape": {
+        "classes": ["note_prefixed", "signed_frame"],
+        "classifier_status": "parsed",
+        "parser_rule_id": "annotated_numeric_candidate.official_note_marker.v1"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "parsed_range_not_single_value_calculation_safe",
+      "candidate_record_id": "candidate:official:jp:jp_001_5lp:active",
+      "character_slug": "jp",
+      "coverage_refs": [
+        "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+      ],
+      "display_label_ja": "持続",
+      "evidence": {
+        "evidence_basis": "synthetic_contract_fixture",
+        "public_reference": "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": ["動作フレーム", "持続"],
+        "source_label": "持続",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "active",
+      "move_id": "jp_001_5lp",
+      "parsed_value": {
+        "end": 8,
+        "kind": "frame_range",
+        "start": 6,
+        "unit": "frame"
+      },
+      "parser_rule_ids": ["frame_range.v1"],
+      "raw_value": "6-8",
+      "raw_value_length": 3,
+      "raw_value_sha256": "742595dc2605b1b9ded786a8b24f3ec0fddb44d49a77bb7186d3090411fb4e9f",
+      "source_cell_key": "official:jp:jp_001_5lp:active:cell",
+      "source_cell_order": 2,
+      "source_family": "timing",
+      "source_header_path": ["動作フレーム", "持続"],
+      "source_label": "持続",
+      "source_name": "official",
+      "source_review_refs": [
+        "docs/source-reviews/20260524-official-note-linkage-source-review.md"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:jp:jp_001_5lp",
+      "source_row_order": 1,
+      "source_value_key": "official:jp:jp_001_5lp:active:value-1",
+      "value_shape": {
+        "classes": ["range"],
+        "classifier_status": "parsed",
+        "parser_rule_id": "frame_range.v1"
+      }
+    }
+  ],
+  "run_id": "20260521T025403Z"
+}

--- a/tests/validation/validate_clean_slate.py
+++ b/tests/validation/validate_clean_slate.py
@@ -44,6 +44,7 @@ ALLOWED_CONTRACT_PATHS = {
     "contracts/current-facts",
     "contracts/current-facts/current_fact_export.schema.json",
     "contracts/current-facts/current_fact_record.schema.json",
+    "contracts/current-facts/current_fact_row_move_cell_candidate_input.schema.json",
     "contracts/current-facts/current_fact_source_record_input.schema.json",
     "contracts/current-facts/parsed_value.schema.json",
     "contracts/current-facts/source_reference.schema.json",

--- a/tests/validation/validate_current_fact_row_move_cell_candidates.py
+++ b/tests/validation/validate_current_fact_row_move_cell_candidates.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+
+from sf6_knowledge_coach.current_fact_guards import is_scalar_calculation_input
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_DIR = ROOT / "contracts/current-facts"
+FIXTURE_DIR = ROOT / "tests/fixtures/current-facts/candidate-inputs"
+CANDIDATE_SCHEMA_PATH = SCHEMA_DIR / "current_fact_row_move_cell_candidate_input.schema.json"
+SCHEMA_FILES = [
+    "parsed_value.schema.json",
+    "value_shape.schema.json",
+    "source_reference.schema.json",
+    "current_fact_record.schema.json",
+    "current_fact_row_move_cell_candidate_input.schema.json",
+]
+LOOKUP_READY_BLOCKED_STATUSES = {
+    "review_required_not_calculation_safe",
+    "out_of_scope_not_emitted",
+}
+FORBIDDEN_PUBLIC_PATTERNS = [
+    re.compile(r"(?i)(?:^|[\s\"'`])(?:/[a-z0-9_.-]+)+"),
+    re.compile(r"(?i)(?:^|[\s\"'`(])[A-Z]:[\\/]"),
+    re.compile(r"(?i)\.local(?:/|\\)"),
+    re.compile(r"(?i)\b(?:cookie|authorization|bearer|token|password|secret)\b"),
+    re.compile(r"(?i)<html|</html|<!doctype|<table|</table|<tr|</tr|<td|</td|<th|</th"),
+    re.compile(r"(?i)\b(?:screenshot|chatgpt|vlm|trace|debug dump|answer[-_ ]?log|training[-_ ]?log|private[-_ ]?vault)\b"),
+]
+FORBIDDEN_SOURCE_PATH_TERMS = (
+    "data/exports/",
+    ".local/",
+    "screenshot",
+    "chatgpt",
+    "vlm",
+    "raw-html",
+    "raw_html",
+    "full-row",
+    "full_raw",
+    "cookie",
+    "profile",
+    "trace",
+    "debug",
+    "private",
+)
+REFERENCE_ARRAY_FIELDS = (
+    "acquisition_report_refs",
+    "coverage_refs",
+    "source_review_refs",
+)
+
+
+def main() -> int:
+    errors: list[str] = []
+    schemas = _load_schemas(errors)
+    if errors:
+        return _finish(errors)
+
+    registry = Registry().with_resources(
+        (schema["$id"], Resource.from_contents(schema)) for schema in schemas.values()
+    )
+    for path, schema in schemas.items():
+        try:
+            Draft202012Validator.check_schema(schema)
+        except Exception as exc:  # pragma: no cover - exact type is not important here
+            errors.append(f"{path.relative_to(ROOT)} is not a valid Draft 2020-12 schema: {exc}")
+
+    validator = Draft202012Validator(schemas[CANDIDATE_SCHEMA_PATH], registry=registry)
+    _validate_schema_contract(schemas[CANDIDATE_SCHEMA_PATH], errors)
+    valid_payloads = _validate_valid_fixtures(validator, errors)
+    _validate_invalid_fixtures(validator, errors)
+    _validate_synthetic_boundary_rejections(validator, valid_payloads, errors)
+    _scan_valid_public_fixtures(errors)
+    _validate_no_production_candidate_artifacts(errors)
+    return _finish(errors)
+
+
+def _load_schemas(errors: list[str]) -> dict[Path, dict[str, Any]]:
+    schemas: dict[Path, dict[str, Any]] = {}
+    for name in SCHEMA_FILES:
+        path = SCHEMA_DIR / name
+        if not path.exists():
+            errors.append(f"Missing {path.relative_to(ROOT)}")
+            continue
+        schemas[path] = json.loads(path.read_text(encoding="utf-8"))
+        if schemas[path].get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+            errors.append(f"{path.relative_to(ROOT)} must use JSON Schema Draft 2020-12")
+    return schemas
+
+
+def _validate_schema_contract(schema: dict[str, Any], errors: list[str]) -> None:
+    version = schema.get("properties", {}).get("artifact_schema_version", {}).get("const")
+    if version != "current_fact_row_move_cell_candidate_input/v1":
+        errors.append("candidate schema must use current_fact_row_move_cell_candidate_input/v1")
+    generated_from = schema.get("properties", {}).get("generated_from", {})
+    if generated_from.get("minItems") != 1 or not generated_from.get("uniqueItems"):
+        errors.append("candidate schema must require non-empty unique generated_from paths")
+    records = schema.get("properties", {}).get("records", {})
+    if records.get("minItems") != 1:
+        errors.append("candidate schema must require at least one lookup-ready record")
+
+
+def _validate_valid_fixtures(
+    validator: Draft202012Validator,
+    errors: list[str],
+) -> dict[Path, dict[str, Any]]:
+    payloads: dict[Path, dict[str, Any]] = {}
+    fixtures = sorted((FIXTURE_DIR / "valid").glob("*.json"))
+    if not fixtures:
+        errors.append(f"Missing valid candidate fixtures under {(FIXTURE_DIR / 'valid').relative_to(ROOT)}")
+    for path in fixtures:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payloads[path] = payload
+        failures = _schema_errors(validator, payload)
+        semantic_failures = _semantic_errors(payload)
+        if failures or semantic_failures:
+            message = failures[0] if failures else semantic_failures[0]
+            errors.append(f"{path.relative_to(ROOT)} should be valid: {message}")
+    return payloads
+
+
+def _validate_invalid_fixtures(validator: Draft202012Validator, errors: list[str]) -> None:
+    fixtures = sorted((FIXTURE_DIR / "invalid").glob("*.json"))
+    if not fixtures:
+        errors.append(f"Missing invalid candidate fixtures under {(FIXTURE_DIR / 'invalid').relative_to(ROOT)}")
+    for path in fixtures:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not _schema_errors(validator, payload) and not _semantic_errors(payload):
+            errors.append(f"{path.relative_to(ROOT)} should be rejected")
+
+
+def _validate_synthetic_boundary_rejections(
+    validator: Draft202012Validator,
+    valid_payloads: dict[Path, dict[str, Any]],
+    errors: list[str],
+) -> None:
+    if not valid_payloads:
+        return
+    base = copy.deepcopy(next(iter(valid_payloads.values())))
+    mutations = {
+        "legacy generated_from": lambda payload: payload.update(
+            {"generated_from": ["data/exports/jp/official_raw.json"]}
+        ),
+        "local generated_from": lambda payload: payload.update(
+            {"generated_from": ["docs/.local/candidate-inputs.json"]}
+        ),
+        "image reviewer path": lambda payload: payload.update(
+            {"generated_from": ["docs/current-facts/candidate-inputs/value-screenshot.png"]}
+        ),
+        "vlm observation path": lambda payload: payload.update(
+            {"generated_from": ["docs/current-facts/candidate-inputs/chatgpt-vlm-observation.md"]}
+        ),
+        "legacy evidence path": lambda payload: _first_record(payload)["evidence"].update(
+            {"public_reference": "data/exports/jp/official_raw.json"}
+        ),
+        "local source review ref": lambda payload: _first_record(payload).update(
+            {"source_review_refs": ["docs/.local/source-review.json"]}
+        ),
+        "raw html value": lambda payload: _first_record(payload).update(
+            {"raw_value": "<table></table>"}
+        ),
+        "hash mismatch": lambda payload: _first_record(payload).update(
+            {"raw_value_sha256": "0" * 64}
+        ),
+        "header mismatch": lambda payload: _first_record(payload).update(
+            {"source_header_path": ["mismatched", "header"]}
+        ),
+        "official authority promotion": lambda payload: _first_record(payload).update(
+            {"authority_status": "not_authority"}
+        ),
+    }
+    for label, mutate in mutations.items():
+        payload = copy.deepcopy(base)
+        mutate(payload)
+        if not _schema_errors(validator, payload) and not _semantic_errors(payload):
+            errors.append(f"synthetic candidate boundary mutation should be rejected: {label}")
+
+
+def _schema_errors(validator: Draft202012Validator, payload: dict[str, Any]) -> list[str]:
+    failures = sorted(validator.iter_errors(payload), key=lambda error: list(error.path))
+    return [failure.message for failure in failures]
+
+
+def _semantic_errors(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for path in payload.get("generated_from", []):
+        _validate_public_source_path(path, "generated_from", errors)
+    for index, record in enumerate(payload.get("records", [])):
+        if not isinstance(record, dict):
+            errors.append(f"records[{index}] must be an object")
+            continue
+        _validate_record_identity(index, record, errors)
+        _validate_record_source_boundary(index, record, errors)
+        _validate_record_guard_boundary(index, record, errors)
+    return errors
+
+
+def _validate_public_source_path(path: Any, context: str, errors: list[str]) -> None:
+    if not isinstance(path, str):
+        errors.append(f"{context} path must be a string")
+        return
+    lowered = path.lower()
+    if re.search(r"(^|[\s\"'`])(?:/[a-z0-9_.-]+)+", path, flags=re.IGNORECASE):
+        errors.append(f"{context} must not contain a local absolute path")
+    for term in FORBIDDEN_SOURCE_PATH_TERMS:
+        if term in lowered:
+            errors.append(f"{context} must not reference forbidden source input: {path}")
+            return
+
+
+def _validate_record_identity(index: int, record: dict[str, Any], errors: list[str]) -> None:
+    raw_value = record.get("raw_value")
+    if isinstance(raw_value, str):
+        expected_hash = hashlib.sha256(raw_value.encode("utf-8")).hexdigest()
+        if record.get("raw_value_sha256") != expected_hash:
+            errors.append(f"records[{index}] raw_value_sha256 does not match raw_value")
+        if record.get("raw_value_length") != len(raw_value):
+            errors.append(f"records[{index}] raw_value_length does not match raw_value")
+    evidence = record.get("evidence", {})
+    if isinstance(evidence, dict):
+        if evidence.get("source_header_path") != record.get("source_header_path"):
+            errors.append(f"records[{index}] evidence.source_header_path must match source_header_path")
+        for field in ("source_name", "source_role", "source_label"):
+            if evidence.get(field) != record.get(field):
+                errors.append(f"records[{index}] evidence.{field} must match record.{field}")
+
+
+def _validate_record_source_boundary(index: int, record: dict[str, Any], errors: list[str]) -> None:
+    evidence = record.get("evidence", {})
+    if isinstance(evidence, dict):
+        _validate_public_source_path(evidence.get("public_reference"), f"records[{index}].evidence.public_reference", errors)
+        if evidence.get("evidence_basis") == "official_raw_snapshot":
+            errors.append(f"records[{index}] must not use official_raw_snapshot as candidate evidence")
+    for field in REFERENCE_ARRAY_FIELDS:
+        for path in record.get(field, []):
+            _validate_public_source_path(path, f"records[{index}].{field}", errors)
+    status = record.get("calculation_input_status")
+    if status in LOOKUP_READY_BLOCKED_STATUSES:
+        errors.append(f"records[{index}] blocked status is not lookup-ready: {status}")
+    if "parsed_value" not in record:
+        errors.append(f"records[{index}] lookup-ready candidate must include parsed_value")
+    if record.get("value_shape", {}).get("classifier_status") == "review_required":
+        errors.append(f"records[{index}] review_required value_shape is not lookup-ready")
+    if record.get("source_name") == "official" and record.get("authority_status") != "authority_candidate":
+        errors.append(f"records[{index}] official candidate must remain authority_candidate")
+    if record.get("source_name") == "supercombo" and status == "eligible_only_after_domain_source_and_unit_checks":
+        errors.append(f"records[{index}] SuperCombo candidate must not be scalar calculation authority")
+
+
+def _validate_record_guard_boundary(index: int, record: dict[str, Any], errors: list[str]) -> None:
+    parsed_value = record.get("parsed_value")
+    status = record.get("calculation_input_status")
+    parsed_kind = parsed_value.get("kind") if isinstance(parsed_value, dict) else None
+    if status == "annotated_candidate_not_calculation_safe" and parsed_kind != "annotated_numeric_candidate":
+        errors.append(f"records[{index}] annotated status must keep annotated_numeric_candidate wrapper")
+    if parsed_kind == "annotated_numeric_candidate" and status != "annotated_candidate_not_calculation_safe":
+        errors.append(f"records[{index}] annotated_numeric_candidate must carry annotated non-calculation status")
+    if status == "parsed_range_not_single_value_calculation_safe" and parsed_kind != "frame_range":
+        errors.append(f"records[{index}] range status must keep frame_range wrapper")
+    if parsed_kind == "frame_range" and status != "parsed_range_not_single_value_calculation_safe":
+        errors.append(f"records[{index}] frame_range must carry non-scalar range status")
+    if parsed_kind in {"annotated_numeric_candidate", "frame_range"}:
+        if is_scalar_calculation_input(parsed_value, status):
+            errors.append(f"records[{index}] non-scalar parsed value must be rejected by scalar guard")
+
+
+def _scan_valid_public_fixtures(errors: list[str]) -> None:
+    for path in sorted((FIXTURE_DIR / "valid").glob("*.json")):
+        text = path.read_text(encoding="utf-8")
+        for pattern in FORBIDDEN_PUBLIC_PATTERNS:
+            if pattern.search(text):
+                errors.append(f"{path.relative_to(ROOT)} contains forbidden public content")
+                break
+
+
+def _validate_no_production_candidate_artifacts(errors: list[str]) -> None:
+    for relative in (
+        "data/current-facts/candidate-inputs",
+        "docs/current-facts/candidate-inputs",
+    ):
+        directory = ROOT / relative
+        if directory.exists() and any(directory.rglob("*")):
+            errors.append(f"production candidate artifact path must remain empty in this slice: {relative}")
+
+
+def _first_record(payload: dict[str, Any]) -> dict[str, Any]:
+    return payload["records"][0]
+
+
+def _finish(errors: list[str]) -> int:
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("Current-fact row/move/cell candidate validation OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/validation/validate_current_fact_schemas.py
+++ b/tests/validation/validate_current_fact_schemas.py
@@ -21,6 +21,7 @@ SCHEMA_FILES = [
     "source_reference.schema.json",
     "current_fact_record.schema.json",
     "current_fact_export.schema.json",
+    "current_fact_row_move_cell_candidate_input.schema.json",
 ]
 CALCULATION_INPUT_STATUSES = {
     "eligible_only_after_domain_source_and_unit_checks",


### PR DESCRIPTION
## Summary
- Add the current_fact_row_move_cell_candidate_input/v1 schema contract.
- Add synthetic candidate-input fixtures covering valid scalar, annotated candidate, frame range, and boundary rejections.
- Add a focused candidate validator plus clean-slate/schema inventory and validator audit updates.

## Boundaries
- No candidate artifact generation.
- No production source-record or current-fact export artifacts.
- No runtime lookup, current_facts.py, answering.py, parser/classifier behavior, retrieval, answer, calculator, SymPy, source acquisition, or live acquisition changes.
- Fixtures are synthetic contract fixtures only and do not prove source truth.

## Validation
- git diff --check
- git diff --cached --check
- uv lock --check
- PYTHONPATH=src uv run --locked python -m unittest discover -s tests
- for script in tests/validation/validate_*.py; do PYTHONPATH=src uv run --locked python "" || exit 0; done
- PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
- production artifact path check under data/current-facts and docs/current-facts