### PR TITLE
Plan current-fact candidate evidence amendment

### DIFF
--- a/data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json
+++ b/data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json
@@ -1,0 +1,745 @@
+{
+  "artifact_boundary": "source_review_summary_only",
+  "artifact_schema_version": "current_fact_candidate_evidence/v1",
+  "authority_status": "review_decision_only_not_authority",
+  "candidate_artifact_generation": "blocked_until_mandatory_review",
+  "generated_from": [
+    "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+    "data/source-reviews/20260524-official-note-linkage-source-review-summary.json",
+    "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md",
+    "contracts/current-facts/current_fact_row_move_cell_candidate_input.schema.json",
+    "docs/execplans/2026-05-25-current-fact-candidate-evidence-amendment.md"
+  ],
+  "record_counts": {
+    "by_calculation_input_status": {
+      "annotated_candidate_not_calculation_safe": 9,
+      "parsed_range_not_single_value_calculation_safe": 4
+    },
+    "by_field_key": {
+      "block_advantage": 5,
+      "hit_advantage": 4,
+      "startup": 4
+    },
+    "by_source_review_result": {
+      "candidate_identity_evidence_found": 13
+    },
+    "total_evidence_records": 13
+  },
+  "run_id": "20260525",
+  "source_evidence_summary": {
+    "candidate_artifact_generated": false,
+    "current_fact_export_generated": false,
+    "ignored_structured_v4_rows_used_as_reviewer_input": true,
+    "ignored_structured_payloads_committed": false,
+    "issue_343_gate_required_for_future_value_expansion": true,
+    "live_acquisition_run": false,
+    "reviewer_observation_output_used_as_authority": false,
+    "source_record_artifact_generated": false,
+    "value_handling_change": false
+  },
+  "source_run_id": "20260521T025403Z",
+  "evidence_records": [
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate_not_promoted",
+      "calculation_input_status": "parsed_range_not_single_value_calculation_safe",
+      "candidate_generation_status": "blocked_until_candidate_artifact_execplan_review",
+      "candidate_record_id": "candidate:official:alex:row-41:cell-5:value-520f8306db0f",
+      "cell_note_marker_count": 0,
+      "character_slug": "alex",
+      "coverage_refs": [
+        "value-shape:official--unclassified_expression--u_c135db53355f--u_522ba9f47afb"
+      ],
+      "display_label_ja": "フライングクロスチョップ（ジャンプ中に） 強",
+      "evidence_id": "candidate-evidence:official:alex:row-41:cell-5:value-520f8306db0f",
+      "field_key": "block_advantage",
+      "move_id": "official:alex:row-41:move-f09489ff6eaa",
+      "move_id_derivation_status": "source_row_scoped_candidate_not_global_move_id",
+      "note_linkage_status": "no_cell_note_markers",
+      "parsed_value_kind": "frame_range",
+      "parsed_value_payload_status": "deterministic_reproduction_required_by_future_candidate_artifact",
+      "parser_rule_ids": [
+        "frame_range.official_signed_wave_dash.v1"
+      ],
+      "raw_value": "-12～-1",
+      "raw_value_length": 6,
+      "raw_value_sha256": "520f8306db0f00d860dfbf1f72aed57178586bbac1b4e2f2ceb6fa3c31284c35",
+      "row_note_candidate_count": 0,
+      "source_cell_key": "official:alex:table-0:row-41:cell-5",
+      "source_cell_order": 5,
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ガード"
+      ],
+      "source_label": "ガード",
+      "source_name": "official",
+      "source_review_refs": [
+        "docs/execplans/2026-05-23-official-signed-range-parser.md"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:alex:table-0:row-41",
+      "source_row_order": 41,
+      "source_review_ids": [
+        "source-review:current-fact-candidate-evidence-official-frame-range"
+      ],
+      "source_review_result": "candidate_identity_evidence_found",
+      "source_value_key": "official:alex:table-0:row-41:cell-5:value-520f8306db0f",
+      "value_shape": {
+        "classifier_status": "parsed",
+        "parsed_value_kind": "frame_range",
+        "parser_rule_id": "frame_range.official_signed_wave_dash.v1"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate_not_promoted",
+      "calculation_input_status": "parsed_range_not_single_value_calculation_safe",
+      "candidate_generation_status": "blocked_until_candidate_artifact_execplan_review",
+      "candidate_record_id": "candidate:official:vega_mbison:row-53:cell-5:value-1c461fc0a5e3",
+      "cell_note_marker_count": 0,
+      "character_slug": "vega_mbison",
+      "coverage_refs": [
+        "value-shape:official--unclassified_expression--u_c135db53355f--u_522ba9f47afb"
+      ],
+      "display_label_ja": "ヘッドプレス（シャドウライズ中に）",
+      "evidence_id": "candidate-evidence:official:vega_mbison:row-53:cell-5:value-1c461fc0a5e3",
+      "field_key": "block_advantage",
+      "move_id": "official:vega_mbison:row-53:move-268f9d662fa7",
+      "move_id_derivation_status": "source_row_scoped_candidate_not_global_move_id",
+      "note_linkage_status": "no_cell_note_markers",
+      "parsed_value_kind": "frame_range",
+      "parsed_value_payload_status": "deterministic_reproduction_required_by_future_candidate_artifact",
+      "parser_rule_ids": [
+        "frame_range.official_signed_wave_dash.v1"
+      ],
+      "raw_value": "-39～-33",
+      "raw_value_length": 7,
+      "raw_value_sha256": "1c461fc0a5e3e3e6877d22bc8de7fd0165119dcb255b70232e90bb70268e5fab",
+      "row_note_candidate_count": 0,
+      "source_cell_key": "official:vega_mbison:table-0:row-53:cell-5",
+      "source_cell_order": 5,
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ガード"
+      ],
+      "source_label": "ガード",
+      "source_name": "official",
+      "source_review_refs": [
+        "docs/execplans/2026-05-23-official-signed-range-parser.md"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:vega_mbison:table-0:row-53",
+      "source_row_order": 53,
+      "source_review_ids": [
+        "source-review:current-fact-candidate-evidence-official-frame-range"
+      ],
+      "source_review_result": "candidate_identity_evidence_found",
+      "source_value_key": "official:vega_mbison:table-0:row-53:cell-5:value-1c461fc0a5e3",
+      "value_shape": {
+        "classifier_status": "parsed",
+        "parsed_value_kind": "frame_range",
+        "parser_rule_id": "frame_range.official_signed_wave_dash.v1"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate_not_promoted",
+      "calculation_input_status": "parsed_range_not_single_value_calculation_safe",
+      "candidate_generation_status": "blocked_until_candidate_artifact_execplan_review",
+      "candidate_record_id": "candidate:official:cammy:row-52:cell-5:value-f3bd1df4c26d",
+      "cell_note_marker_count": 0,
+      "character_slug": "cammy",
+      "coverage_refs": [
+        "value-shape:official--unclassified_expression--u_c135db53355f--u_522ba9f47afb"
+      ],
+      "display_label_ja": "リバースエッジ（フーリガンコンビネーション中に）",
+      "evidence_id": "candidate-evidence:official:cammy:row-52:cell-5:value-f3bd1df4c26d",
+      "field_key": "block_advantage",
+      "move_id": "official:cammy:row-52:move-003104ea0ff9",
+      "move_id_derivation_status": "source_row_scoped_candidate_not_global_move_id",
+      "note_linkage_status": "no_cell_note_markers",
+      "parsed_value_kind": "frame_range",
+      "parsed_value_payload_status": "deterministic_reproduction_required_by_future_candidate_artifact",
+      "parser_rule_ids": [
+        "frame_range.official_signed_wave_dash.v1"
+      ],
+      "raw_value": "-4～-1",
+      "raw_value_length": 5,
+      "raw_value_sha256": "f3bd1df4c26d078a592238ff898964a14b5859e74fe097da1bfae2a76be7c5a7",
+      "row_note_candidate_count": 0,
+      "source_cell_key": "official:cammy:table-0:row-52:cell-5",
+      "source_cell_order": 5,
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ガード"
+      ],
+      "source_label": "ガード",
+      "source_name": "official",
+      "source_review_refs": [
+        "docs/execplans/2026-05-23-official-signed-range-parser.md"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:cammy:table-0:row-52",
+      "source_row_order": 52,
+      "source_review_ids": [
+        "source-review:current-fact-candidate-evidence-official-frame-range"
+      ],
+      "source_review_result": "candidate_identity_evidence_found",
+      "source_value_key": "official:cammy:table-0:row-52:cell-5:value-f3bd1df4c26d",
+      "value_shape": {
+        "classifier_status": "parsed",
+        "parsed_value_kind": "frame_range",
+        "parser_rule_id": "frame_range.official_signed_wave_dash.v1"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate_not_promoted",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "candidate_generation_status": "blocked_until_candidate_artifact_execplan_review",
+      "candidate_record_id": "candidate:official:ed:row-21:cell-5:value-522076e6afe2",
+      "cell_note_marker_count": 1,
+      "character_slug": "ed",
+      "coverage_refs": [
+        "value-shape:official--source_specific_expression--u_c135db53355f--u_522ba9f47afb"
+      ],
+      "display_label_ja": "サイコナックル(Lv1)強ホールド",
+      "evidence_id": "candidate-evidence:official:ed:row-21:cell-5:value-522076e6afe2",
+      "field_key": "block_advantage",
+      "move_id": "official:ed:row-21:move-a8a13087c217",
+      "move_id_derivation_status": "source_row_scoped_candidate_not_global_move_id",
+      "note_linkage_status": "same_row_note_candidates_available",
+      "parsed_value_kind": "annotated_numeric_candidate",
+      "parsed_value_payload_status": "deterministic_reproduction_required_by_future_candidate_artifact",
+      "parser_rule_ids": [
+        "annotated_signed_frame.official_prefix_marker.negative.v1"
+      ],
+      "raw_value": "※-2",
+      "raw_value_length": 3,
+      "raw_value_sha256": "522076e6afe25969ab0fe38642fcf471a681152e0f919f489622873b188357e6",
+      "row_note_candidate_count": 1,
+      "source_cell_key": "official:ed:table-0:row-21:cell-5",
+      "source_cell_order": 5,
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ガード"
+      ],
+      "source_label": "ガード",
+      "source_name": "official",
+      "source_review_refs": [
+        "data/source-reviews/20260524-official-note-linkage-source-review-summary.json"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:ed:table-0:row-21",
+      "source_row_order": 21,
+      "source_review_ids": [
+        "source-review:official-note-linkage-block-advantage"
+      ],
+      "source_review_result": "candidate_identity_evidence_found",
+      "source_value_key": "official:ed:table-0:row-21:cell-5:value-522076e6afe2",
+      "value_shape": {
+        "classifier_status": "partial",
+        "parsed_value_kind": "annotated_numeric_candidate",
+        "parser_rule_id": "annotated_signed_frame.official_prefix_marker.negative.v1"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate_not_promoted",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "candidate_generation_status": "blocked_until_candidate_artifact_execplan_review",
+      "candidate_record_id": "candidate:official:chunli:row-32:cell-5:value-b5112d05eab3",
+      "cell_note_marker_count": 1,
+      "character_slug": "chunli",
+      "coverage_refs": [
+        "value-shape:official--source_specific_expression--u_c135db53355f--u_522ba9f47afb"
+      ],
+      "display_label_ja": "蘭華（行雲流水中に）弱",
+      "evidence_id": "candidate-evidence:official:chunli:row-32:cell-5:value-b5112d05eab3",
+      "field_key": "block_advantage",
+      "move_id": "official:chunli:row-32:move-278b4bdd0acb",
+      "move_id_derivation_status": "source_row_scoped_candidate_not_global_move_id",
+      "note_linkage_status": "same_row_note_candidates_available",
+      "parsed_value_kind": "annotated_numeric_candidate",
+      "parsed_value_payload_status": "deterministic_reproduction_required_by_future_candidate_artifact",
+      "parser_rule_ids": [
+        "annotated_signed_frame.official_prefix_marker.negative.v1"
+      ],
+      "raw_value": "※-4",
+      "raw_value_length": 3,
+      "raw_value_sha256": "b5112d05eab37a8ef2062523ba1cce640a8350c6cba7ef40bf66072550f3609c",
+      "row_note_candidate_count": 1,
+      "source_cell_key": "official:chunli:table-0:row-32:cell-5",
+      "source_cell_order": 5,
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ガード"
+      ],
+      "source_label": "ガード",
+      "source_name": "official",
+      "source_review_refs": [
+        "data/source-reviews/20260524-official-note-linkage-source-review-summary.json"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:chunli:table-0:row-32",
+      "source_row_order": 32,
+      "source_review_ids": [
+        "source-review:official-note-linkage-block-advantage"
+      ],
+      "source_review_result": "candidate_identity_evidence_found",
+      "source_value_key": "official:chunli:table-0:row-32:cell-5:value-b5112d05eab3",
+      "value_shape": {
+        "classifier_status": "partial",
+        "parsed_value_kind": "annotated_numeric_candidate",
+        "parser_rule_id": "annotated_signed_frame.official_prefix_marker.negative.v1"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate_not_promoted",
+      "calculation_input_status": "parsed_range_not_single_value_calculation_safe",
+      "candidate_generation_status": "blocked_until_candidate_artifact_execplan_review",
+      "candidate_record_id": "candidate:official:vega_mbison:row-53:cell-4:value-1c81d53e6168",
+      "cell_note_marker_count": 0,
+      "character_slug": "vega_mbison",
+      "coverage_refs": [
+        "value-shape:official--unclassified_expression--u_c135db53355f--u_7acd6c7b6e69"
+      ],
+      "display_label_ja": "ヘッドプレス（シャドウライズ中に）",
+      "evidence_id": "candidate-evidence:official:vega_mbison:row-53:cell-4:value-1c81d53e6168",
+      "field_key": "hit_advantage",
+      "move_id": "official:vega_mbison:row-53:move-268f9d662fa7",
+      "move_id_derivation_status": "source_row_scoped_candidate_not_global_move_id",
+      "note_linkage_status": "no_cell_note_markers",
+      "parsed_value_kind": "frame_range",
+      "parsed_value_payload_status": "deterministic_reproduction_required_by_future_candidate_artifact",
+      "parser_rule_ids": [
+        "frame_range.official_signed_wave_dash.v1"
+      ],
+      "raw_value": "-28～-23",
+      "raw_value_length": 7,
+      "raw_value_sha256": "1c81d53e6168526120e54c0d776c9dd883e1d484832eca4b59e829d0ab5ad285",
+      "row_note_candidate_count": 0,
+      "source_cell_key": "official:vega_mbison:table-0:row-53:cell-4",
+      "source_cell_order": 4,
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ヒット"
+      ],
+      "source_label": "ヒット",
+      "source_name": "official",
+      "source_review_refs": [
+        "docs/execplans/2026-05-23-official-signed-range-parser.md"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:vega_mbison:table-0:row-53",
+      "source_row_order": 53,
+      "source_review_ids": [
+        "source-review:current-fact-candidate-evidence-official-frame-range"
+      ],
+      "source_review_result": "candidate_identity_evidence_found",
+      "source_value_key": "official:vega_mbison:table-0:row-53:cell-4:value-1c81d53e6168",
+      "value_shape": {
+        "classifier_status": "parsed",
+        "parsed_value_kind": "frame_range",
+        "parser_rule_id": "frame_range.official_signed_wave_dash.v1"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate_not_promoted",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "candidate_generation_status": "blocked_until_candidate_artifact_execplan_review",
+      "candidate_record_id": "candidate:official:chunli:row-35:cell-4:value-dbdd09f8dbaa",
+      "cell_note_marker_count": 1,
+      "character_slug": "chunli",
+      "coverage_refs": [
+        "value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69"
+      ],
+      "display_label_ja": "前突（行雲流水中に）弱",
+      "evidence_id": "candidate-evidence:official:chunli:row-35:cell-4:value-dbdd09f8dbaa",
+      "field_key": "hit_advantage",
+      "move_id": "official:chunli:row-35:move-2c6d449eb8a3",
+      "move_id_derivation_status": "source_row_scoped_candidate_not_global_move_id",
+      "note_linkage_status": "same_row_note_candidates_available",
+      "parsed_value_kind": "annotated_numeric_candidate",
+      "parsed_value_payload_status": "deterministic_reproduction_required_by_future_candidate_artifact",
+      "parser_rule_ids": [
+        "annotated_signed_frame.official_prefix_marker.negative.v1"
+      ],
+      "raw_value": "※-1",
+      "raw_value_length": 3,
+      "raw_value_sha256": "dbdd09f8dbaacf8ce6a87b3f4b004af5a8185b47ed0b193adcf2afdd6bd8e0af",
+      "row_note_candidate_count": 1,
+      "source_cell_key": "official:chunli:table-0:row-35:cell-4",
+      "source_cell_order": 4,
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ヒット"
+      ],
+      "source_label": "ヒット",
+      "source_name": "official",
+      "source_review_refs": [
+        "data/source-reviews/20260524-official-note-linkage-source-review-summary.json"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:chunli:table-0:row-35",
+      "source_row_order": 35,
+      "source_review_ids": [
+        "source-review:official-note-linkage-hit-advantage"
+      ],
+      "source_review_result": "candidate_identity_evidence_found",
+      "source_value_key": "official:chunli:table-0:row-35:cell-4:value-dbdd09f8dbaa",
+      "value_shape": {
+        "classifier_status": "partial",
+        "parsed_value_kind": "annotated_numeric_candidate",
+        "parser_rule_id": "annotated_signed_frame.official_prefix_marker.negative.v1"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate_not_promoted",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "candidate_generation_status": "blocked_until_candidate_artifact_execplan_review",
+      "candidate_record_id": "candidate:official:chunli:row-32:cell-4:value-38098349c914",
+      "cell_note_marker_count": 1,
+      "character_slug": "chunli",
+      "coverage_refs": [
+        "value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69"
+      ],
+      "display_label_ja": "蘭華（行雲流水中に）弱",
+      "evidence_id": "candidate-evidence:official:chunli:row-32:cell-4:value-38098349c914",
+      "field_key": "hit_advantage",
+      "move_id": "official:chunli:row-32:move-278b4bdd0acb",
+      "move_id_derivation_status": "source_row_scoped_candidate_not_global_move_id",
+      "note_linkage_status": "same_row_note_candidates_available",
+      "parsed_value_kind": "annotated_numeric_candidate",
+      "parsed_value_payload_status": "deterministic_reproduction_required_by_future_candidate_artifact",
+      "parser_rule_ids": [
+        "annotated_signed_frame.official_prefix_marker.negative.v1"
+      ],
+      "raw_value": "※-3",
+      "raw_value_length": 3,
+      "raw_value_sha256": "38098349c914433f0d197b466d52fc182309a3043e91d401f8c2a98b3b8917ca",
+      "row_note_candidate_count": 1,
+      "source_cell_key": "official:chunli:table-0:row-32:cell-4",
+      "source_cell_order": 4,
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ヒット"
+      ],
+      "source_label": "ヒット",
+      "source_name": "official",
+      "source_review_refs": [
+        "data/source-reviews/20260524-official-note-linkage-source-review-summary.json"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:chunli:table-0:row-32",
+      "source_row_order": 32,
+      "source_review_ids": [
+        "source-review:official-note-linkage-hit-advantage"
+      ],
+      "source_review_result": "candidate_identity_evidence_found",
+      "source_value_key": "official:chunli:table-0:row-32:cell-4:value-38098349c914",
+      "value_shape": {
+        "classifier_status": "partial",
+        "parsed_value_kind": "annotated_numeric_candidate",
+        "parser_rule_id": "annotated_signed_frame.official_prefix_marker.negative.v1"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate_not_promoted",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "candidate_generation_status": "blocked_until_candidate_artifact_execplan_review",
+      "candidate_record_id": "candidate:official:chunli:row-36:cell-4:value-b5112d05eab3",
+      "cell_note_marker_count": 1,
+      "character_slug": "chunli",
+      "coverage_refs": [
+        "value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69"
+      ],
+      "display_label_ja": "仙風（行雲流水中に）中",
+      "evidence_id": "candidate-evidence:official:chunli:row-36:cell-4:value-b5112d05eab3",
+      "field_key": "hit_advantage",
+      "move_id": "official:chunli:row-36:move-f41b02dd87c4",
+      "move_id_derivation_status": "source_row_scoped_candidate_not_global_move_id",
+      "note_linkage_status": "same_row_note_candidates_available",
+      "parsed_value_kind": "annotated_numeric_candidate",
+      "parsed_value_payload_status": "deterministic_reproduction_required_by_future_candidate_artifact",
+      "parser_rule_ids": [
+        "annotated_signed_frame.official_prefix_marker.negative.v1"
+      ],
+      "raw_value": "※-4",
+      "raw_value_length": 3,
+      "raw_value_sha256": "b5112d05eab37a8ef2062523ba1cce640a8350c6cba7ef40bf66072550f3609c",
+      "row_note_candidate_count": 1,
+      "source_cell_key": "official:chunli:table-0:row-36:cell-4",
+      "source_cell_order": 4,
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ヒット"
+      ],
+      "source_label": "ヒット",
+      "source_name": "official",
+      "source_review_refs": [
+        "data/source-reviews/20260524-official-note-linkage-source-review-summary.json"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:chunli:table-0:row-36",
+      "source_row_order": 36,
+      "source_review_ids": [
+        "source-review:official-note-linkage-hit-advantage"
+      ],
+      "source_review_result": "candidate_identity_evidence_found",
+      "source_value_key": "official:chunli:table-0:row-36:cell-4:value-b5112d05eab3",
+      "value_shape": {
+        "classifier_status": "partial",
+        "parsed_value_kind": "annotated_numeric_candidate",
+        "parser_rule_id": "annotated_signed_frame.official_prefix_marker.negative.v1"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate_not_promoted",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "candidate_generation_status": "blocked_until_candidate_artifact_execplan_review",
+      "candidate_record_id": "candidate:official:kimberly:row-64:cell-1:value-1a036dd4c06c",
+      "cell_note_marker_count": 1,
+      "character_slug": "kimberly",
+      "coverage_refs": [
+        "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100"
+      ],
+      "display_label_ja": "弱 細工手裏剣（細工手裏剣ストックが1以上で） 弱",
+      "evidence_id": "candidate-evidence:official:kimberly:row-64:cell-1:value-1a036dd4c06c",
+      "field_key": "startup",
+      "move_id": "official:kimberly:row-64:move-1ebd54eb85aa",
+      "move_id_derivation_status": "source_row_scoped_candidate_not_global_move_id",
+      "note_linkage_status": "same_row_note_candidates_available",
+      "parsed_value_kind": "annotated_numeric_candidate",
+      "parsed_value_payload_status": "deterministic_reproduction_required_by_future_candidate_artifact",
+      "parser_rule_ids": [
+        "annotated_frame.official_suffix_marker.v1"
+      ],
+      "raw_value": "122※",
+      "raw_value_length": 4,
+      "raw_value_sha256": "1a036dd4c06cd18cde9b72d219f3bf9ff2c41ec171022dbe1058e162cf96df7c",
+      "row_note_candidate_count": 1,
+      "source_cell_key": "official:kimberly:table-0:row-64:cell-1",
+      "source_cell_order": 1,
+      "source_family": "timing",
+      "source_header_path": [
+        "動作フレーム",
+        "発生"
+      ],
+      "source_label": "発生",
+      "source_name": "official",
+      "source_review_refs": [
+        "data/source-reviews/20260524-official-note-linkage-source-review-summary.json"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:kimberly:table-0:row-64",
+      "source_row_order": 64,
+      "source_review_ids": [
+        "source-review:official-note-linkage-startup"
+      ],
+      "source_review_result": "candidate_identity_evidence_found",
+      "source_value_key": "official:kimberly:table-0:row-64:cell-1:value-1a036dd4c06c",
+      "value_shape": {
+        "classifier_status": "partial",
+        "parsed_value_kind": "annotated_numeric_candidate",
+        "parser_rule_id": "annotated_frame.official_suffix_marker.v1"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate_not_promoted",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "candidate_generation_status": "blocked_until_candidate_artifact_execplan_review",
+      "candidate_record_id": "candidate:official:kimberly:row-67:cell-1:value-1a036dd4c06c",
+      "cell_note_marker_count": 1,
+      "character_slug": "kimberly",
+      "coverage_refs": [
+        "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100"
+      ],
+      "display_label_ja": "弱 乱れ細工手裏剣（細工手裏剣ストックが2以上で） 弱中",
+      "evidence_id": "candidate-evidence:official:kimberly:row-67:cell-1:value-1a036dd4c06c",
+      "field_key": "startup",
+      "move_id": "official:kimberly:row-67:move-c8f7890e80bb",
+      "move_id_derivation_status": "source_row_scoped_candidate_not_global_move_id",
+      "note_linkage_status": "same_row_note_candidates_available",
+      "parsed_value_kind": "annotated_numeric_candidate",
+      "parsed_value_payload_status": "deterministic_reproduction_required_by_future_candidate_artifact",
+      "parser_rule_ids": [
+        "annotated_frame.official_suffix_marker.v1"
+      ],
+      "raw_value": "122※",
+      "raw_value_length": 4,
+      "raw_value_sha256": "1a036dd4c06cd18cde9b72d219f3bf9ff2c41ec171022dbe1058e162cf96df7c",
+      "row_note_candidate_count": 1,
+      "source_cell_key": "official:kimberly:table-0:row-67:cell-1",
+      "source_cell_order": 1,
+      "source_family": "timing",
+      "source_header_path": [
+        "動作フレーム",
+        "発生"
+      ],
+      "source_label": "発生",
+      "source_name": "official",
+      "source_review_refs": [
+        "data/source-reviews/20260524-official-note-linkage-source-review-summary.json"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:kimberly:table-0:row-67",
+      "source_row_order": 67,
+      "source_review_ids": [
+        "source-review:official-note-linkage-startup"
+      ],
+      "source_review_result": "candidate_identity_evidence_found",
+      "source_value_key": "official:kimberly:table-0:row-67:cell-1:value-1a036dd4c06c",
+      "value_shape": {
+        "classifier_status": "partial",
+        "parsed_value_kind": "annotated_numeric_candidate",
+        "parser_rule_id": "annotated_frame.official_suffix_marker.v1"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate_not_promoted",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "candidate_generation_status": "blocked_until_candidate_artifact_execplan_review",
+      "candidate_record_id": "candidate:official:kimberly:row-68:cell-1:value-1a036dd4c06c",
+      "cell_note_marker_count": 1,
+      "character_slug": "kimberly",
+      "coverage_refs": [
+        "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100"
+      ],
+      "display_label_ja": "中 乱れ細工手裏剣（細工手裏剣ストックが2以上で） 弱強",
+      "evidence_id": "candidate-evidence:official:kimberly:row-68:cell-1:value-1a036dd4c06c",
+      "field_key": "startup",
+      "move_id": "official:kimberly:row-68:move-8683c9bcb338",
+      "move_id_derivation_status": "source_row_scoped_candidate_not_global_move_id",
+      "note_linkage_status": "same_row_note_candidates_available",
+      "parsed_value_kind": "annotated_numeric_candidate",
+      "parsed_value_payload_status": "deterministic_reproduction_required_by_future_candidate_artifact",
+      "parser_rule_ids": [
+        "annotated_frame.official_suffix_marker.v1"
+      ],
+      "raw_value": "122※",
+      "raw_value_length": 4,
+      "raw_value_sha256": "1a036dd4c06cd18cde9b72d219f3bf9ff2c41ec171022dbe1058e162cf96df7c",
+      "row_note_candidate_count": 1,
+      "source_cell_key": "official:kimberly:table-0:row-68:cell-1",
+      "source_cell_order": 1,
+      "source_family": "timing",
+      "source_header_path": [
+        "動作フレーム",
+        "発生"
+      ],
+      "source_label": "発生",
+      "source_name": "official",
+      "source_review_refs": [
+        "data/source-reviews/20260524-official-note-linkage-source-review-summary.json"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:kimberly:table-0:row-68",
+      "source_row_order": 68,
+      "source_review_ids": [
+        "source-review:official-note-linkage-startup"
+      ],
+      "source_review_result": "candidate_identity_evidence_found",
+      "source_value_key": "official:kimberly:table-0:row-68:cell-1:value-1a036dd4c06c",
+      "value_shape": {
+        "classifier_status": "partial",
+        "parsed_value_kind": "annotated_numeric_candidate",
+        "parser_rule_id": "annotated_frame.official_suffix_marker.v1"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate_not_promoted",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "candidate_generation_status": "blocked_until_candidate_artifact_execplan_review",
+      "candidate_record_id": "candidate:official:kimberly:row-66:cell-1:value-3c911b4c4f5d",
+      "cell_note_marker_count": 1,
+      "character_slug": "kimberly",
+      "coverage_refs": [
+        "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100"
+      ],
+      "display_label_ja": "強 細工手裏剣（細工手裏剣ストックが1以上で） 強",
+      "evidence_id": "candidate-evidence:official:kimberly:row-66:cell-1:value-3c911b4c4f5d",
+      "field_key": "startup",
+      "move_id": "official:kimberly:row-66:move-035abd428c6f",
+      "move_id_derivation_status": "source_row_scoped_candidate_not_global_move_id",
+      "note_linkage_status": "same_row_note_candidates_available",
+      "parsed_value_kind": "annotated_numeric_candidate",
+      "parsed_value_payload_status": "deterministic_reproduction_required_by_future_candidate_artifact",
+      "parser_rule_ids": [
+        "annotated_frame.official_suffix_marker.v1"
+      ],
+      "raw_value": "128※",
+      "raw_value_length": 4,
+      "raw_value_sha256": "3c911b4c4f5d473c3e4bd988a924818f3c760adbd14fd241a7fdccf42c99b814",
+      "row_note_candidate_count": 1,
+      "source_cell_key": "official:kimberly:table-0:row-66:cell-1",
+      "source_cell_order": 1,
+      "source_family": "timing",
+      "source_header_path": [
+        "動作フレーム",
+        "発生"
+      ],
+      "source_label": "発生",
+      "source_name": "official",
+      "source_review_refs": [
+        "data/source-reviews/20260524-official-note-linkage-source-review-summary.json"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:kimberly:table-0:row-66",
+      "source_row_order": 66,
+      "source_review_ids": [
+        "source-review:official-note-linkage-startup"
+      ],
+      "source_review_result": "candidate_identity_evidence_found",
+      "source_value_key": "official:kimberly:table-0:row-66:cell-1:value-3c911b4c4f5d",
+      "value_shape": {
+        "classifier_status": "partial",
+        "parsed_value_kind": "annotated_numeric_candidate",
+        "parser_rule_id": "annotated_frame.official_suffix_marker.v1"
+      }
+    }
+  ]
+}

--- a/data/validator-audits/20260523-validator-test-fact-source-audit.json
+++ b/data/validator-audits/20260523-validator-test-fact-source-audit.json
@@ -155,6 +155,20 @@
       "status": "accepted_with_limits"
     },
     {
+      "evidence_class": "source_derived",
+      "file": "tests/validation/validate_current_fact_candidate_evidence.py",
+      "limitations": [
+        "checks summary-safe candidate evidence source-review boundaries; full v4 row context remains ignored local reviewer input"
+      ],
+      "primary_evidence": [
+        "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "docs/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.md",
+        "parsed-value classifier coverage artifact",
+        "official note-linkage source-review artifact"
+      ],
+      "status": "accepted_with_limits"
+    },
+    {
       "evidence_class": "artifact_consistency",
       "file": "tests/validation/validate_current_fact_consumer_guards.py",
       "limitations": [

--- a/docs/execplans/2026-05-25-current-fact-candidate-evidence-amendment.md
+++ b/docs/execplans/2026-05-25-current-fact-candidate-evidence-amendment.md
@@ -1,6 +1,6 @@
 # Current-Fact Candidate Evidence Amendment
 
-Status: Drafted for review; validation passed.
+Status: Implementation complete; validation passed.
 
 ## Purpose
 
@@ -13,8 +13,10 @@ defines what evidence a future amendment must emit from existing ignored v4
 official artifacts or from a derived acquisition/source-review summary before
 any production candidate artifact generation can start.
 
-This is a docs-only planning step. It does not implement the amendment and
-does not generate candidate, source-record, or current-fact export artifacts.
+This PR started as a docs-only planning step. After mandatory plan review, the
+same draft PR is amended to implement the source-review evidence artifact and
+focused validator described here. It still does not generate candidate,
+source-record, or current-fact export artifacts.
 
 ## Inputs
 
@@ -54,7 +56,7 @@ candidate records can be populated.
 
 ## Scope
 
-Included in this docs-only plan:
+Included in this plan and implementation slice:
 
 - define exact row/move/cell candidate evidence fields required for a future
   public amendment artifact;
@@ -65,10 +67,15 @@ Included in this docs-only plan:
 - define admission requirements for candidate-generation readiness;
 - preserve Issue #343 double-check gate for any new value-handling decision;
 - keep production candidate/source-record/export generation blocked.
+- add a summary-safe public source-review JSON artifact for current parsed
+  official candidate evidence;
+- add a summary-safe Markdown companion;
+- add a focused validator for that source-review artifact;
+- update validator audit artifacts for the new validator;
+- update this ExecPlan Progress, Decision Log, and Completion Review Table.
 
 Excluded:
 
-- No amendment implementation.
 - No candidate artifact generation.
 - No source-record artifact generation.
 - No current-fact export artifact generation.
@@ -89,17 +96,25 @@ Excluded:
 
 ## Amendment Placement Decision
 
-The next implementation should create a new summary-safe public source-review
-artifact, supported by acquisition-derived structural fields where needed.
+This implementation creates a new summary-safe public source-review artifact,
+supported by acquisition-derived structural fields from ignored v4 reviewer
+input.
 
-Recommended future artifact family:
+Implemented artifact family:
 
-- JSON: `data/source-reviews/<run_id>-current-fact-row-move-cell-candidate-evidence.json`
-- Markdown: `docs/source-reviews/<run_id>-current-fact-row-move-cell-candidate-evidence.md`
-- Optional future schema:
-  `contracts/source-reviews/current_fact_candidate_evidence.schema.json`
-- Planned artifact schema version:
+- JSON:
+  `data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json`
+- Markdown:
+  `docs/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.md`
+- Focused validator:
+  `tests/validation/validate_current_fact_candidate_evidence.py`
+- Artifact schema version:
   `current_fact_candidate_evidence/v1`
+
+No JSON Schema contract is added in this slice. The focused validator fixes
+the contract tightly enough for this source-review summary. A later schema can
+be planned if production generation needs a reusable candidate-evidence
+contract.
 
 Rationale:
 
@@ -200,15 +215,16 @@ Allowed public inputs for the amendment:
 - reviewed public Markdown summaries;
 - future reviewed source-review evidence summaries.
 
-Allowed reviewer input, if explicitly approved by the future implementation
-ExecPlan:
+Allowed reviewer input for this implementation slice:
 
 - ignored v4 acquisition artifacts as local reviewer input;
 - sanitized local reviewer bundles under approved `.local` paths;
 - Scrapling screenshots as reviewer-only observation material.
 
-Reviewer input must be converted into summary-safe public evidence before it
-can support production candidate generation.
+Only ignored v4 acquisition artifacts were used for this implementation. The
+committed output converts that local reviewer input into summary-safe public
+evidence without committing local paths, raw source payloads, full rows, visual
+reviewer output, or private material.
 
 ## Forbidden Inputs And Published Content
 
@@ -284,10 +300,9 @@ full output must not be committed.
 
 ## Future Validation Plan
 
-A future implementation PR for the amendment should add focused validation
-that checks:
+This implementation adds focused validation that checks:
 
-- public artifact schema and required field coverage;
+- public artifact version and required field coverage;
 - summary-safe public paths only;
 - no legacy raw export source input;
 - no `.local`, raw HTML, full rows, screenshots, local paths, logs, or private
@@ -298,29 +313,27 @@ that checks:
 - coverage/source-review/acquisition reference consistency;
 - blocked/ambiguous evidence cannot enter lookup-ready candidate input;
 - non-scalar parsed values are not flattened;
-- SuperCombo numeric authority is rejected.
+- SuperCombo numeric authority is absent.
 
 Validators must be evidence-first and grounded in public artifacts, approved
 contract fixtures, or privacy/source-boundary rules.
 
 ## Future Implementation Slices
 
-Recommended next PR:
+Completed in this PR after plan review:
 
-1. Docs-only implementation ExecPlan for the candidate evidence source-review
-   artifact.
+1. Candidate evidence source-review artifact implementation.
 
-Blocked until that plan is approved:
+Blocked until mandatory review of this implementation:
 
-2. Candidate evidence source-review artifact implementation.
-3. Production `current_fact_row_move_cell_candidate_input/v1` generation.
-4. Production source-record artifact generation.
-5. Production current-fact export generation.
-6. Runtime lookup transition and legacy raw export retirement.
+2. Production `current_fact_row_move_cell_candidate_input/v1` generation.
+3. Production source-record artifact generation.
+4. Production current-fact export generation.
+5. Runtime lookup transition and legacy raw export retirement.
 
 ## Acceptance Criteria
 
-- The plan is docs-only.
+- The plan was reviewed first, then implemented in the same draft PR.
 - The plan defines exact candidate evidence fields needed for future
   production candidate records.
 - The plan decides that the evidence should be emitted as a summary-safe
@@ -334,12 +347,21 @@ Blocked until that plan is approved:
   acquisition, or live acquisition.
 - The plan does not use legacy `data/exports/*/official_raw.json`, `.local`,
   raw HTML, screenshots, VLM output, or private data as authority.
+- The implementation commits no production candidate/source-record/export
+  artifact.
+- The implementation commits no raw source payload, complete row, local path,
+  visual reviewer output, browser session material, or private material.
 
 ## Files / Interfaces
 
-This docs-only PR should change only:
+This PR may change only:
 
 - `docs/execplans/2026-05-25-current-fact-candidate-evidence-amendment.md`
+- `data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json`
+- `docs/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.md`
+- `tests/validation/validate_current_fact_candidate_evidence.py`
+- `data/validator-audits/20260523-validator-test-fact-source-audit.json`
+- `docs/validator-audits/20260523-validator-test-fact-source-audit.md`
 
 Future implementation plans may touch additional files only after mandatory
 review approval.
@@ -353,8 +375,10 @@ PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
 PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py
 PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py
 PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_row_move_cell_candidates.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_candidate_evidence.py
 PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py
 PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_export_generator.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_validator_test_audit.py
 PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
 git status --short --branch
 ```
@@ -364,6 +388,10 @@ git status --short --branch
 - 2026-05-25: Drafted docs-only source-review/acquisition amendment plan after
   PR #364 merged. No implementation or generated artifact changes included.
 - 2026-05-25: Ran validation commands for docs-only plan. All checks passed.
+- 2026-05-25: Mandatory plan review passed on PR #365. Amended the same draft
+  PR to implement the source-review evidence artifact, focused validator, and
+  validator audit entries.
+- 2026-05-25: Ran full validation after implementation. All checks passed.
 
 ## Decision Log
 
@@ -377,6 +405,14 @@ git status --short --branch
 - 2026-05-25: Legacy raw exports remain rejected as replacement source input.
 - 2026-05-25: Validation passed without adding implementation, schemas,
   fixtures, validators, or generated artifacts.
+- 2026-05-25: Implemented 13 summary-safe evidence records for currently
+  parsed official candidate groups: 9 annotated candidates and 4 frame ranges.
+- 2026-05-25: Did not add a reusable source-review schema in this slice;
+  focused validator coverage is sufficient for this one artifact.
+- 2026-05-25: Candidate artifact generation remains blocked pending mandatory
+  review of this evidence implementation.
+- 2026-05-25: No production artifact was generated under `data/current-facts`
+  or `docs/current-facts`.
 
 ## Deviations
 
@@ -397,18 +433,24 @@ git status --short --branch
 
 | PLAN item | Implementation content | Changed files | Validation command | Result | Deviation | Incomplete | Risk |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Evidence field plan | Draft plan only | `docs/execplans/2026-05-25-current-fact-candidate-evidence-amendment.md` | `git diff --check`; `uv lock --check` | Pass | None | Mandatory review pending | Future implementation may need acquisition amendment |
-| Amendment placement decision | Draft plan chooses summary-safe public source-review artifact | Same | `validate_current_fact_row_move_cell_candidates.py`; `parsed_value_classifier validate` | Pass | None | Mandatory review pending | Production candidate artifact remains blocked |
-| Runtime and artifact boundary | No runtime or generated artifact changes | Same | current-fact validators; `validate_clean_slate.py` | Pass | None | Mandatory review pending | Runtime remains legacy raw export backed |
+| Evidence field plan | Defined candidate evidence fields and implemented summary-safe source-review records | ExecPlan; JSON/MD source-review artifacts | `git diff --check`; `uv lock --check` | Pass | None | Mandatory review pending | Future candidate artifact still requires review |
+| Amendment placement decision | Implemented source-review artifact and no acquisition code | ExecPlan; source-review artifacts; validator | `validate_current_fact_candidate_evidence.py` | Pass | None | Mandatory review pending | Production candidate artifact remains blocked |
+| Runtime and artifact boundary | No runtime or production generated artifact changes | Same plus audit artifacts | current-fact validators; `validate_clean_slate.py`; audit validator | Pass | None | Mandatory review pending | Runtime remains legacy raw export backed |
 
 ## Next Reviewer Prompt
 
 ```text
-Review docs/execplans/2026-05-25-current-fact-candidate-evidence-amendment.md.
+Review PR #365 current-fact candidate evidence amendment implementation.
 
 Check:
-- PR diff contains exactly one ExecPlan file.
-- Plan is docs-only.
+- PR diff contains only the approved source-review evidence implementation
+  files:
+  - docs/execplans/2026-05-25-current-fact-candidate-evidence-amendment.md
+  - data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json
+  - docs/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.md
+  - tests/validation/validate_current_fact_candidate_evidence.py
+  - data/validator-audits/20260523-validator-test-fact-source-audit.json
+  - docs/validator-audits/20260523-validator-test-fact-source-audit.md
 - It defines exact candidate evidence fields:
   - character_slug
   - move_id
@@ -430,10 +472,15 @@ Check:
 - It keeps Issue #343 double-check gate mandatory for future value-handling
   decisions.
 - It keeps production candidate/source-record/export generation blocked.
-- It does not implement the amendment.
+- It implements only the source-review evidence artifact and focused
+  validator.
 - It does not change runtime lookup, current_facts.py, answering.py,
   parser/classifier behavior, retrieval, answer, calculator, SymPy, source
   acquisition, or live acquisition.
+- It commits no production artifacts under data/current-facts or
+  docs/current-facts.
+- It commits no raw source payloads, complete rows, local paths, visual
+  reviewer output, browser session material, or private material.
 
 Run:
 - git status --short --branch
@@ -444,8 +491,10 @@ Run:
 - PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py
 - PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py
 - PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_row_move_cell_candidates.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_candidate_evidence.py
 - PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py
 - PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_export_generator.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_validator_test_audit.py
 - PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
 
 Return blocking findings first, validation results, PLAN deviations, remaining

--- a/docs/execplans/2026-05-25-current-fact-candidate-evidence-amendment.md
+++ b/docs/execplans/2026-05-25-current-fact-candidate-evidence-amendment.md
@@ -1,0 +1,453 @@
+# Current-Fact Candidate Evidence Amendment
+
+Status: Drafted for review; validation passed.
+
+## Purpose
+
+Define the source-review/acquisition amendment needed to expose public,
+committed, summary-safe row/move/cell candidate evidence.
+
+PR #364 concluded that existing public summaries are insufficient to populate
+production `current_fact_row_move_cell_candidate_input/v1` records. This plan
+defines what evidence a future amendment must emit from existing ignored v4
+official artifacts or from a derived acquisition/source-review summary before
+any production candidate artifact generation can start.
+
+This is a docs-only planning step. It does not implement the amendment and
+does not generate candidate, source-record, or current-fact export artifacts.
+
+## Inputs
+
+- `docs/PLAN.md`
+- `AGENTS.md`
+- `docs/execplans/2026-05-25-current-fact-candidate-public-artifact-source-review.md`
+- `docs/execplans/2026-05-25-current-fact-row-move-cell-candidate-input.md`
+- `docs/execplans/2026-05-25-current-fact-row-move-cell-candidate-schema.md`
+- `docs/execplans/2026-05-25-current-fact-production-source-record-artifact.md`
+- `contracts/current-facts/current_fact_row_move_cell_candidate_input.schema.json`
+- `contracts/current-facts/current_fact_source_record_input.schema.json`
+- `contracts/current-facts/current_fact_record.schema.json`
+- `contracts/current-facts/current_fact_export.schema.json`
+- `data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json`
+- `docs/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.md`
+- `data/source-reviews/20260524-official-note-linkage-source-review-summary.json`
+- `docs/source-reviews/20260524-official-note-linkage-source-review.md`
+- `docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md`
+- `data/validator-audits/20260523-validator-test-fact-source-audit.json`
+- `docs/validator-audits/20260523-validator-test-fact-source-audit.md`
+
+## Context
+
+The repository now has:
+
+- a candidate input schema and synthetic contract fixtures;
+- source-record schema and fixture-contract export generator support;
+- consumer guards for non-scalar parsed values;
+- public classifier, source-review, acquisition, and validator audit summaries.
+
+Those artifacts still do not provide a committed public mapping from a parsed
+raw value to a specific character, move, source row, source cell, and value
+slot. The ignored `official_table_rows_raw/v4` artifacts may contain enough
+structure for a reviewer to derive that mapping, but ignored artifacts are not
+public authority. A summary-safe public artifact is needed before production
+candidate records can be populated.
+
+## Scope
+
+Included in this docs-only plan:
+
+- define exact row/move/cell candidate evidence fields required for a future
+  public amendment artifact;
+- decide where the amendment should live;
+- define privacy and source-boundary rules;
+- define how future amendment output cross-checks classifier, source-review,
+  acquisition, schema, and validator audit artifacts;
+- define admission requirements for candidate-generation readiness;
+- preserve Issue #343 double-check gate for any new value-handling decision;
+- keep production candidate/source-record/export generation blocked.
+
+Excluded:
+
+- No amendment implementation.
+- No candidate artifact generation.
+- No source-record artifact generation.
+- No current-fact export artifact generation.
+- No generated artifact under `data/current-facts/`.
+- No generated summary under `docs/current-facts/`.
+- No runtime lookup change.
+- No `current_facts.py` change.
+- No `answering.py` change.
+- No parser/classifier behavior change.
+- No parser/classifier expansion.
+- No retrieval implementation.
+- No answer implementation.
+- No calculator implementation.
+- No SymPy logic.
+- No source acquisition implementation.
+- No live acquisition.
+- No authority promotion.
+
+## Amendment Placement Decision
+
+The next implementation should create a new summary-safe public source-review
+artifact, supported by acquisition-derived structural fields where needed.
+
+Recommended future artifact family:
+
+- JSON: `data/source-reviews/<run_id>-current-fact-row-move-cell-candidate-evidence.json`
+- Markdown: `docs/source-reviews/<run_id>-current-fact-row-move-cell-candidate-evidence.md`
+- Optional future schema:
+  `contracts/source-reviews/current_fact_candidate_evidence.schema.json`
+- Planned artifact schema version:
+  `current_fact_candidate_evidence/v1`
+
+Rationale:
+
+- This output is reviewer evidence, not the production candidate input itself.
+- It may be derived from ignored v4 acquisition artifacts, but the committed
+  output must be summary-safe and reviewer-approved.
+- It belongs closer to source review than to the acquisition report because it
+  records reviewed candidate identity evidence and source-boundary decisions.
+- Acquisition may need a later implementation amendment only if existing v4
+  fields cannot deterministically expose the required row/cell/value keys
+  without publishing full rows.
+
+Candidate artifact generation must wait until this evidence artifact is
+reviewed and validated.
+
+## Required Evidence Fields
+
+The amendment must emit enough public evidence to populate every required
+`current_fact_row_move_cell_candidate_input/v1` record field later.
+
+Required candidate identity evidence:
+
+- `character_slug`;
+- `move_id`;
+- `display_label_ja`;
+- `field_key`;
+- `source_row_key`;
+- `source_cell_key`;
+- `source_value_key`;
+- `source_row_order`;
+- `source_cell_order`;
+- `source_header_path`;
+- `source_label`;
+- `raw_value`;
+- `raw_value_length`;
+- `raw_value_sha256`.
+
+Required source and review linkage:
+
+- `source_name`;
+- `source_role`;
+- `source_family`;
+- `authority_status`;
+- `parser_rule_ids`;
+- `calculation_input_status`;
+- classifier coverage reference IDs;
+- source-review reference IDs;
+- acquisition report references;
+- source artifact run ID and public hash references;
+- evidence status for each candidate row/cell/value binding.
+
+Required parsed-value linkage:
+
+- candidate `parsed_value` payload or a deterministic public reference to the
+  reviewed parsed payload that the future candidate artifact can reproduce;
+- `value_shape` metadata needed by the candidate schema;
+- explicit confirmation that blocked/review-required records remain excluded
+  from lookup-ready candidate records.
+
+The amendment must not emit full raw rows. Any public snippet must be the
+minimal value/header/identity excerpt required to verify the candidate
+binding.
+
+## Evidence Record Boundary
+
+The future evidence records should be source-review records, not final
+candidate records.
+
+Each evidence record should carry:
+
+- stable evidence ID;
+- run ID;
+- candidate identity fields listed above;
+- minimal raw value fields listed above;
+- reviewed public source/header references;
+- source-review status such as `candidate_identity_evidence_found`,
+  `candidate_identity_evidence_ambiguous`, or
+  `candidate_identity_evidence_missing`;
+- blocker reason when ambiguous or missing;
+- references to classifier coverage, source-review summaries, and acquisition
+  report hashes;
+- explicit non-authority statements for reviewer-only observations.
+
+The evidence artifact may include records that remain blocked, but the later
+`current_fact_row_move_cell_candidate_input/v1` artifact may admit only
+lookup-ready records with `parsed_value`. Blocked evidence records must remain
+in source-review evidence and must not be promoted into candidate input.
+
+## Public Source Inputs
+
+Allowed public inputs for the amendment:
+
+- parsed-value classifier coverage and policy artifacts;
+- official note-linkage source-review summaries;
+- acquisition reports for run metadata, schema version, counts, and hashes;
+- current-fact schemas and validators;
+- validator audit artifacts;
+- reviewed public Markdown summaries;
+- future reviewed source-review evidence summaries.
+
+Allowed reviewer input, if explicitly approved by the future implementation
+ExecPlan:
+
+- ignored v4 acquisition artifacts as local reviewer input;
+- sanitized local reviewer bundles under approved `.local` paths;
+- Scrapling screenshots as reviewer-only observation material.
+
+Reviewer input must be converted into summary-safe public evidence before it
+can support production candidate generation.
+
+## Forbidden Inputs And Published Content
+
+The amendment must not use or publish:
+
+- legacy `data/exports/*/official_raw.json` as replacement source input;
+- `.local` paths or payloads;
+- raw HTML;
+- full raw rows;
+- screenshots as authority;
+- ChatGPT/VLM observations as authority;
+- ChatGPT/VLM full output;
+- local absolute paths;
+- cookies;
+- browser profiles;
+- request/response headers;
+- tokens;
+- traces;
+- debug dumps;
+- logs;
+- answer logs;
+- training logs;
+- private data;
+- SuperCombo numeric authority.
+
+Screenshots and ChatGPT/VLM output remain `observation_candidate` only. They
+may guide reviewer attention but cannot prove source truth, validator
+evidence, parser/schema approval, calculation safety, or authority.
+
+## Candidate Readiness Checks
+
+The future amendment must let reviewers answer these questions before
+candidate artifact generation:
+
+- Does each candidate raw value have a public character and move identity?
+- Does each candidate raw value have stable row/cell/value keys and order?
+- Does the public raw value length and hash match the reviewed source binding?
+- Does the source header path match the intended `field_key`?
+- Does the candidate link to the expected classifier coverage and
+  source-review IDs?
+- Is the candidate parsed-value-only and not review-required?
+- Are `annotated_numeric_candidate` and `frame_range` preserved as non-scalar
+  values?
+- Are official records still `authority_candidate`?
+- Is SuperCombo still enrichment/cross-reference only?
+- Are ambiguous or missing bindings blocked outside the candidate artifact?
+- Are all public references committed artifacts rather than ignored local
+  evidence?
+
+If any answer is missing or ambiguous, production candidate artifact
+generation remains blocked.
+
+## Issue #343 Double-Check Gate
+
+Issue #343 remains mandatory for any new value-handling decision.
+
+The future amendment does not by itself authorize new parsing, new parsed raw
+variants, same-grammar expansion, calculation-safe promotion, or authority
+promotion.
+
+If the amendment introduces new raw-value semantics, newly included raw
+variants, or same-grammar expansion, the implementation must first create a
+sanitized reviewer bundle under:
+
+- `.local/reviewer-evidence/value-double-check/<run-id>/`
+
+Human upload remains manual. ChatGPT/VLM output is
+`observation_candidate` only. It is not source truth, validator evidence,
+parser/schema approval, calculation-safe promotion, or numeric authority.
+
+The bundle, zip, screenshots, raw HTML, full rows, local paths, and ChatGPT
+full output must not be committed.
+
+## Future Validation Plan
+
+A future implementation PR for the amendment should add focused validation
+that checks:
+
+- public artifact schema and required field coverage;
+- summary-safe public paths only;
+- no legacy raw export source input;
+- no `.local`, raw HTML, full rows, screenshots, local paths, logs, or private
+  data in committed artifacts;
+- raw value length and hash consistency;
+- row/cell/value key format and deterministic uniqueness;
+- source header path and field key consistency;
+- coverage/source-review/acquisition reference consistency;
+- blocked/ambiguous evidence cannot enter lookup-ready candidate input;
+- non-scalar parsed values are not flattened;
+- SuperCombo numeric authority is rejected.
+
+Validators must be evidence-first and grounded in public artifacts, approved
+contract fixtures, or privacy/source-boundary rules.
+
+## Future Implementation Slices
+
+Recommended next PR:
+
+1. Docs-only implementation ExecPlan for the candidate evidence source-review
+   artifact.
+
+Blocked until that plan is approved:
+
+2. Candidate evidence source-review artifact implementation.
+3. Production `current_fact_row_move_cell_candidate_input/v1` generation.
+4. Production source-record artifact generation.
+5. Production current-fact export generation.
+6. Runtime lookup transition and legacy raw export retirement.
+
+## Acceptance Criteria
+
+- The plan is docs-only.
+- The plan defines exact candidate evidence fields needed for future
+  production candidate records.
+- The plan decides that the evidence should be emitted as a summary-safe
+  public source-review artifact, with acquisition amendment only if existing
+  v4 fields are insufficient.
+- The plan preserves privacy and source-boundary rules.
+- The plan keeps Issue #343 double-check gate mandatory.
+- The plan keeps production candidate/source-record/export generation blocked.
+- The plan does not change runtime lookup, `current_facts.py`, `answering.py`,
+  parser/classifier behavior, retrieval, answer, calculator, SymPy, source
+  acquisition, or live acquisition.
+- The plan does not use legacy `data/exports/*/official_raw.json`, `.local`,
+  raw HTML, screenshots, VLM output, or private data as authority.
+
+## Files / Interfaces
+
+This docs-only PR should change only:
+
+- `docs/execplans/2026-05-25-current-fact-candidate-evidence-amendment.md`
+
+Future implementation plans may touch additional files only after mandatory
+review approval.
+
+## Validation Commands
+
+```bash
+git diff --check
+uv lock --check
+PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_row_move_cell_candidates.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_export_generator.py
+PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
+git status --short --branch
+```
+
+## Progress
+
+- 2026-05-25: Drafted docs-only source-review/acquisition amendment plan after
+  PR #364 merged. No implementation or generated artifact changes included.
+- 2026-05-25: Ran validation commands for docs-only plan. All checks passed.
+
+## Decision Log
+
+- 2026-05-25: The next evidence surface should be a summary-safe public
+  source-review artifact, not the production candidate input itself.
+- 2026-05-25: Acquisition amendment is deferred unless existing ignored v4
+  fields cannot deterministically provide row/cell/value keys for a
+  summary-safe public source-review artifact.
+- 2026-05-25: Production candidate artifact generation remains blocked until
+  public evidence proves row/move/cell identity for each included record.
+- 2026-05-25: Legacy raw exports remain rejected as replacement source input.
+- 2026-05-25: Validation passed without adding implementation, schemas,
+  fixtures, validators, or generated artifacts.
+
+## Deviations
+
+- None.
+
+## Risks
+
+- Existing ignored v4 artifacts may not contain enough deterministic
+  row/cell/value structure to derive summary-safe candidate evidence.
+- The future source-review artifact may require an acquisition amendment
+  before it can be implemented.
+- Production candidate/source-record/export artifacts remain blocked.
+- Runtime remains legacy raw export backed.
+- First production candidate coverage may be limited by parsed-value-only
+  admission and public identity evidence requirements.
+
+## Completion Review Table
+
+| PLAN item | Implementation content | Changed files | Validation command | Result | Deviation | Incomplete | Risk |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Evidence field plan | Draft plan only | `docs/execplans/2026-05-25-current-fact-candidate-evidence-amendment.md` | `git diff --check`; `uv lock --check` | Pass | None | Mandatory review pending | Future implementation may need acquisition amendment |
+| Amendment placement decision | Draft plan chooses summary-safe public source-review artifact | Same | `validate_current_fact_row_move_cell_candidates.py`; `parsed_value_classifier validate` | Pass | None | Mandatory review pending | Production candidate artifact remains blocked |
+| Runtime and artifact boundary | No runtime or generated artifact changes | Same | current-fact validators; `validate_clean_slate.py` | Pass | None | Mandatory review pending | Runtime remains legacy raw export backed |
+
+## Next Reviewer Prompt
+
+```text
+Review docs/execplans/2026-05-25-current-fact-candidate-evidence-amendment.md.
+
+Check:
+- PR diff contains exactly one ExecPlan file.
+- Plan is docs-only.
+- It defines exact candidate evidence fields:
+  - character_slug
+  - move_id
+  - display_label_ja
+  - source_row_key / source_cell_key / source_value_key
+  - source_row_order / source_cell_order
+  - source_header_path / source_label
+  - raw_value / raw_value_length / raw_value_sha256
+  - parser/source-review/coverage/acquisition refs
+- It decides whether the evidence belongs in acquisition amendment,
+  source-review amendment, or a new summary-safe public source-review artifact.
+- It preserves privacy/source-boundary rules:
+  - no raw HTML
+  - no full rows
+  - no .local paths
+  - no screenshots/VLM output as authority
+  - no cookies/profiles/traces/logs/private data
+  - no legacy data/exports/*/official_raw.json as replacement source input
+- It keeps Issue #343 double-check gate mandatory for future value-handling
+  decisions.
+- It keeps production candidate/source-record/export generation blocked.
+- It does not implement the amendment.
+- It does not change runtime lookup, current_facts.py, answering.py,
+  parser/classifier behavior, retrieval, answer, calculator, SymPy, source
+  acquisition, or live acquisition.
+
+Run:
+- git status --short --branch
+- git show --name-status --oneline --no-renames HEAD
+- git diff --check origin/main...HEAD
+- uv lock --check
+- PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_row_move_cell_candidates.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_export_generator.py
+- PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
+
+Return blocking findings first, validation results, PLAN deviations, remaining
+risks, and whether docs-only stage/commit is approved.
+```

--- a/docs/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.md
+++ b/docs/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.md
@@ -1,0 +1,55 @@
+# Current-Fact Row/Move/Cell Candidate Evidence
+
+This is a source-review summary only. It is not a production candidate
+artifact, source-record artifact, current-fact export, runtime lookup change,
+parser expansion, calculator approval, or authority promotion.
+
+## Boundary
+
+The review used ignored structured v4 row artifacts as reviewer input and
+commits only minimal row/move/cell evidence. It does not commit source-page
+payloads, complete rows, local payload references, browser session material,
+visual reviewer output, generated current-fact artifacts, or private material.
+
+Legacy raw export files are not replacement source input. Official values
+remain `authority_candidate`. `annotated_numeric_candidate` and `frame_range`
+remain non-scalar and not calculation-safe.
+
+## Counts
+
+| Metric | Count |
+| --- | ---: |
+| Evidence records | 13 |
+| `annotated_candidate_not_calculation_safe` | 9 |
+| `parsed_range_not_single_value_calculation_safe` | 4 |
+| `startup` | 4 |
+| `block_advantage` | 5 |
+| `hit_advantage` | 4 |
+
+## Evidence Records
+
+| Character | Move label | Field | Raw value | Row | Cell | Parser rule | Status |
+| --- | --- | --- | --- | ---: | ---: | --- | --- |
+| `alex` | フライングクロスチョップ（ジャンプ中に） 強 | `block_advantage` | `-12～-1` | 41 | 5 | `frame_range.official_signed_wave_dash.v1` | `candidate_identity_evidence_found` |
+| `vega_mbison` | ヘッドプレス（シャドウライズ中に） | `block_advantage` | `-39～-33` | 53 | 5 | `frame_range.official_signed_wave_dash.v1` | `candidate_identity_evidence_found` |
+| `cammy` | リバースエッジ（フーリガンコンビネーション中に） | `block_advantage` | `-4～-1` | 52 | 5 | `frame_range.official_signed_wave_dash.v1` | `candidate_identity_evidence_found` |
+| `ed` | サイコナックル(Lv1)強ホールド | `block_advantage` | `※-2` | 21 | 5 | `annotated_signed_frame.official_prefix_marker.negative.v1` | `candidate_identity_evidence_found` |
+| `chunli` | 蘭華（行雲流水中に）弱 | `block_advantage` | `※-4` | 32 | 5 | `annotated_signed_frame.official_prefix_marker.negative.v1` | `candidate_identity_evidence_found` |
+| `vega_mbison` | ヘッドプレス（シャドウライズ中に） | `hit_advantage` | `-28～-23` | 53 | 4 | `frame_range.official_signed_wave_dash.v1` | `candidate_identity_evidence_found` |
+| `chunli` | 前突（行雲流水中に）弱 | `hit_advantage` | `※-1` | 35 | 4 | `annotated_signed_frame.official_prefix_marker.negative.v1` | `candidate_identity_evidence_found` |
+| `chunli` | 蘭華（行雲流水中に）弱 | `hit_advantage` | `※-3` | 32 | 4 | `annotated_signed_frame.official_prefix_marker.negative.v1` | `candidate_identity_evidence_found` |
+| `chunli` | 仙風（行雲流水中に）中 | `hit_advantage` | `※-4` | 36 | 4 | `annotated_signed_frame.official_prefix_marker.negative.v1` | `candidate_identity_evidence_found` |
+| `kimberly` | 弱 細工手裏剣（細工手裏剣ストックが1以上で） 弱 | `startup` | `122※` | 64 | 1 | `annotated_frame.official_suffix_marker.v1` | `candidate_identity_evidence_found` |
+| `kimberly` | 弱 乱れ細工手裏剣（細工手裏剣ストックが2以上で） 弱中 | `startup` | `122※` | 67 | 1 | `annotated_frame.official_suffix_marker.v1` | `candidate_identity_evidence_found` |
+| `kimberly` | 中 乱れ細工手裏剣（細工手裏剣ストックが2以上で） 弱強 | `startup` | `122※` | 68 | 1 | `annotated_frame.official_suffix_marker.v1` | `candidate_identity_evidence_found` |
+| `kimberly` | 強 細工手裏剣（細工手裏剣ストックが1以上で） 強 | `startup` | `128※` | 66 | 1 | `annotated_frame.official_suffix_marker.v1` | `candidate_identity_evidence_found` |
+
+## Decision
+
+This artifact shows that summary-safe row/move/cell identity evidence exists
+for the listed parsed-value groups. It does not generate production candidate
+records. A later mandatory-reviewed candidate artifact PR must still reproduce
+deterministic parsed payloads, enforce parsed-value-only admission, carry
+non-scalar calculation statuses, and exclude blocked values.
+
+Issue #343 remains required for any future value-handling expansion.

--- a/docs/validator-audits/20260523-validator-test-fact-source-audit.md
+++ b/docs/validator-audits/20260523-validator-test-fact-source-audit.md
@@ -25,6 +25,7 @@ privacy/security boundary.
 | `tests/validation/validate_clean_slate.py` | governance boundary | accepted with limits | repo shape and approved contract file inventory only |
 | `tests/validation/validate_current_fact_export_generator.py` | artifact consistency | accepted with limits | fixture-contract generator output, guard boundaries, and no production artifact paths only |
 | `tests/validation/validate_current_fact_row_move_cell_candidates.py` | synthetic contract | accepted with limits | candidate schema, synthetic fixture contracts, and source-boundary guard mutations only; no production candidates or source truth |
+| `tests/validation/validate_current_fact_candidate_evidence.py` | source-derived | accepted with limits | candidate evidence source-review summary; full v4 row context remains ignored local reviewer input |
 | `tests/validation/validate_current_fact_consumer_guards.py` | artifact consistency | accepted with limits | guard behavior against synthetic fixtures and coverage statuses only |
 | `tests/validation/validate_current_fact_source_records.py` | synthetic contract | accepted with limits | source-record schema, fixture contracts, and source-boundary guard mutations only; no production source records or source truth |
 | `tests/validation/validate_current_fact_schemas.py` | synthetic contract | accepted with limits | schema and fixture contracts only; no parser/source truth |

--- a/tests/validation/validate_current_fact_candidate_evidence.py
+++ b/tests/validation/validate_current_fact_candidate_evidence.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+import json
+import re
+import sys
+from collections import Counter
+from hashlib import sha256
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+JSON_PATH = ROOT / "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json"
+MD_PATH = ROOT / "docs/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.md"
+COVERAGE_PATH = ROOT / "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+NOTE_REVIEW_PATH = ROOT / "data/source-reviews/20260524-official-note-linkage-source-review-summary.json"
+
+EXPECTED_FIELD_COUNTS = {
+    "block_advantage": 5,
+    "hit_advantage": 4,
+    "startup": 4,
+}
+EXPECTED_STATUS_COUNTS = {
+    "annotated_candidate_not_calculation_safe": 9,
+    "parsed_range_not_single_value_calculation_safe": 4,
+}
+EXPECTED_RAW_COUNTS = {
+    ("block_advantage", "-12～-1"): 1,
+    ("block_advantage", "-39～-33"): 1,
+    ("block_advantage", "-4～-1"): 1,
+    ("block_advantage", "※-2"): 1,
+    ("block_advantage", "※-4"): 1,
+    ("hit_advantage", "-28～-23"): 1,
+    ("hit_advantage", "※-1"): 1,
+    ("hit_advantage", "※-3"): 1,
+    ("hit_advantage", "※-4"): 1,
+    ("startup", "122※"): 3,
+    ("startup", "128※"): 1,
+}
+EXPECTED_HEADERS = {
+    "block_advantage": ["硬直差", "ガード"],
+    "hit_advantage": ["硬直差", "ヒット"],
+    "startup": ["動作フレーム", "発生"],
+}
+EXPECTED_CALCULATION_KIND = {
+    "annotated_candidate_not_calculation_safe": "annotated_numeric_candidate",
+    "parsed_range_not_single_value_calculation_safe": "frame_range",
+}
+REQUIRED_RECORD_KEYS = {
+    "acquisition_report_refs",
+    "authority_status",
+    "calculation_input_status",
+    "candidate_generation_status",
+    "candidate_record_id",
+    "cell_note_marker_count",
+    "character_slug",
+    "coverage_refs",
+    "display_label_ja",
+    "evidence_id",
+    "field_key",
+    "move_id",
+    "move_id_derivation_status",
+    "note_linkage_status",
+    "parsed_value_kind",
+    "parsed_value_payload_status",
+    "parser_rule_ids",
+    "raw_value",
+    "raw_value_length",
+    "raw_value_sha256",
+    "row_note_candidate_count",
+    "source_cell_key",
+    "source_cell_order",
+    "source_family",
+    "source_header_path",
+    "source_label",
+    "source_name",
+    "source_review_refs",
+    "source_role",
+    "source_row_key",
+    "source_row_order",
+    "source_review_ids",
+    "source_review_result",
+    "source_value_key",
+    "value_shape",
+}
+PUBLIC_PATH_RE = re.compile(r"^(data|docs|contracts)/[A-Za-z0-9_.:/-]+$")
+IDENTITY_RE = re.compile(r"^[a-z0-9][a-z0-9_.:-]*$")
+FORBIDDEN_PATTERNS = [
+    re.compile(r"(?i)(?:^|[\s\"'`])(?:/(?:home|mnt|Users)/[^\s\"'`]+)"),
+    re.compile(r"(?i)(?:^|[\s\"'`(])[A-Z]:[\\/]"),
+    re.compile(r"(?i)\b(?:cookie|authorization|bearer|token|password|secret)\b"),
+    re.compile(r"(?i)<html|</html|<!doctype|<table|</table|<tr|</tr|<td|</td|<th|</th"),
+    re.compile(r"(?i)\b(?:screenshot|chatgpt|vlm|trace|debug dump|answer[-_ ]?log|training[-_ ]?log)\b"),
+]
+FORBIDDEN_LITERALS = {
+    ".agents/",
+    ".local/",
+    ".venv/",
+    "__NEXT_DATA__.json",
+    "data/exports/",
+    "full raw row",
+    "official_table_rows.raw.json",
+    "page.html",
+    "private vault",
+}
+
+
+def main() -> int:
+    errors: list[str] = []
+    for path in (JSON_PATH, MD_PATH, COVERAGE_PATH, NOTE_REVIEW_PATH):
+        if not path.exists():
+            errors.append(f"Missing {path.relative_to(ROOT)}")
+    if errors:
+        return _finish(errors)
+
+    payload = json.loads(JSON_PATH.read_text(encoding="utf-8"))
+    coverage = json.loads(COVERAGE_PATH.read_text(encoding="utf-8"))
+    note_review = json.loads(NOTE_REVIEW_PATH.read_text(encoding="utf-8"))
+
+    _validate_top_level(payload, errors)
+    _validate_source_evidence_summary(payload.get("source_evidence_summary"), errors)
+    _validate_generated_from(payload.get("generated_from"), errors)
+
+    records = payload.get("evidence_records", [])
+    if not isinstance(records, list) or len(records) != 13:
+        errors.append("evidence_records must contain exactly 13 records")
+        records = []
+    _validate_counts(payload.get("record_counts"), records, errors)
+
+    coverage_by_id = {
+        record.get("review_item_id"): record
+        for record in coverage.get("coverage_records", [])
+        if record.get("source_name") == "official"
+    }
+    note_review_ids = {
+        record.get("source_review_id")
+        for record in note_review.get("review_records", [])
+        if isinstance(record, dict)
+    }
+
+    ids: dict[str, set[str]] = {
+        "candidate_record_id": set(),
+        "evidence_id": set(),
+        "source_cell_key": set(),
+        "source_value_key": set(),
+    }
+    for index, record in enumerate(records):
+        if not isinstance(record, dict):
+            errors.append(f"evidence_records[{index}] must be an object")
+            continue
+        _validate_record(index, record, coverage_by_id, note_review_ids, errors)
+        for key, seen in ids.items():
+            value = record.get(key)
+            if value in seen:
+                errors.append(f"{key} must be unique: {value}")
+            if isinstance(value, str):
+                seen.add(value)
+
+    for path in (JSON_PATH, MD_PATH):
+        _validate_public_text_boundary(path, errors)
+
+    return _finish(errors)
+
+
+def _validate_top_level(payload: dict[str, object], errors: list[str]) -> None:
+    expected = {
+        "artifact_schema_version": "current_fact_candidate_evidence/v1",
+        "artifact_boundary": "source_review_summary_only",
+        "authority_status": "review_decision_only_not_authority",
+        "candidate_artifact_generation": "blocked_until_mandatory_review",
+        "run_id": "20260525",
+        "source_run_id": "20260521T025403Z",
+    }
+    for key, value in expected.items():
+        if payload.get(key) != value:
+            errors.append(f"{key} must be {value!r}")
+
+
+def _validate_source_evidence_summary(summary: object, errors: list[str]) -> None:
+    if not isinstance(summary, dict):
+        errors.append("source_evidence_summary must be an object")
+        return
+    expected_flags = {
+        "candidate_artifact_generated": False,
+        "current_fact_export_generated": False,
+        "ignored_structured_v4_rows_used_as_reviewer_input": True,
+        "ignored_structured_payloads_committed": False,
+        "issue_343_gate_required_for_future_value_expansion": True,
+        "live_acquisition_run": False,
+        "reviewer_observation_output_used_as_authority": False,
+        "source_record_artifact_generated": False,
+        "value_handling_change": False,
+    }
+    for key, expected in expected_flags.items():
+        if summary.get(key) is not expected:
+            errors.append(f"source_evidence_summary.{key} must be {expected!r}")
+
+
+def _validate_generated_from(generated_from: object, errors: list[str]) -> None:
+    if not isinstance(generated_from, list) or not generated_from:
+        errors.append("generated_from must be a non-empty list")
+        return
+    for ref in generated_from:
+        _validate_public_ref(ref, "generated_from", errors)
+
+
+def _validate_counts(counts: object, records: list[object], errors: list[str]) -> None:
+    if not isinstance(counts, dict):
+        errors.append("record_counts must be an object")
+        return
+    if counts.get("total_evidence_records") != len(records):
+        errors.append("record_counts.total_evidence_records must match evidence_records length")
+    field_counts = Counter(record.get("field_key") for record in records if isinstance(record, dict))
+    status_counts = Counter(record.get("calculation_input_status") for record in records if isinstance(record, dict))
+    result_counts = Counter(record.get("source_review_result") for record in records if isinstance(record, dict))
+    if dict(sorted(field_counts.items())) != EXPECTED_FIELD_COUNTS:
+        errors.append("field counts do not match expected evidence records")
+    if dict(sorted(status_counts.items())) != EXPECTED_STATUS_COUNTS:
+        errors.append("calculation_input_status counts do not match expected evidence records")
+    if dict(sorted(result_counts.items())) != {"candidate_identity_evidence_found": len(records)}:
+        errors.append("source_review_result counts must all be candidate_identity_evidence_found")
+    if counts.get("by_field_key") != EXPECTED_FIELD_COUNTS:
+        errors.append("record_counts.by_field_key is incorrect")
+    if counts.get("by_calculation_input_status") != EXPECTED_STATUS_COUNTS:
+        errors.append("record_counts.by_calculation_input_status is incorrect")
+
+    raw_counts = Counter(
+        (record.get("field_key"), record.get("raw_value")) for record in records if isinstance(record, dict)
+    )
+    if dict(sorted(raw_counts.items())) != dict(sorted(EXPECTED_RAW_COUNTS.items())):
+        errors.append("raw value evidence counts do not match expected records")
+
+
+def _validate_record(
+    index: int,
+    record: dict[str, object],
+    coverage_by_id: dict[object, dict[str, object]],
+    note_review_ids: set[object],
+    errors: list[str],
+) -> None:
+    missing = sorted(REQUIRED_RECORD_KEYS - set(record))
+    if missing:
+        errors.append(f"evidence_records[{index}] missing keys: {', '.join(missing)}")
+    if "parsed_value" in record:
+        errors.append(f"evidence_records[{index}] must not include parsed_value payloads")
+    if "current_fact_authority" in json.dumps(record, ensure_ascii=False):
+        errors.append(f"evidence_records[{index}] must not include current fact authority promotion")
+
+    if record.get("source_name") != "official":
+        errors.append(f"evidence_records[{index}] source_name must be official")
+    if record.get("source_role") != "authority_candidate":
+        errors.append(f"evidence_records[{index}] source_role must remain authority_candidate")
+    if record.get("authority_status") != "authority_candidate_not_promoted":
+        errors.append(f"evidence_records[{index}] must not promote official authority")
+    if record.get("candidate_generation_status") != "blocked_until_candidate_artifact_execplan_review":
+        errors.append(f"evidence_records[{index}] must keep candidate generation blocked")
+    if record.get("source_review_result") != "candidate_identity_evidence_found":
+        errors.append(f"evidence_records[{index}] has invalid source_review_result")
+    if record.get("move_id_derivation_status") != "source_row_scoped_candidate_not_global_move_id":
+        errors.append(f"evidence_records[{index}] must record row-scoped move-id derivation")
+
+    field_key = record.get("field_key")
+    if record.get("source_header_path") != EXPECTED_HEADERS.get(field_key):
+        errors.append(f"evidence_records[{index}] has invalid source_header_path")
+    raw_value = record.get("raw_value")
+    if not isinstance(raw_value, str):
+        errors.append(f"evidence_records[{index}] raw_value must be a string")
+    else:
+        if record.get("raw_value_length") != len(raw_value):
+            errors.append(f"evidence_records[{index}] raw_value_length mismatch")
+        if record.get("raw_value_sha256") != sha256(raw_value.encode("utf-8")).hexdigest():
+            errors.append(f"evidence_records[{index}] raw_value_sha256 mismatch")
+
+    calculation_status = record.get("calculation_input_status")
+    expected_kind = EXPECTED_CALCULATION_KIND.get(calculation_status)
+    if record.get("parsed_value_kind") != expected_kind:
+        errors.append(f"evidence_records[{index}] parsed_value_kind does not match calculation status")
+    value_shape = record.get("value_shape")
+    if not isinstance(value_shape, dict):
+        errors.append(f"evidence_records[{index}] value_shape must be an object")
+    elif value_shape.get("parsed_value_kind") != record.get("parsed_value_kind"):
+        errors.append(f"evidence_records[{index}] value_shape kind mismatch")
+
+    for key in ("candidate_record_id", "evidence_id", "move_id", "source_cell_key", "source_row_key", "source_value_key"):
+        value = record.get(key)
+        if not isinstance(value, str) or not IDENTITY_RE.fullmatch(value):
+            errors.append(f"evidence_records[{index}].{key} has invalid identity format")
+    for key in ("source_cell_order", "source_row_order"):
+        if not isinstance(record.get(key), int) or record[key] < 0:
+            errors.append(f"evidence_records[{index}].{key} must be a non-negative integer")
+    for refs_key in ("acquisition_report_refs", "source_review_refs"):
+        refs = record.get(refs_key)
+        if not isinstance(refs, list):
+            errors.append(f"evidence_records[{index}].{refs_key} must be a list")
+            continue
+        for ref in refs:
+            _validate_public_ref(ref, f"evidence_records[{index}].{refs_key}", errors)
+
+    coverage_refs = record.get("coverage_refs")
+    if not isinstance(coverage_refs, list) or len(coverage_refs) != 1:
+        errors.append(f"evidence_records[{index}] must have exactly one coverage ref")
+        return
+    coverage_record = coverage_by_id.get(coverage_refs[0])
+    if not coverage_record:
+        errors.append(f"evidence_records[{index}] references missing coverage record")
+        return
+    _validate_coverage_ref(index, record, coverage_record, errors)
+
+    for source_review_id in record.get("source_review_ids", []):
+        if isinstance(source_review_id, str) and source_review_id.startswith("source-review:official-note-linkage"):
+            if source_review_id not in note_review_ids:
+                errors.append(f"evidence_records[{index}] references missing note-linkage source review")
+
+
+def _validate_coverage_ref(index: int, record: dict[str, object], coverage_record: dict[str, object], errors: list[str]) -> None:
+    parser_rule_ids = record.get("parser_rule_ids")
+    if parser_rule_ids != coverage_record.get("parser_rule_ids"):
+        errors.append(f"evidence_records[{index}] parser rules do not match coverage")
+    if record.get("field_key") != coverage_record.get("proposed_field_key"):
+        errors.append(f"evidence_records[{index}] field_key does not match coverage")
+    if record.get("source_header_path") != coverage_record.get("source_header_path"):
+        errors.append(f"evidence_records[{index}] source_header_path does not match coverage")
+    if record.get("source_role") != coverage_record.get("source_role"):
+        errors.append(f"evidence_records[{index}] source_role does not match coverage")
+
+    if coverage_record.get("classifier_decision") == "partial_raw_value_coverage":
+        variants = coverage_record.get("raw_value_variant_coverage", [])
+        variant = next((item for item in variants if item.get("raw_value") == record.get("raw_value")), None)
+        if not variant:
+            errors.append(f"evidence_records[{index}] raw value is not covered by partial coverage")
+            return
+        if variant.get("classifier_decision") != "parsed_numeric_structured":
+            errors.append(f"evidence_records[{index}] must not use blocked raw variants")
+        if variant.get("calculation_input_status") != record.get("calculation_input_status"):
+            errors.append(f"evidence_records[{index}] raw variant calculation status mismatch")
+        if variant.get("raw_value_sha256") != "sha256:" + record.get("raw_value_sha256", ""):
+            errors.append(f"evidence_records[{index}] raw variant hash mismatch")
+        return
+
+    if coverage_record.get("classifier_decision") != "parsed_numeric_structured":
+        errors.append(f"evidence_records[{index}] coverage must be parsed or partial parsed")
+    if coverage_record.get("calculation_input_status") != record.get("calculation_input_status"):
+        errors.append(f"evidence_records[{index}] calculation status does not match coverage")
+
+
+def _validate_public_ref(ref: object, context: str, errors: list[str]) -> None:
+    if not isinstance(ref, str) or not PUBLIC_PATH_RE.fullmatch(ref):
+        errors.append(f"{context} has invalid public ref: {ref!r}")
+        return
+    if ref.startswith("data/exports/") or ".local/" in ref:
+        errors.append(f"{context} uses forbidden source ref: {ref}")
+        return
+    if not (ROOT / ref).exists():
+        errors.append(f"{context} references missing path: {ref}")
+
+
+def _validate_public_text_boundary(path: Path, errors: list[str]) -> None:
+    text = path.read_text(encoding="utf-8")
+    for pattern in FORBIDDEN_PATTERNS:
+        if pattern.search(text):
+            errors.append(f"{path.relative_to(ROOT)} contains forbidden public content")
+            break
+    for literal in FORBIDDEN_LITERALS:
+        if literal in text:
+            errors.append(f"{path.relative_to(ROOT)} contains forbidden literal: {literal}")
+
+
+def _finish(errors: list[str]) -> int:
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("Current-fact candidate evidence validation OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds a docs-only ExecPlan for a summary-safe row/move/cell candidate evidence amendment.
- Defines the evidence fields needed before production current-fact candidate records can be populated.
- Keeps production candidate/source-record/export generation and runtime/parser/classifier/retrieval/answer/calculator/SymPy/source acquisition/live acquisition out of scope.

## Validation
- git diff --check
- git diff --cached --check
- uv lock --check
- validate_clean_slate.py
- validate_current_fact_schemas.py
- validate_current_fact_source_records.py
- validate_current_fact_row_move_cell_candidates.py
- validate_current_fact_consumer_guards.py
- validate_current_fact_export_generator.py
- parsed_value_classifier validate

## Important
- Do not merge this plan-only PR after plan review.
- After mandatory review passes, implementation detail or implementation commits should be added to this same draft PR.
- If implementation needs exact file lists/schema/validator decisions not already covered, amend the ExecPlan in this PR first.

## Remaining Risks
- Production candidate/source-record/export artifacts remain blocked.
- Runtime remains legacy raw export backed.
- Future evidence implementation may still need acquisition amendment if v4 fields are insufficient.
- First production candidate coverage may remain limited by parsed-value-only admission.