### PR TITLE
Plan current-fact production candidate artifact

### DIFF
--- a/contracts/current-facts/source_reference.schema.json
+++ b/contracts/current-facts/source_reference.schema.json
@@ -8,6 +8,7 @@
         "official_raw_snapshot",
         "supercombo_mapping_summary",
         "source_acquisition_report",
+        "source_review_summary",
         "synthetic_contract_fixture",
         "value_shape_inventory",
         "value_shape_policy"

--- a/data/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.json
+++ b/data/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.json
@@ -1,0 +1,1067 @@
+{
+  "artifact_schema_version": "current_fact_row_move_cell_candidate_input/v1",
+  "authority_boundary": {
+    "official": "authority_candidate_only",
+    "supercombo": "enrichment_or_cross_reference_only"
+  },
+  "candidate_boundary": {
+    "blocked_records": "excluded_to_classifier_or_source_review",
+    "legacy_raw_exports": "excluded_as_source_input",
+    "local_source_payloads": "excluded_from_public_artifact",
+    "lookup_ready_candidates": "parsed_value_only",
+    "reviewer_observations": "observation_candidate_only_not_authority",
+    "supercombo": "enrichment_or_cross_reference_only",
+    "synthetic_fixtures": "not_source_truth"
+  },
+  "generated_from": [
+    "contracts/current-facts/current_fact_row_move_cell_candidate_input.schema.json",
+    "data/source-reviews/20260524-official-note-linkage-source-review-summary.json",
+    "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+    "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+    "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md",
+    "docs/execplans/2026-05-25-current-fact-candidate-evidence-amendment.md",
+    "docs/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.md"
+  ],
+  "records": [
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "parsed_range_not_single_value_calculation_safe",
+      "candidate_record_id": "candidate:official:alex:row-41:cell-5:value-520f8306db0f",
+      "character_slug": "alex",
+      "coverage_refs": [
+        "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+      ],
+      "display_label_ja": "フライングクロスチョップ（ジャンプ中に） 強",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "硬直差",
+          "ガード"
+        ],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "block_advantage",
+      "move_id": "official:alex:row-41:move-f09489ff6eaa",
+      "parsed_value": {
+        "end": -1,
+        "kind": "frame_range",
+        "start": -12,
+        "unit": "frame"
+      },
+      "parser_rule_ids": [
+        "frame_range.official_signed_wave_dash.v1"
+      ],
+      "raw_value": "-12～-1",
+      "raw_value_length": 6,
+      "raw_value_sha256": "520f8306db0f00d860dfbf1f72aed57178586bbac1b4e2f2ceb6fa3c31284c35",
+      "source_cell_key": "official:alex:table-0:row-41:cell-5",
+      "source_cell_order": 5,
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ガード"
+      ],
+      "source_label": "ガード",
+      "source_name": "official",
+      "source_review_refs": [
+        "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "docs/execplans/2026-05-23-official-signed-range-parser.md"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:alex:table-0:row-41",
+      "source_row_order": 41,
+      "source_value_key": "official:alex:table-0:row-41:cell-5:value-520f8306db0f",
+      "value_shape": {
+        "classes": [
+          "range"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "frame_range.official_signed_wave_dash.v1",
+        "review_item_id": "value-shape:official--unclassified_expression--u_c135db53355f--u_522ba9f47afb"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "parsed_range_not_single_value_calculation_safe",
+      "candidate_record_id": "candidate:official:cammy:row-52:cell-5:value-f3bd1df4c26d",
+      "character_slug": "cammy",
+      "coverage_refs": [
+        "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+      ],
+      "display_label_ja": "リバースエッジ（フーリガンコンビネーション中に）",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "硬直差",
+          "ガード"
+        ],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "block_advantage",
+      "move_id": "official:cammy:row-52:move-003104ea0ff9",
+      "parsed_value": {
+        "end": -1,
+        "kind": "frame_range",
+        "start": -4,
+        "unit": "frame"
+      },
+      "parser_rule_ids": [
+        "frame_range.official_signed_wave_dash.v1"
+      ],
+      "raw_value": "-4～-1",
+      "raw_value_length": 5,
+      "raw_value_sha256": "f3bd1df4c26d078a592238ff898964a14b5859e74fe097da1bfae2a76be7c5a7",
+      "source_cell_key": "official:cammy:table-0:row-52:cell-5",
+      "source_cell_order": 5,
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ガード"
+      ],
+      "source_label": "ガード",
+      "source_name": "official",
+      "source_review_refs": [
+        "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "docs/execplans/2026-05-23-official-signed-range-parser.md"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:cammy:table-0:row-52",
+      "source_row_order": 52,
+      "source_value_key": "official:cammy:table-0:row-52:cell-5:value-f3bd1df4c26d",
+      "value_shape": {
+        "classes": [
+          "range"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "frame_range.official_signed_wave_dash.v1",
+        "review_item_id": "value-shape:official--unclassified_expression--u_c135db53355f--u_522ba9f47afb"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "candidate_record_id": "candidate:official:chunli:row-32:cell-4:value-38098349c914",
+      "character_slug": "chunli",
+      "coverage_refs": [
+        "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+      ],
+      "display_label_ja": "蘭華（行雲流水中に）弱",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "硬直差",
+          "ヒット"
+        ],
+        "source_label": "ヒット",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "hit_advantage",
+      "move_id": "official:chunli:row-32:move-278b4bdd0acb",
+      "parsed_value": {
+        "annotation": {
+          "marker_placement": "prefix",
+          "note_id": null,
+          "note_linkage_status": "same_row_note_candidates_available",
+          "note_marker": "※",
+          "note_scope": "row_hit_advantage_condition",
+          "note_text_status": "structured_row_note_text_found",
+          "row_note_candidate_count": 1
+        },
+        "calculation": {
+          "calculation_input_status": "annotated_candidate_not_calculation_safe",
+          "reason": "condition_bound_by_official_note"
+        },
+        "kind": "annotated_numeric_candidate",
+        "numeric_candidate": {
+          "candidate_type": "signed_frame",
+          "unit": "frame",
+          "value": -3
+        },
+        "source_context": {
+          "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69",
+          "source_column_header_path": [
+            "硬直差",
+            "ヒット"
+          ],
+          "source_review_id": "source-review:official-note-linkage-hit-advantage"
+        }
+      },
+      "parser_rule_ids": [
+        "annotated_signed_frame.official_prefix_marker.negative.v1"
+      ],
+      "raw_value": "※-3",
+      "raw_value_length": 3,
+      "raw_value_sha256": "38098349c914433f0d197b466d52fc182309a3043e91d401f8c2a98b3b8917ca",
+      "source_cell_key": "official:chunli:table-0:row-32:cell-4",
+      "source_cell_order": 4,
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ヒット"
+      ],
+      "source_label": "ヒット",
+      "source_name": "official",
+      "source_review_refs": [
+        "data/source-reviews/20260524-official-note-linkage-source-review-summary.json",
+        "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:chunli:table-0:row-32",
+      "source_row_order": 32,
+      "source_value_key": "official:chunli:table-0:row-32:cell-4:value-38098349c914",
+      "value_shape": {
+        "classes": [
+          "note_prefixed"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "annotated_signed_frame.official_prefix_marker.negative.v1",
+        "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "candidate_record_id": "candidate:official:chunli:row-32:cell-5:value-b5112d05eab3",
+      "character_slug": "chunli",
+      "coverage_refs": [
+        "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+      ],
+      "display_label_ja": "蘭華（行雲流水中に）弱",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "硬直差",
+          "ガード"
+        ],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "block_advantage",
+      "move_id": "official:chunli:row-32:move-278b4bdd0acb",
+      "parsed_value": {
+        "annotation": {
+          "marker_placement": "prefix",
+          "note_id": null,
+          "note_linkage_status": "same_row_note_candidates_available",
+          "note_marker": "※",
+          "note_scope": "row_block_advantage_condition",
+          "note_text_status": "structured_row_note_text_found",
+          "row_note_candidate_count": 1
+        },
+        "calculation": {
+          "calculation_input_status": "annotated_candidate_not_calculation_safe",
+          "reason": "condition_bound_by_official_note"
+        },
+        "kind": "annotated_numeric_candidate",
+        "numeric_candidate": {
+          "candidate_type": "signed_frame",
+          "unit": "frame",
+          "value": -4
+        },
+        "source_context": {
+          "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_522ba9f47afb",
+          "source_column_header_path": [
+            "硬直差",
+            "ガード"
+          ],
+          "source_review_id": "source-review:official-note-linkage-block-advantage"
+        }
+      },
+      "parser_rule_ids": [
+        "annotated_signed_frame.official_prefix_marker.negative.v1"
+      ],
+      "raw_value": "※-4",
+      "raw_value_length": 3,
+      "raw_value_sha256": "b5112d05eab37a8ef2062523ba1cce640a8350c6cba7ef40bf66072550f3609c",
+      "source_cell_key": "official:chunli:table-0:row-32:cell-5",
+      "source_cell_order": 5,
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ガード"
+      ],
+      "source_label": "ガード",
+      "source_name": "official",
+      "source_review_refs": [
+        "data/source-reviews/20260524-official-note-linkage-source-review-summary.json",
+        "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:chunli:table-0:row-32",
+      "source_row_order": 32,
+      "source_value_key": "official:chunli:table-0:row-32:cell-5:value-b5112d05eab3",
+      "value_shape": {
+        "classes": [
+          "note_prefixed"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "annotated_signed_frame.official_prefix_marker.negative.v1",
+        "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_522ba9f47afb"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "candidate_record_id": "candidate:official:chunli:row-35:cell-4:value-dbdd09f8dbaa",
+      "character_slug": "chunli",
+      "coverage_refs": [
+        "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+      ],
+      "display_label_ja": "前突（行雲流水中に）弱",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "硬直差",
+          "ヒット"
+        ],
+        "source_label": "ヒット",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "hit_advantage",
+      "move_id": "official:chunli:row-35:move-2c6d449eb8a3",
+      "parsed_value": {
+        "annotation": {
+          "marker_placement": "prefix",
+          "note_id": null,
+          "note_linkage_status": "same_row_note_candidates_available",
+          "note_marker": "※",
+          "note_scope": "row_hit_advantage_condition",
+          "note_text_status": "structured_row_note_text_found",
+          "row_note_candidate_count": 1
+        },
+        "calculation": {
+          "calculation_input_status": "annotated_candidate_not_calculation_safe",
+          "reason": "condition_bound_by_official_note"
+        },
+        "kind": "annotated_numeric_candidate",
+        "numeric_candidate": {
+          "candidate_type": "signed_frame",
+          "unit": "frame",
+          "value": -1
+        },
+        "source_context": {
+          "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69",
+          "source_column_header_path": [
+            "硬直差",
+            "ヒット"
+          ],
+          "source_review_id": "source-review:official-note-linkage-hit-advantage"
+        }
+      },
+      "parser_rule_ids": [
+        "annotated_signed_frame.official_prefix_marker.negative.v1"
+      ],
+      "raw_value": "※-1",
+      "raw_value_length": 3,
+      "raw_value_sha256": "dbdd09f8dbaacf8ce6a87b3f4b004af5a8185b47ed0b193adcf2afdd6bd8e0af",
+      "source_cell_key": "official:chunli:table-0:row-35:cell-4",
+      "source_cell_order": 4,
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ヒット"
+      ],
+      "source_label": "ヒット",
+      "source_name": "official",
+      "source_review_refs": [
+        "data/source-reviews/20260524-official-note-linkage-source-review-summary.json",
+        "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:chunli:table-0:row-35",
+      "source_row_order": 35,
+      "source_value_key": "official:chunli:table-0:row-35:cell-4:value-dbdd09f8dbaa",
+      "value_shape": {
+        "classes": [
+          "note_prefixed"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "annotated_signed_frame.official_prefix_marker.negative.v1",
+        "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "candidate_record_id": "candidate:official:chunli:row-36:cell-4:value-b5112d05eab3",
+      "character_slug": "chunli",
+      "coverage_refs": [
+        "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+      ],
+      "display_label_ja": "仙風（行雲流水中に）中",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "硬直差",
+          "ヒット"
+        ],
+        "source_label": "ヒット",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "hit_advantage",
+      "move_id": "official:chunli:row-36:move-f41b02dd87c4",
+      "parsed_value": {
+        "annotation": {
+          "marker_placement": "prefix",
+          "note_id": null,
+          "note_linkage_status": "same_row_note_candidates_available",
+          "note_marker": "※",
+          "note_scope": "row_hit_advantage_condition",
+          "note_text_status": "structured_row_note_text_found",
+          "row_note_candidate_count": 1
+        },
+        "calculation": {
+          "calculation_input_status": "annotated_candidate_not_calculation_safe",
+          "reason": "condition_bound_by_official_note"
+        },
+        "kind": "annotated_numeric_candidate",
+        "numeric_candidate": {
+          "candidate_type": "signed_frame",
+          "unit": "frame",
+          "value": -4
+        },
+        "source_context": {
+          "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69",
+          "source_column_header_path": [
+            "硬直差",
+            "ヒット"
+          ],
+          "source_review_id": "source-review:official-note-linkage-hit-advantage"
+        }
+      },
+      "parser_rule_ids": [
+        "annotated_signed_frame.official_prefix_marker.negative.v1"
+      ],
+      "raw_value": "※-4",
+      "raw_value_length": 3,
+      "raw_value_sha256": "b5112d05eab37a8ef2062523ba1cce640a8350c6cba7ef40bf66072550f3609c",
+      "source_cell_key": "official:chunli:table-0:row-36:cell-4",
+      "source_cell_order": 4,
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ヒット"
+      ],
+      "source_label": "ヒット",
+      "source_name": "official",
+      "source_review_refs": [
+        "data/source-reviews/20260524-official-note-linkage-source-review-summary.json",
+        "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:chunli:table-0:row-36",
+      "source_row_order": 36,
+      "source_value_key": "official:chunli:table-0:row-36:cell-4:value-b5112d05eab3",
+      "value_shape": {
+        "classes": [
+          "note_prefixed"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "annotated_signed_frame.official_prefix_marker.negative.v1",
+        "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "candidate_record_id": "candidate:official:ed:row-21:cell-5:value-522076e6afe2",
+      "character_slug": "ed",
+      "coverage_refs": [
+        "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+      ],
+      "display_label_ja": "サイコナックル(Lv1)強ホールド",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "硬直差",
+          "ガード"
+        ],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "block_advantage",
+      "move_id": "official:ed:row-21:move-a8a13087c217",
+      "parsed_value": {
+        "annotation": {
+          "marker_placement": "prefix",
+          "note_id": null,
+          "note_linkage_status": "same_row_note_candidates_available",
+          "note_marker": "※",
+          "note_scope": "row_block_advantage_condition",
+          "note_text_status": "structured_row_note_text_found",
+          "row_note_candidate_count": 1
+        },
+        "calculation": {
+          "calculation_input_status": "annotated_candidate_not_calculation_safe",
+          "reason": "condition_bound_by_official_note"
+        },
+        "kind": "annotated_numeric_candidate",
+        "numeric_candidate": {
+          "candidate_type": "signed_frame",
+          "unit": "frame",
+          "value": -2
+        },
+        "source_context": {
+          "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_522ba9f47afb",
+          "source_column_header_path": [
+            "硬直差",
+            "ガード"
+          ],
+          "source_review_id": "source-review:official-note-linkage-block-advantage"
+        }
+      },
+      "parser_rule_ids": [
+        "annotated_signed_frame.official_prefix_marker.negative.v1"
+      ],
+      "raw_value": "※-2",
+      "raw_value_length": 3,
+      "raw_value_sha256": "522076e6afe25969ab0fe38642fcf471a681152e0f919f489622873b188357e6",
+      "source_cell_key": "official:ed:table-0:row-21:cell-5",
+      "source_cell_order": 5,
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ガード"
+      ],
+      "source_label": "ガード",
+      "source_name": "official",
+      "source_review_refs": [
+        "data/source-reviews/20260524-official-note-linkage-source-review-summary.json",
+        "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:ed:table-0:row-21",
+      "source_row_order": 21,
+      "source_value_key": "official:ed:table-0:row-21:cell-5:value-522076e6afe2",
+      "value_shape": {
+        "classes": [
+          "note_prefixed"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "annotated_signed_frame.official_prefix_marker.negative.v1",
+        "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_522ba9f47afb"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "candidate_record_id": "candidate:official:kimberly:row-64:cell-1:value-1a036dd4c06c",
+      "character_slug": "kimberly",
+      "coverage_refs": [
+        "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+      ],
+      "display_label_ja": "弱 細工手裏剣（細工手裏剣ストックが1以上で） 弱",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "動作フレーム",
+          "発生"
+        ],
+        "source_label": "発生",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "startup",
+      "move_id": "official:kimberly:row-64:move-1ebd54eb85aa",
+      "parsed_value": {
+        "annotation": {
+          "marker_placement": "suffix",
+          "note_id": null,
+          "note_linkage_status": "same_row_note_candidates_available",
+          "note_marker": "※",
+          "note_scope": "row_startup_condition",
+          "note_text_status": "structured_row_note_text_found",
+          "row_note_candidate_count": 1
+        },
+        "calculation": {
+          "calculation_input_status": "annotated_candidate_not_calculation_safe",
+          "reason": "condition_bound_by_official_note"
+        },
+        "kind": "annotated_numeric_candidate",
+        "numeric_candidate": {
+          "candidate_type": "unsigned_frame",
+          "unit": "frame",
+          "value": 122
+        },
+        "source_context": {
+          "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100",
+          "source_column_header_path": [
+            "動作フレーム",
+            "発生"
+          ],
+          "source_review_id": "source-review:official-note-linkage-startup"
+        }
+      },
+      "parser_rule_ids": [
+        "annotated_frame.official_suffix_marker.v1"
+      ],
+      "raw_value": "122※",
+      "raw_value_length": 4,
+      "raw_value_sha256": "1a036dd4c06cd18cde9b72d219f3bf9ff2c41ec171022dbe1058e162cf96df7c",
+      "source_cell_key": "official:kimberly:table-0:row-64:cell-1",
+      "source_cell_order": 1,
+      "source_family": "timing",
+      "source_header_path": [
+        "動作フレーム",
+        "発生"
+      ],
+      "source_label": "発生",
+      "source_name": "official",
+      "source_review_refs": [
+        "data/source-reviews/20260524-official-note-linkage-source-review-summary.json",
+        "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:kimberly:table-0:row-64",
+      "source_row_order": 64,
+      "source_value_key": "official:kimberly:table-0:row-64:cell-1:value-1a036dd4c06c",
+      "value_shape": {
+        "classes": [
+          "note_suffixed"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "annotated_frame.official_suffix_marker.v1",
+        "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "candidate_record_id": "candidate:official:kimberly:row-66:cell-1:value-3c911b4c4f5d",
+      "character_slug": "kimberly",
+      "coverage_refs": [
+        "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+      ],
+      "display_label_ja": "強 細工手裏剣（細工手裏剣ストックが1以上で） 強",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "動作フレーム",
+          "発生"
+        ],
+        "source_label": "発生",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "startup",
+      "move_id": "official:kimberly:row-66:move-035abd428c6f",
+      "parsed_value": {
+        "annotation": {
+          "marker_placement": "suffix",
+          "note_id": null,
+          "note_linkage_status": "same_row_note_candidates_available",
+          "note_marker": "※",
+          "note_scope": "row_startup_condition",
+          "note_text_status": "structured_row_note_text_found",
+          "row_note_candidate_count": 1
+        },
+        "calculation": {
+          "calculation_input_status": "annotated_candidate_not_calculation_safe",
+          "reason": "condition_bound_by_official_note"
+        },
+        "kind": "annotated_numeric_candidate",
+        "numeric_candidate": {
+          "candidate_type": "unsigned_frame",
+          "unit": "frame",
+          "value": 128
+        },
+        "source_context": {
+          "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100",
+          "source_column_header_path": [
+            "動作フレーム",
+            "発生"
+          ],
+          "source_review_id": "source-review:official-note-linkage-startup"
+        }
+      },
+      "parser_rule_ids": [
+        "annotated_frame.official_suffix_marker.v1"
+      ],
+      "raw_value": "128※",
+      "raw_value_length": 4,
+      "raw_value_sha256": "3c911b4c4f5d473c3e4bd988a924818f3c760adbd14fd241a7fdccf42c99b814",
+      "source_cell_key": "official:kimberly:table-0:row-66:cell-1",
+      "source_cell_order": 1,
+      "source_family": "timing",
+      "source_header_path": [
+        "動作フレーム",
+        "発生"
+      ],
+      "source_label": "発生",
+      "source_name": "official",
+      "source_review_refs": [
+        "data/source-reviews/20260524-official-note-linkage-source-review-summary.json",
+        "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:kimberly:table-0:row-66",
+      "source_row_order": 66,
+      "source_value_key": "official:kimberly:table-0:row-66:cell-1:value-3c911b4c4f5d",
+      "value_shape": {
+        "classes": [
+          "note_suffixed"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "annotated_frame.official_suffix_marker.v1",
+        "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "candidate_record_id": "candidate:official:kimberly:row-67:cell-1:value-1a036dd4c06c",
+      "character_slug": "kimberly",
+      "coverage_refs": [
+        "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+      ],
+      "display_label_ja": "弱 乱れ細工手裏剣（細工手裏剣ストックが2以上で） 弱中",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "動作フレーム",
+          "発生"
+        ],
+        "source_label": "発生",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "startup",
+      "move_id": "official:kimberly:row-67:move-c8f7890e80bb",
+      "parsed_value": {
+        "annotation": {
+          "marker_placement": "suffix",
+          "note_id": null,
+          "note_linkage_status": "same_row_note_candidates_available",
+          "note_marker": "※",
+          "note_scope": "row_startup_condition",
+          "note_text_status": "structured_row_note_text_found",
+          "row_note_candidate_count": 1
+        },
+        "calculation": {
+          "calculation_input_status": "annotated_candidate_not_calculation_safe",
+          "reason": "condition_bound_by_official_note"
+        },
+        "kind": "annotated_numeric_candidate",
+        "numeric_candidate": {
+          "candidate_type": "unsigned_frame",
+          "unit": "frame",
+          "value": 122
+        },
+        "source_context": {
+          "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100",
+          "source_column_header_path": [
+            "動作フレーム",
+            "発生"
+          ],
+          "source_review_id": "source-review:official-note-linkage-startup"
+        }
+      },
+      "parser_rule_ids": [
+        "annotated_frame.official_suffix_marker.v1"
+      ],
+      "raw_value": "122※",
+      "raw_value_length": 4,
+      "raw_value_sha256": "1a036dd4c06cd18cde9b72d219f3bf9ff2c41ec171022dbe1058e162cf96df7c",
+      "source_cell_key": "official:kimberly:table-0:row-67:cell-1",
+      "source_cell_order": 1,
+      "source_family": "timing",
+      "source_header_path": [
+        "動作フレーム",
+        "発生"
+      ],
+      "source_label": "発生",
+      "source_name": "official",
+      "source_review_refs": [
+        "data/source-reviews/20260524-official-note-linkage-source-review-summary.json",
+        "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:kimberly:table-0:row-67",
+      "source_row_order": 67,
+      "source_value_key": "official:kimberly:table-0:row-67:cell-1:value-1a036dd4c06c",
+      "value_shape": {
+        "classes": [
+          "note_suffixed"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "annotated_frame.official_suffix_marker.v1",
+        "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "candidate_record_id": "candidate:official:kimberly:row-68:cell-1:value-1a036dd4c06c",
+      "character_slug": "kimberly",
+      "coverage_refs": [
+        "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+      ],
+      "display_label_ja": "中 乱れ細工手裏剣（細工手裏剣ストックが2以上で） 弱強",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "動作フレーム",
+          "発生"
+        ],
+        "source_label": "発生",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "startup",
+      "move_id": "official:kimberly:row-68:move-8683c9bcb338",
+      "parsed_value": {
+        "annotation": {
+          "marker_placement": "suffix",
+          "note_id": null,
+          "note_linkage_status": "same_row_note_candidates_available",
+          "note_marker": "※",
+          "note_scope": "row_startup_condition",
+          "note_text_status": "structured_row_note_text_found",
+          "row_note_candidate_count": 1
+        },
+        "calculation": {
+          "calculation_input_status": "annotated_candidate_not_calculation_safe",
+          "reason": "condition_bound_by_official_note"
+        },
+        "kind": "annotated_numeric_candidate",
+        "numeric_candidate": {
+          "candidate_type": "unsigned_frame",
+          "unit": "frame",
+          "value": 122
+        },
+        "source_context": {
+          "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100",
+          "source_column_header_path": [
+            "動作フレーム",
+            "発生"
+          ],
+          "source_review_id": "source-review:official-note-linkage-startup"
+        }
+      },
+      "parser_rule_ids": [
+        "annotated_frame.official_suffix_marker.v1"
+      ],
+      "raw_value": "122※",
+      "raw_value_length": 4,
+      "raw_value_sha256": "1a036dd4c06cd18cde9b72d219f3bf9ff2c41ec171022dbe1058e162cf96df7c",
+      "source_cell_key": "official:kimberly:table-0:row-68:cell-1",
+      "source_cell_order": 1,
+      "source_family": "timing",
+      "source_header_path": [
+        "動作フレーム",
+        "発生"
+      ],
+      "source_label": "発生",
+      "source_name": "official",
+      "source_review_refs": [
+        "data/source-reviews/20260524-official-note-linkage-source-review-summary.json",
+        "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:kimberly:table-0:row-68",
+      "source_row_order": 68,
+      "source_value_key": "official:kimberly:table-0:row-68:cell-1:value-1a036dd4c06c",
+      "value_shape": {
+        "classes": [
+          "note_suffixed"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "annotated_frame.official_suffix_marker.v1",
+        "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "parsed_range_not_single_value_calculation_safe",
+      "candidate_record_id": "candidate:official:vega_mbison:row-53:cell-4:value-1c81d53e6168",
+      "character_slug": "vega_mbison",
+      "coverage_refs": [
+        "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+      ],
+      "display_label_ja": "ヘッドプレス（シャドウライズ中に）",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "硬直差",
+          "ヒット"
+        ],
+        "source_label": "ヒット",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "hit_advantage",
+      "move_id": "official:vega_mbison:row-53:move-268f9d662fa7",
+      "parsed_value": {
+        "end": -23,
+        "kind": "frame_range",
+        "start": -28,
+        "unit": "frame"
+      },
+      "parser_rule_ids": [
+        "frame_range.official_signed_wave_dash.v1"
+      ],
+      "raw_value": "-28～-23",
+      "raw_value_length": 7,
+      "raw_value_sha256": "1c81d53e6168526120e54c0d776c9dd883e1d484832eca4b59e829d0ab5ad285",
+      "source_cell_key": "official:vega_mbison:table-0:row-53:cell-4",
+      "source_cell_order": 4,
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ヒット"
+      ],
+      "source_label": "ヒット",
+      "source_name": "official",
+      "source_review_refs": [
+        "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "docs/execplans/2026-05-23-official-signed-range-parser.md"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:vega_mbison:table-0:row-53",
+      "source_row_order": 53,
+      "source_value_key": "official:vega_mbison:table-0:row-53:cell-4:value-1c81d53e6168",
+      "value_shape": {
+        "classes": [
+          "range"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "frame_range.official_signed_wave_dash.v1",
+        "review_item_id": "value-shape:official--unclassified_expression--u_c135db53355f--u_7acd6c7b6e69"
+      }
+    },
+    {
+      "acquisition_report_refs": [
+        "docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md"
+      ],
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "parsed_range_not_single_value_calculation_safe",
+      "candidate_record_id": "candidate:official:vega_mbison:row-53:cell-5:value-1c461fc0a5e3",
+      "character_slug": "vega_mbison",
+      "coverage_refs": [
+        "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+      ],
+      "display_label_ja": "ヘッドプレス（シャドウライズ中に）",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "硬直差",
+          "ガード"
+        ],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "block_advantage",
+      "move_id": "official:vega_mbison:row-53:move-268f9d662fa7",
+      "parsed_value": {
+        "end": -33,
+        "kind": "frame_range",
+        "start": -39,
+        "unit": "frame"
+      },
+      "parser_rule_ids": [
+        "frame_range.official_signed_wave_dash.v1"
+      ],
+      "raw_value": "-39～-33",
+      "raw_value_length": 7,
+      "raw_value_sha256": "1c461fc0a5e3e3e6877d22bc8de7fd0165119dcb255b70232e90bb70268e5fab",
+      "source_cell_key": "official:vega_mbison:table-0:row-53:cell-5",
+      "source_cell_order": 5,
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ガード"
+      ],
+      "source_label": "ガード",
+      "source_name": "official",
+      "source_review_refs": [
+        "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "docs/execplans/2026-05-23-official-signed-range-parser.md"
+      ],
+      "source_role": "authority_candidate",
+      "source_row_key": "official:vega_mbison:table-0:row-53",
+      "source_row_order": 53,
+      "source_value_key": "official:vega_mbison:table-0:row-53:cell-5:value-1c461fc0a5e3",
+      "value_shape": {
+        "classes": [
+          "range"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "frame_range.official_signed_wave_dash.v1",
+        "review_item_id": "value-shape:official--unclassified_expression--u_c135db53355f--u_522ba9f47afb"
+      }
+    }
+  ],
+  "run_id": "20260525T000000Z"
+}

--- a/data/validator-audits/20260523-validator-test-fact-source-audit.json
+++ b/data/validator-audits/20260523-validator-test-fact-source-audit.json
@@ -24,6 +24,19 @@
       "status": "accepted_with_limits"
     },
     {
+      "evidence_class": "source_derived",
+      "file": "tests/test_current_fact_candidate_generator.py",
+      "limitations": [
+        "uses reviewed candidate evidence and deterministic classifier reproduction; does not prove source truth beyond reviewed public evidence"
+      ],
+      "primary_evidence": [
+        "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json",
+        "current-fact production candidate artifact ExecPlan"
+      ],
+      "status": "accepted_with_limits"
+    },
+    {
       "evidence_class": "synthetic_contract",
       "file": "tests/test_current_fact_export_generator.py",
       "limitations": [
@@ -131,26 +144,30 @@
       "evidence_class": "artifact_consistency",
       "file": "tests/validation/validate_current_fact_export_generator.py",
       "limitations": [
-        "checks fixture-contract generator output, guard boundaries, and no production artifact paths; does not prove source truth"
+        "checks fixture-contract generator output, guard boundaries, and absence of production source-record/export artifacts; does not prove source truth"
       ],
       "primary_evidence": [
         "contracts/current-facts/current_fact_export.schema.json",
         "contracts/current-facts/current_fact_source_record_input.schema.json",
         "tests/fixtures/current-facts/source-records",
-        "current-fact export generator fixture-contract implementation ExecPlan"
+        "current-fact export generator fixture-contract implementation ExecPlan",
+        "current-fact production candidate artifact ExecPlan"
       ],
       "status": "accepted_with_limits"
     },
     {
-      "evidence_class": "synthetic_contract",
+      "evidence_class": "source_derived",
       "file": "tests/validation/validate_current_fact_row_move_cell_candidates.py",
       "limitations": [
-        "checks row/move/cell candidate schema, synthetic fixture contracts, and source-boundary guard mutations; does not produce production candidates or prove source truth"
+        "checks row/move/cell candidate schema, synthetic fixture contracts, source-boundary guard mutations, and production candidate consistency with reviewed public evidence; does not prove source truth beyond reviewed evidence"
       ],
       "primary_evidence": [
         "contracts/current-facts/current_fact_row_move_cell_candidate_input.schema.json",
+        "data/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.json",
+        "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
         "tests/fixtures/current-facts/candidate-inputs",
-        "current-fact row/move/cell candidate schema ExecPlan"
+        "current-fact row/move/cell candidate schema ExecPlan",
+        "current-fact production candidate artifact ExecPlan"
       ],
       "status": "accepted_with_limits"
     },

--- a/docs/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.md
+++ b/docs/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.md
@@ -1,0 +1,27 @@
+# Current-Fact Row/Move/Cell Candidate Input
+
+- JSON artifact: `data/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.json`
+- Run ID: `20260525T000000Z`
+- Source evidence: `data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json`
+- Source run ID: `20260521T025403Z`
+- Total records: `13`
+- Candidate boundary: parsed-value-only, non-scalar values remain not calculation-safe.
+- Authority boundary: official values remain authority candidates only.
+- Legacy raw exports, ignored local artifacts, raw source payloads, reviewer observations, and private data are excluded as authority.
+
+## Counts
+
+| Dimension | Value | Count |
+| --- | --- | --- |
+| calculation_input_status | `annotated_candidate_not_calculation_safe` | 9 |
+| calculation_input_status | `parsed_range_not_single_value_calculation_safe` | 4 |
+| field_key | `block_advantage` | 5 |
+| field_key | `hit_advantage` | 4 |
+| field_key | `startup` | 4 |
+
+## Boundaries
+
+- No production source-record artifact is generated.
+- No production current-fact export artifact is generated.
+- Runtime lookup and answer behavior are unchanged.
+- `annotated_numeric_candidate` and `frame_range` must not be flattened into scalar values.

--- a/docs/execplans/2026-05-25-current-fact-production-candidate-artifact.md
+++ b/docs/execplans/2026-05-25-current-fact-production-candidate-artifact.md
@@ -1,6 +1,6 @@
 # Current-Fact Production Candidate Artifact
 
-Status: Drafted for review; run_id schema amendment pending review; validation passed.
+Status: Implementation complete; validation passed; mandatory review pending.
 
 ## Purpose
 
@@ -102,10 +102,14 @@ Excluded:
 Planned production candidate JSON:
 
 - `data/current-facts/candidate-inputs/<candidate_run_id>-row-move-cell-candidates.json`
+- Implemented as
+  `data/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.json`.
 
 Planned summary Markdown:
 
 - `docs/current-facts/candidate-inputs/<candidate_run_id>-row-move-cell-candidates.md`
+- Implemented as
+  `docs/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.md`.
 
 `<candidate_run_id>` is the production candidate artifact run ID and must match
 the schema-required UTC timestamp format `YYYYMMDDTHHMMSSZ`. The JSON
@@ -357,6 +361,13 @@ git status --short --branch
 - 2026-05-25: Amended candidate artifact path and top-level `run_id` plan to
   use schema-valid `YYYYMMDDTHHMMSSZ` timestamps while retaining PR #365
   `20260525` only as a source-review evidence reference.
+- 2026-05-25: Added in-memory candidate generator, focused unit tests,
+  `source_review_summary` evidence basis, production candidate JSON/Markdown
+  artifacts, validator boundary updates, and validator audit updates. Full
+  validation passed.
+- 2026-05-25: Ran implementation validation: `git diff --check`,
+  `uv lock --check`, unittest discovery, all `tests/validation/validate_*.py`,
+  and `parsed_value_classifier validate`; all passed.
 
 ## Decision Log
 
@@ -371,6 +382,11 @@ git status --short --branch
   candidate artifact changes.
 - 2026-05-25: Candidate artifact `run_id` must be a schema-valid timestamp and
   must not reuse PR #365's date-only source-review evidence identifier.
+- 2026-05-25: Chose `20260525T000000Z` as the stable candidate artifact
+  `run_id` for this first production candidate artifact.
+- 2026-05-25: Added `source_review_summary` to `source_reference.schema.json`
+  as the evidence basis for production candidate records derived from reviewed
+  public source-review evidence.
 
 ## Deviations
 
@@ -396,6 +412,10 @@ git status --short --branch
 | Input boundary | Plan restricts input to PR #365 public evidence | Same | `validate_current_fact_candidate_evidence.py` | Pass | None | Mandatory plan review pending | Candidate generation remains unimplemented |
 | Candidate run ID | Plan requires schema-valid timestamp `run_id` and keeps PR #365 `20260525` as evidence reference only | Same | `validate_current_fact_schemas.py` | Pass | None | Mandatory plan review pending | Implementation must choose one stable timestamp for JSON and Markdown paths |
 | Runtime/export boundary | No runtime/source-record/export changes | Same | current-fact validators | Pass | None | Mandatory plan review pending | Runtime remains legacy raw export backed |
+| Candidate generator | Deterministic helper transforms PR #365 evidence into candidate payload and summary | `src/sf6_knowledge_coach/current_fact_candidate_generator.py`; `tests/test_current_fact_candidate_generator.py` | `python -m unittest tests.test_current_fact_candidate_generator` | Pass | None | Mandatory implementation review pending | Helper proves transformation only, not source truth |
+| Production candidate artifact | 13-record JSON plus summary Markdown with timestamp `run_id` | `data/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.json`; `docs/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.md` | `validate_current_fact_row_move_cell_candidates.py` | Pass | None | Mandatory implementation review pending | All records remain non-scalar and not calculation-safe |
+| Evidence basis schema | Added `source_review_summary` evidence basis only | `contracts/current-facts/source_reference.schema.json` | `validate_current_fact_schemas.py` | Pass | None | Mandatory implementation review pending | No broader schema change planned |
+| Validator boundaries | Candidate validator now allows only approved production candidate artifact; export validator still rejects source-record/export artifacts | `tests/validation/validate_current_fact_row_move_cell_candidates.py`; `tests/validation/validate_current_fact_export_generator.py`; validator audit artifacts | validation suite | Pass | None | Mandatory implementation review pending | Runtime remains legacy raw export backed |
 
 ## Next Reviewer Prompt
 

--- a/docs/execplans/2026-05-25-current-fact-production-candidate-artifact.md
+++ b/docs/execplans/2026-05-25-current-fact-production-candidate-artifact.md
@@ -1,6 +1,6 @@
 # Current-Fact Production Candidate Artifact
 
-Status: Drafted for review; validation passed.
+Status: Drafted for review; run_id schema amendment pending review; validation passed.
 
 ## Purpose
 
@@ -101,16 +101,22 @@ Excluded:
 
 Planned production candidate JSON:
 
-- `data/current-facts/candidate-inputs/20260525-row-move-cell-candidates.json`
+- `data/current-facts/candidate-inputs/<candidate_run_id>-row-move-cell-candidates.json`
 
 Planned summary Markdown:
 
-- `docs/current-facts/candidate-inputs/20260525-row-move-cell-candidates.md`
+- `docs/current-facts/candidate-inputs/<candidate_run_id>-row-move-cell-candidates.md`
 
-The artifact `run_id` should be `20260525`, matching the reviewed evidence
-artifact run. Records must keep source references to the `20260521T025403Z`
-acquisition and classifier run through `generated_from`, `coverage_refs`,
-`source_review_refs`, `acquisition_report_refs`, and `evidence`.
+`<candidate_run_id>` is the production candidate artifact run ID and must match
+the schema-required UTC timestamp format `YYYYMMDDTHHMMSSZ`. The JSON
+top-level `run_id` must exactly match `<candidate_run_id>`.
+
+Do not reuse the PR #365 evidence artifact's date-only `20260525` identifier as
+the candidate artifact `run_id`. Keep the PR #365 evidence artifact identity in
+`generated_from`, `source_review_refs`, and `evidence`; keep source references
+to the `20260521T025403Z` acquisition and classifier run through
+`generated_from`, `coverage_refs`, `source_review_refs`,
+`acquisition_report_refs`, and `evidence`.
 
 ## Allowed Source Inputs
 
@@ -276,6 +282,8 @@ double-check gate first.
   same draft PR.
 - Production candidate artifact is generated only from PR #365 reviewed public
   evidence.
+- Production candidate artifact top-level `run_id` is a schema-valid
+  `YYYYMMDDTHHMMSSZ` timestamp, not the PR #365 date-only evidence identifier.
 - Production candidate artifact has exactly 13 records.
 - No production source-record or current-fact export artifact is generated.
 - No runtime lookup, parser/classifier behavior, retrieval, answer,
@@ -304,8 +312,8 @@ Future implementation commits in the same draft PR may change only:
 - `contracts/current-facts/source_reference.schema.json` only for
   `source_review_summary` evidence basis if needed
 - current-fact schema fixtures only if a schema enum change requires them
-- `data/current-facts/candidate-inputs/20260525-row-move-cell-candidates.json`
-- `docs/current-facts/candidate-inputs/20260525-row-move-cell-candidates.md`
+- `data/current-facts/candidate-inputs/<candidate_run_id>-row-move-cell-candidates.json`
+- `docs/current-facts/candidate-inputs/<candidate_run_id>-row-move-cell-candidates.md`
 - validator audit JSON/MD if tests or validators change
 
 Any additional file requires ExecPlan amendment and mandatory review before
@@ -346,6 +354,9 @@ git status --short --branch
 - 2026-05-25: Drafted plan after PR #365 merged. No implementation or
   production candidate artifact generated yet.
 - 2026-05-25: Ran plan-only validation. All checks passed.
+- 2026-05-25: Amended candidate artifact path and top-level `run_id` plan to
+  use schema-valid `YYYYMMDDTHHMMSSZ` timestamps while retaining PR #365
+  `20260525` only as a source-review evidence reference.
 
 ## Decision Log
 
@@ -358,6 +369,8 @@ git status --short --branch
   if a source-review evidence basis is needed.
 - 2026-05-25: Plan-only validation passed without implementation or generated
   candidate artifact changes.
+- 2026-05-25: Candidate artifact `run_id` must be a schema-valid timestamp and
+  must not reuse PR #365's date-only source-review evidence identifier.
 
 ## Deviations
 
@@ -381,6 +394,7 @@ git status --short --branch
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Production candidate artifact plan | Draft plan only | `docs/execplans/2026-05-25-current-fact-production-candidate-artifact.md` | `git diff --check`; `uv lock --check` | Pass | None | Mandatory plan review pending | Schema enum may be needed later |
 | Input boundary | Plan restricts input to PR #365 public evidence | Same | `validate_current_fact_candidate_evidence.py` | Pass | None | Mandatory plan review pending | Candidate generation remains unimplemented |
+| Candidate run ID | Plan requires schema-valid timestamp `run_id` and keeps PR #365 `20260525` as evidence reference only | Same | `validate_current_fact_schemas.py` | Pass | None | Mandatory plan review pending | Implementation must choose one stable timestamp for JSON and Markdown paths |
 | Runtime/export boundary | No runtime/source-record/export changes | Same | current-fact validators | Pass | None | Mandatory plan review pending | Runtime remains legacy raw export backed |
 
 ## Next Reviewer Prompt
@@ -399,6 +413,9 @@ Check:
   calculator, SymPy, source acquisition, or live acquisition.
 - Planned production candidate artifact is exactly 13 records from PR #365
   evidence.
+- Candidate artifact JSON top-level `run_id` and artifact filename use a
+  schema-valid `YYYYMMDDTHHMMSSZ` candidate run ID; PR #365's `20260525`
+  evidence ID is retained only in references.
 - annotated_numeric_candidate and frame_range remain non-scalar and not
   calculation-safe.
 - validator boundary changes are explicitly planned.

--- a/docs/execplans/2026-05-25-current-fact-production-candidate-artifact.md
+++ b/docs/execplans/2026-05-25-current-fact-production-candidate-artifact.md
@@ -1,0 +1,426 @@
+# Current-Fact Production Candidate Artifact
+
+Status: Drafted for review; validation passed.
+
+## Purpose
+
+Plan generation of the first production
+`current_fact_row_move_cell_candidate_input/v1` artifact from the reviewed
+public candidate evidence artifact added by PR #365.
+
+This uses the same draft-PR flow as PR #365: land this ExecPlan in a draft PR,
+complete mandatory plan review, then add implementation commits to the same
+draft PR. Do not merge the plan-only PR.
+
+The implementation must not use legacy raw exports, ignored local artifacts,
+raw HTML, screenshots, VLM output, or private data as authority.
+
+## Inputs
+
+- `docs/PLAN.md`
+- `AGENTS.md`
+- `docs/execplans/2026-05-25-current-fact-candidate-evidence-amendment.md`
+- `docs/execplans/2026-05-25-current-fact-row-move-cell-candidate-input.md`
+- `docs/execplans/2026-05-25-current-fact-row-move-cell-candidate-schema.md`
+- `contracts/current-facts/current_fact_row_move_cell_candidate_input.schema.json`
+- `contracts/current-facts/current_fact_record.schema.json`
+- `contracts/current-facts/parsed_value.schema.json`
+- `contracts/current-facts/source_reference.schema.json`
+- `contracts/current-facts/value_shape.schema.json`
+- `src/sf6_knowledge_coach/parsed_value_classifier.py`
+- `src/sf6_knowledge_coach/current_fact_guards.py`
+- `data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json`
+- `docs/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.md`
+- `data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json`
+- `data/source-reviews/20260524-official-note-linkage-source-review-summary.json`
+- `docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md`
+- `data/validator-audits/20260523-validator-test-fact-source-audit.json`
+- `docs/validator-audits/20260523-validator-test-fact-source-audit.md`
+
+## Context
+
+PR #365 produced summary-safe source-review evidence for 13 current parsed
+official candidate cells:
+
+- 9 `annotated_numeric_candidate` records with
+  `annotated_candidate_not_calculation_safe`;
+- 4 `frame_range` records with
+  `parsed_range_not_single_value_calculation_safe`.
+
+Those records prove public row/move/cell identity evidence, but they are not
+the production candidate artifact. The next step is to transform that reviewed
+evidence into a schema-valid candidate input artifact while preserving all
+non-scalar and authority boundaries.
+
+Existing validators still assume `data/current-facts/candidate-inputs/` is
+empty. The implementation must deliberately change that boundary from "no
+production candidate artifacts yet" to "only the approved candidate artifact
+is allowed and validated."
+
+## Scope
+
+Included in this plan and future implementation slice:
+
+- generate one production
+  `current_fact_row_move_cell_candidate_input/v1` JSON artifact from the PR
+  #365 reviewed public evidence artifact;
+- generate one summary-safe Markdown companion;
+- add a small deterministic in-memory candidate generator/helper if needed;
+- add focused unit tests for generator behavior if a helper is added;
+- update `validate_current_fact_row_move_cell_candidates.py` to validate the
+  approved production candidate artifact instead of requiring the production
+  candidate directory to stay empty;
+- update `validate_current_fact_export_generator.py` only to stop treating the
+  candidate artifact as a forbidden current-fact export/source-record
+  artifact;
+- update source/evidence schema only if required to represent a source-review
+  evidence basis honestly;
+- update validator audit artifacts for any new or changed tests/validators;
+- update this ExecPlan Progress, Decision Log, and Completion Review Table.
+
+Excluded:
+
+- No production source-record artifact generation.
+- No production current-fact export artifact generation.
+- No runtime lookup change.
+- No `current_facts.py` change.
+- No `answering.py` change.
+- No parser/classifier behavior change.
+- No parser/classifier expansion.
+- No retrieval implementation.
+- No answer implementation.
+- No calculator implementation.
+- No SymPy logic.
+- No source acquisition implementation.
+- No live acquisition.
+- No authority promotion.
+- No calculation-safe promotion.
+- No Issue #343 raw-value expansion.
+
+## Artifact Paths
+
+Planned production candidate JSON:
+
+- `data/current-facts/candidate-inputs/20260525-row-move-cell-candidates.json`
+
+Planned summary Markdown:
+
+- `docs/current-facts/candidate-inputs/20260525-row-move-cell-candidates.md`
+
+The artifact `run_id` should be `20260525`, matching the reviewed evidence
+artifact run. Records must keep source references to the `20260521T025403Z`
+acquisition and classifier run through `generated_from`, `coverage_refs`,
+`source_review_refs`, `acquisition_report_refs`, and `evidence`.
+
+## Allowed Source Inputs
+
+Allowed implementation inputs:
+
+- `data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json`;
+- `docs/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.md`;
+- parsed-value classifier coverage and disposition artifacts needed to
+  deterministically reproduce `parsed_value` payloads;
+- current-fact schemas and guard helpers;
+- public acquisition report and source-review references already carried by
+  the PR #365 evidence artifact.
+
+The implementation may use `parsed_value_classifier.classify_raw_value` with
+the evidence record's `raw_value` and `coverage_refs` review item ID to
+reproduce `parsed_value`. The reproduced result must match the evidence
+record's `parser_rule_ids`, `calculation_input_status`, and
+`parsed_value_kind`.
+
+Forbidden implementation inputs:
+
+- legacy `data/exports/*/official_raw.json`;
+- ignored `.local` artifacts;
+- raw HTML;
+- full rows;
+- screenshots as authority;
+- ChatGPT/VLM output as authority;
+- cookies;
+- browser profiles;
+- request/response headers;
+- tokens;
+- traces;
+- debug dumps;
+- logs;
+- answer logs;
+- training logs;
+- private data;
+- SuperCombo numeric authority.
+
+## Candidate Record Mapping
+
+For each reviewed evidence record, the generator or artifact builder must:
+
+- copy row/move/cell identity fields:
+  - `candidate_record_id`;
+  - `character_slug`;
+  - `move_id`;
+  - `display_label_ja`;
+  - `field_key`;
+  - `source_row_key`;
+  - `source_cell_key`;
+  - `source_value_key`;
+  - `source_row_order`;
+  - `source_cell_order`;
+- copy source context:
+  - `source_name`;
+  - `source_role`;
+  - `source_family`;
+  - `source_header_path`;
+  - `source_label`;
+- copy raw fields:
+  - `raw_value`;
+  - `raw_value_length`;
+  - `raw_value_sha256`;
+- map `authority_status` from `authority_candidate_not_promoted` to
+  candidate-schema `authority_candidate`;
+- map public references:
+  - `coverage_refs` must be public artifact paths, not review item IDs;
+  - `source_review_refs` must include the PR #365 evidence JSON and may include
+    other public source-review summary paths;
+  - `acquisition_report_refs` must be public acquisition report paths;
+- reproduce `parsed_value` deterministically;
+- carry `value_shape`, `parser_rule_ids`, and top-level
+  `calculation_input_status`;
+- create an `evidence` object that points to the PR #365 evidence artifact.
+
+## Schema Decision
+
+`source_reference.schema.json` currently has no evidence basis for reviewed
+source-review summaries. The implementation may add exactly one enum value if
+needed:
+
+- `source_review_summary`
+
+This is preferred over misusing `source_acquisition_report`,
+`value_shape_policy`, or `synthetic_contract_fixture` for production candidate
+records.
+
+No other schema change is planned. If a broader schema change is needed,
+implementation must stop and amend this ExecPlan in the same draft PR before
+continuing.
+
+## Candidate Admission
+
+The first production candidate artifact must contain exactly the 13 records
+from the PR #365 evidence artifact.
+
+Allowed records:
+
+- `source_review_result == "candidate_identity_evidence_found"`;
+- `candidate_generation_status == "blocked_until_candidate_artifact_execplan_review"`;
+- `source_name == "official"`;
+- `source_role == "authority_candidate"`;
+- classifier outcome can deterministically reproduce a `parsed_value`;
+- `calculation_input_status` is either
+  `annotated_candidate_not_calculation_safe` or
+  `parsed_range_not_single_value_calculation_safe`.
+
+Forbidden records:
+
+- review-required or blocked raw variants;
+- `candidate_identity_evidence_ambiguous`;
+- `candidate_identity_evidence_missing`;
+- records with no `parsed_value`;
+- SuperCombo scalar numeric authority;
+- any value not present in the PR #365 reviewed evidence artifact.
+
+This artifact is lookup-ready as a candidate input, but it does not make any
+record calculation-safe. Exact scalar answer paths and calculators must still
+reject these non-scalar statuses through `current_fact_guards`.
+
+## Validator Changes
+
+Required validator behavior:
+
+- `validate_current_fact_row_move_cell_candidates.py` must validate:
+  - synthetic fixture contracts still pass;
+  - production candidate artifact path contains only the approved JSON;
+  - Markdown summary path contains only the approved summary;
+  - production artifact is schema-valid;
+  - production artifact has exactly 13 records;
+  - all records come from PR #365 evidence;
+  - raw hashes and lengths match;
+  - row/cell/value keys are stable and unique;
+  - `annotated_numeric_candidate` remains wrapped;
+  - `frame_range` remains a range;
+  - non-scalar statuses are not scalar calculation inputs;
+  - no legacy raw exports, local paths, raw HTML, full rows, screenshots,
+    VLM output, or private data are referenced.
+- `validate_current_fact_export_generator.py` must continue rejecting
+  production source-record/current-fact export artifacts, but must not reject
+  the approved candidate input artifact.
+- `validate_current_fact_candidate_evidence.py` must continue passing.
+- `validate_validator_test_audit.py` must cover any new or modified
+  test/validator boundaries.
+
+## Issue #343 Gate
+
+Issue #343 remains mandatory for any future value-handling decision.
+
+This implementation must not add raw values beyond the 13 PR #365 evidence
+records. Because the implementation only transforms already-reviewed evidence
+into candidate records, no new screenshot/ChatGPT/VLM double-check is required.
+
+If implementation attempts to include any additional raw value, same-grammar
+expansion, or changed semantics, it must stop and complete the Issue #343
+double-check gate first.
+
+## Acceptance Criteria
+
+- PR begins as docs-only and remains draft after plan review.
+- After mandatory plan review, implementation commits may be added to this
+  same draft PR.
+- Production candidate artifact is generated only from PR #365 reviewed public
+  evidence.
+- Production candidate artifact has exactly 13 records.
+- No production source-record or current-fact export artifact is generated.
+- No runtime lookup, parser/classifier behavior, retrieval, answer,
+  calculator, SymPy, source acquisition, or live acquisition changes are made.
+- Legacy raw exports and private/local evidence are not used as replacement
+  source input.
+- `annotated_numeric_candidate` and `frame_range` remain non-scalar.
+- Official records remain `authority_candidate`.
+- Issue #343 gate remains required for future raw-value expansion.
+
+## Files / Interfaces
+
+Plan-only initial PR should change only:
+
+- `docs/execplans/2026-05-25-current-fact-production-candidate-artifact.md`
+
+Future implementation commits in the same draft PR may change only:
+
+- `docs/execplans/2026-05-25-current-fact-production-candidate-artifact.md`
+- `src/sf6_knowledge_coach/current_fact_candidate_generator.py` if helper is
+  needed
+- `tests/test_current_fact_candidate_generator.py` if helper is added
+- `tests/validation/validate_current_fact_row_move_cell_candidates.py`
+- `tests/validation/validate_current_fact_export_generator.py` if needed
+- `tests/validation/validate_current_fact_candidate_evidence.py` if needed
+- `contracts/current-facts/source_reference.schema.json` only for
+  `source_review_summary` evidence basis if needed
+- current-fact schema fixtures only if a schema enum change requires them
+- `data/current-facts/candidate-inputs/20260525-row-move-cell-candidates.json`
+- `docs/current-facts/candidate-inputs/20260525-row-move-cell-candidates.md`
+- validator audit JSON/MD if tests or validators change
+
+Any additional file requires ExecPlan amendment and mandatory review before
+implementation continues.
+
+## Validation Commands
+
+Plan-only validation:
+
+```bash
+git diff --check
+uv lock --check
+PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_row_move_cell_candidates.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_candidate_evidence.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_export_generator.py
+PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
+git status --short --branch
+```
+
+Implementation validation:
+
+```bash
+git diff --check
+git diff --cached --check
+uv lock --check
+PYTHONPATH=src uv run --locked python -m unittest discover -s tests
+for f in tests/validation/validate_*.py; do PYTHONPATH=src uv run --locked python "$f" || exit $?; done
+PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
+git status --short --branch
+```
+
+## Progress
+
+- 2026-05-25: Drafted plan after PR #365 merged. No implementation or
+  production candidate artifact generated yet.
+- 2026-05-25: Ran plan-only validation. All checks passed.
+
+## Decision Log
+
+- 2026-05-25: The production candidate artifact will use PR #365 candidate
+  evidence as the input boundary.
+- 2026-05-25: The first production candidate artifact is limited to 13 records.
+- 2026-05-25: Source-record/export generation and runtime lookup transition
+  remain out of scope.
+- 2026-05-25: `source_review_summary` is the only planned schema enum addition
+  if a source-review evidence basis is needed.
+- 2026-05-25: Plan-only validation passed without implementation or generated
+  candidate artifact changes.
+
+## Deviations
+
+- None.
+
+## Risks
+
+- A schema enum addition may be required to represent source-review evidence
+  honestly.
+- Candidate artifact generation may reveal that a reviewed evidence record
+  cannot reproduce a valid `parsed_value`; if so, implementation must stop and
+  amend the plan.
+- Production source-record/export artifacts remain blocked.
+- Runtime remains legacy raw export backed.
+- The first production candidate artifact contains only non-scalar parsed
+  values and is not calculation-safe.
+
+## Completion Review Table
+
+| PLAN item | Implementation content | Changed files | Validation command | Result | Deviation | Incomplete | Risk |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Production candidate artifact plan | Draft plan only | `docs/execplans/2026-05-25-current-fact-production-candidate-artifact.md` | `git diff --check`; `uv lock --check` | Pass | None | Mandatory plan review pending | Schema enum may be needed later |
+| Input boundary | Plan restricts input to PR #365 public evidence | Same | `validate_current_fact_candidate_evidence.py` | Pass | None | Mandatory plan review pending | Candidate generation remains unimplemented |
+| Runtime/export boundary | No runtime/source-record/export changes | Same | current-fact validators | Pass | None | Mandatory plan review pending | Runtime remains legacy raw export backed |
+
+## Next Reviewer Prompt
+
+```text
+Review docs/execplans/2026-05-25-current-fact-production-candidate-artifact.md.
+
+Check:
+- PR diff initially contains exactly one ExecPlan file.
+- Plan uses PR #365 reviewed public candidate evidence as the input boundary.
+- Plan does not use legacy data/exports/*/official_raw.json.
+- Plan does not use .local, raw HTML, full rows, screenshots, VLM output, or
+  private data as authority.
+- Plan generates no source-record artifact, current-fact export artifact,
+  runtime lookup change, parser/classifier behavior change, retrieval, answer,
+  calculator, SymPy, source acquisition, or live acquisition.
+- Planned production candidate artifact is exactly 13 records from PR #365
+  evidence.
+- annotated_numeric_candidate and frame_range remain non-scalar and not
+  calculation-safe.
+- validator boundary changes are explicitly planned.
+- any schema change is limited to source_review_summary evidence basis if
+  needed.
+- Issue #343 double-check gate remains required for future raw-value
+  expansion.
+
+Run:
+- git status --short --branch
+- git show --name-status --oneline --no-renames HEAD
+- git diff --check origin/main...HEAD
+- uv lock --check
+- PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_row_move_cell_candidates.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_candidate_evidence.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_export_generator.py
+- PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
+
+Return blocking findings first, validation results, PLAN deviations, remaining
+risks, and whether docs-only plan is approved for same-PR implementation.
+```

--- a/docs/validator-audits/20260523-validator-test-fact-source-audit.md
+++ b/docs/validator-audits/20260523-validator-test-fact-source-audit.md
@@ -15,6 +15,7 @@ privacy/security boundary.
 | File | Evidence class | Status | Limitation |
 | --- | --- | --- | --- |
 | `tests/test_cli.py` | source-derived | accepted with limits | JP 5LP smoke only; not full roster validation |
+| `tests/test_current_fact_candidate_generator.py` | source-derived | accepted with limits | reviewed candidate evidence and deterministic classifier reproduction only |
 | `tests/test_current_fact_export_generator.py` | synthetic contract | accepted with limits | source-record synthetic fixtures only; no production exports or source truth |
 | `tests/test_current_fact_guards.py` | synthetic contract | accepted with limits | scalar/non-scalar guard fixtures only; no source truth or calculation correctness |
 | `tests/test_source_acquisition.py` | synthetic contract | accepted with limits | synthetic HTML tests parser/guard behavior, not live source truth |
@@ -23,8 +24,8 @@ privacy/security boundary.
 | `tests/test_parsed_value_classifier.py` | policy-derived | accepted with limits | parser/classifier behavior is policy-derived and not calculation correctness |
 | `tests/test_value_shape_inventory.py` | source-derived | accepted with limits | representative shape checks are not parser semantics |
 | `tests/validation/validate_clean_slate.py` | governance boundary | accepted with limits | repo shape and approved contract file inventory only |
-| `tests/validation/validate_current_fact_export_generator.py` | artifact consistency | accepted with limits | fixture-contract generator output, guard boundaries, and no production artifact paths only |
-| `tests/validation/validate_current_fact_row_move_cell_candidates.py` | synthetic contract | accepted with limits | candidate schema, synthetic fixture contracts, and source-boundary guard mutations only; no production candidates or source truth |
+| `tests/validation/validate_current_fact_export_generator.py` | artifact consistency | accepted with limits | fixture-contract generator output, guard boundaries, and absence of production source-record/export artifacts only |
+| `tests/validation/validate_current_fact_row_move_cell_candidates.py` | source-derived | accepted with limits | candidate schema, synthetic fixtures, and production candidate consistency with reviewed public evidence only |
 | `tests/validation/validate_current_fact_candidate_evidence.py` | source-derived | accepted with limits | candidate evidence source-review summary; full v4 row context remains ignored local reviewer input |
 | `tests/validation/validate_current_fact_consumer_guards.py` | artifact consistency | accepted with limits | guard behavior against synthetic fixtures and coverage statuses only |
 | `tests/validation/validate_current_fact_source_records.py` | synthetic contract | accepted with limits | source-record schema, fixture contracts, and source-boundary guard mutations only; no production source records or source truth |

--- a/src/sf6_knowledge_coach/current_fact_candidate_generator.py
+++ b/src/sf6_knowledge_coach/current_fact_candidate_generator.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+from collections import Counter
+from collections.abc import Mapping
+from typing import Any
+
+from .parsed_value_classifier import (
+    classify_raw_value,
+    disposition_by_review_item_id,
+    load_disposition,
+)
+
+
+CANDIDATE_RUN_ID = "20260525T000000Z"
+CANDIDATE_JSON_PATH = f"data/current-facts/candidate-inputs/{CANDIDATE_RUN_ID}-row-move-cell-candidates.json"
+CANDIDATE_MD_PATH = f"docs/current-facts/candidate-inputs/{CANDIDATE_RUN_ID}-row-move-cell-candidates.md"
+EVIDENCE_JSON_PATH = "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json"
+EVIDENCE_MD_PATH = "docs/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.md"
+COVERAGE_JSON_PATH = "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+ALLOWED_STATUSES = frozenset(
+    {
+        "annotated_candidate_not_calculation_safe",
+        "parsed_range_not_single_value_calculation_safe",
+    }
+)
+
+
+class CurrentFactCandidateGeneratorError(ValueError):
+    """Raised when reviewed evidence cannot build candidate records."""
+
+
+def build_candidate_input_payload(evidence_payload: Mapping[str, Any]) -> dict[str, Any]:
+    _validate_evidence_top_level(evidence_payload)
+    disposition_by_id = disposition_by_review_item_id(load_disposition())
+    records = [
+        _candidate_record(record, disposition_by_id)
+        for record in evidence_payload["evidence_records"]
+    ]
+    return {
+        "artifact_schema_version": "current_fact_row_move_cell_candidate_input/v1",
+        "authority_boundary": {
+            "official": "authority_candidate_only",
+            "supercombo": "enrichment_or_cross_reference_only",
+        },
+        "candidate_boundary": {
+            "blocked_records": "excluded_to_classifier_or_source_review",
+            "legacy_raw_exports": "excluded_as_source_input",
+            "local_source_payloads": "excluded_from_public_artifact",
+            "lookup_ready_candidates": "parsed_value_only",
+            "reviewer_observations": "observation_candidate_only_not_authority",
+            "supercombo": "enrichment_or_cross_reference_only",
+            "synthetic_fixtures": "not_source_truth",
+        },
+        "generated_from": _generated_from(evidence_payload),
+        "records": sorted(records, key=_record_sort_key),
+        "run_id": CANDIDATE_RUN_ID,
+    }
+
+
+def build_candidate_summary_markdown(
+    candidate_payload: Mapping[str, Any],
+    evidence_payload: Mapping[str, Any],
+) -> str:
+    records = candidate_payload.get("records", [])
+    if not isinstance(records, list):
+        raise CurrentFactCandidateGeneratorError("candidate payload records must be a list")
+    status_counts = Counter(record.get("calculation_input_status") for record in records if isinstance(record, Mapping))
+    field_counts = Counter(record.get("field_key") for record in records if isinstance(record, Mapping))
+    source_run_id = str(evidence_payload.get("source_run_id"))
+    return "\n".join(
+        [
+            "# Current-Fact Row/Move/Cell Candidate Input",
+            "",
+            f"- JSON artifact: `{CANDIDATE_JSON_PATH}`",
+            f"- Run ID: `{candidate_payload.get('run_id')}`",
+            f"- Source evidence: `{EVIDENCE_JSON_PATH}`",
+            f"- Source run ID: `{source_run_id}`",
+            f"- Total records: `{len(records)}`",
+            "- Candidate boundary: parsed-value-only, non-scalar values remain not calculation-safe.",
+            "- Authority boundary: official values remain authority candidates only.",
+            "- Legacy raw exports, ignored local artifacts, raw source payloads, reviewer observations, and private data are excluded as authority.",
+            "",
+            "## Counts",
+            "",
+            "| Dimension | Value | Count |",
+            "| --- | --- | --- |",
+            *[
+                f"| calculation_input_status | `{status}` | {count} |"
+                for status, count in sorted(status_counts.items())
+            ],
+            *[
+                f"| field_key | `{field}` | {count} |"
+                for field, count in sorted(field_counts.items())
+            ],
+            "",
+            "## Boundaries",
+            "",
+            "- No production source-record artifact is generated.",
+            "- No production current-fact export artifact is generated.",
+            "- Runtime lookup and answer behavior are unchanged.",
+            "- `annotated_numeric_candidate` and `frame_range` must not be flattened into scalar values.",
+            "",
+        ]
+    )
+
+
+def _validate_evidence_top_level(evidence_payload: Mapping[str, Any]) -> None:
+    expected = {
+        "artifact_schema_version": "current_fact_candidate_evidence/v1",
+        "artifact_boundary": "source_review_summary_only",
+        "authority_status": "review_decision_only_not_authority",
+        "candidate_artifact_generation": "blocked_until_mandatory_review",
+        "run_id": "20260525",
+        "source_run_id": "20260521T025403Z",
+    }
+    for key, value in expected.items():
+        if evidence_payload.get(key) != value:
+            raise CurrentFactCandidateGeneratorError(f"unexpected evidence {key}: {evidence_payload.get(key)!r}")
+    records = evidence_payload.get("evidence_records")
+    if not isinstance(records, list) or len(records) != 13:
+        raise CurrentFactCandidateGeneratorError("evidence_records must contain exactly 13 records")
+
+
+def _candidate_record(
+    evidence_record: Mapping[str, Any],
+    disposition_by_id: Mapping[str, Mapping[str, Any]],
+) -> dict[str, Any]:
+    _validate_evidence_record(evidence_record)
+    review_item_id = _single_review_item_id(evidence_record)
+    disposition_record = disposition_by_id.get(review_item_id)
+    if disposition_record is None:
+        raise CurrentFactCandidateGeneratorError(f"missing disposition record for {review_item_id}")
+    classification = classify_raw_value(str(evidence_record["raw_value"]), dict(disposition_record))
+    if classification.parsed_value is None:
+        raise CurrentFactCandidateGeneratorError(f"evidence record did not reproduce parsed_value: {review_item_id}")
+    parser_rule_id = classification.value_shape.get("parser_rule_id")
+    if evidence_record.get("parser_rule_ids") != [parser_rule_id]:
+        raise CurrentFactCandidateGeneratorError(f"parser rule mismatch for {evidence_record.get('candidate_record_id')}")
+    if classification.calculation_input_status != evidence_record.get("calculation_input_status"):
+        raise CurrentFactCandidateGeneratorError(f"calculation status mismatch for {evidence_record.get('candidate_record_id')}")
+    if classification.parsed_value.get("kind") != evidence_record.get("parsed_value_kind"):
+        raise CurrentFactCandidateGeneratorError(f"parsed kind mismatch for {evidence_record.get('candidate_record_id')}")
+
+    raw_value = str(evidence_record["raw_value"])
+    expected_hash = hashlib.sha256(raw_value.encode("utf-8")).hexdigest()
+    if evidence_record.get("raw_value_sha256") != expected_hash:
+        raise CurrentFactCandidateGeneratorError(f"raw hash mismatch for {evidence_record.get('candidate_record_id')}")
+    if evidence_record.get("raw_value_length") != len(raw_value):
+        raise CurrentFactCandidateGeneratorError(f"raw length mismatch for {evidence_record.get('candidate_record_id')}")
+
+    source_review_refs = sorted({EVIDENCE_JSON_PATH, *[str(ref) for ref in evidence_record["source_review_refs"]]})
+    return {
+        "acquisition_report_refs": copy.deepcopy(evidence_record["acquisition_report_refs"]),
+        "authority_status": "authority_candidate",
+        "calculation_input_status": classification.calculation_input_status,
+        "candidate_record_id": str(evidence_record["candidate_record_id"]),
+        "character_slug": str(evidence_record["character_slug"]),
+        "coverage_refs": [COVERAGE_JSON_PATH],
+        "display_label_ja": str(evidence_record["display_label_ja"]),
+        "evidence": {
+            "evidence_basis": "source_review_summary",
+            "public_reference": EVIDENCE_JSON_PATH,
+            "run_id": "20260521T025403Z",
+            "source_header_path": copy.deepcopy(evidence_record["source_header_path"]),
+            "source_label": str(evidence_record["source_label"]),
+            "source_name": str(evidence_record["source_name"]),
+            "source_role": str(evidence_record["source_role"]),
+        },
+        "field_key": str(evidence_record["field_key"]),
+        "move_id": str(evidence_record["move_id"]),
+        "parsed_value": copy.deepcopy(classification.parsed_value),
+        "parser_rule_ids": copy.deepcopy(evidence_record["parser_rule_ids"]),
+        "raw_value": raw_value,
+        "raw_value_length": len(raw_value),
+        "raw_value_sha256": expected_hash,
+        "source_cell_key": str(evidence_record["source_cell_key"]),
+        "source_cell_order": int(evidence_record["source_cell_order"]),
+        "source_family": str(evidence_record["source_family"]),
+        "source_header_path": copy.deepcopy(evidence_record["source_header_path"]),
+        "source_label": str(evidence_record["source_label"]),
+        "source_name": str(evidence_record["source_name"]),
+        "source_review_refs": source_review_refs,
+        "source_role": str(evidence_record["source_role"]),
+        "source_row_key": str(evidence_record["source_row_key"]),
+        "source_row_order": int(evidence_record["source_row_order"]),
+        "source_value_key": str(evidence_record["source_value_key"]),
+        "value_shape": copy.deepcopy(classification.value_shape),
+    }
+
+
+def _validate_evidence_record(evidence_record: Mapping[str, Any]) -> None:
+    expected = {
+        "authority_status": "authority_candidate_not_promoted",
+        "candidate_generation_status": "blocked_until_candidate_artifact_execplan_review",
+        "source_name": "official",
+        "source_role": "authority_candidate",
+        "source_review_result": "candidate_identity_evidence_found",
+    }
+    for key, value in expected.items():
+        if evidence_record.get(key) != value:
+            raise CurrentFactCandidateGeneratorError(
+                f"{evidence_record.get('candidate_record_id')} has unexpected {key}: {evidence_record.get(key)!r}"
+            )
+    if evidence_record.get("calculation_input_status") not in ALLOWED_STATUSES:
+        raise CurrentFactCandidateGeneratorError(f"unsupported calculation status: {evidence_record.get('calculation_input_status')}")
+    if "parsed_value" in evidence_record:
+        raise CurrentFactCandidateGeneratorError("source-review evidence must not provide parsed_value payloads")
+
+
+def _single_review_item_id(evidence_record: Mapping[str, Any]) -> str:
+    coverage_refs = evidence_record.get("coverage_refs")
+    if not isinstance(coverage_refs, list) or len(coverage_refs) != 1 or not isinstance(coverage_refs[0], str):
+        raise CurrentFactCandidateGeneratorError(f"{evidence_record.get('candidate_record_id')} must have one review item ref")
+    return coverage_refs[0]
+
+
+def _generated_from(evidence_payload: Mapping[str, Any]) -> list[str]:
+    generated_from = {
+        EVIDENCE_JSON_PATH,
+        EVIDENCE_MD_PATH,
+        *[str(ref) for ref in evidence_payload.get("generated_from", [])],
+    }
+    return sorted(generated_from)
+
+
+def _record_sort_key(record: Mapping[str, Any]) -> tuple[str, str, int, int, str]:
+    return (
+        str(record.get("source_name", "")),
+        str(record.get("character_slug", "")),
+        int(record.get("source_row_order", 0)),
+        int(record.get("source_cell_order", 0)),
+        str(record.get("source_value_key", "")),
+    )

--- a/tests/test_current_fact_candidate_generator.py
+++ b/tests/test_current_fact_candidate_generator.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import copy
+import json
+import unittest
+from collections import Counter
+from pathlib import Path
+
+from sf6_knowledge_coach.current_fact_candidate_generator import (
+    CANDIDATE_RUN_ID,
+    EVIDENCE_JSON_PATH,
+    CurrentFactCandidateGeneratorError,
+    build_candidate_input_payload,
+    build_candidate_summary_markdown,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _evidence_payload() -> dict:
+    return json.loads((ROOT / EVIDENCE_JSON_PATH).read_text(encoding="utf-8"))
+
+
+class CurrentFactCandidateGeneratorTests(unittest.TestCase):
+    def test_builds_candidate_payload_from_reviewed_evidence(self) -> None:
+        payload = build_candidate_input_payload(_evidence_payload())
+
+        self.assertEqual(payload["artifact_schema_version"], "current_fact_row_move_cell_candidate_input/v1")
+        self.assertEqual(payload["run_id"], CANDIDATE_RUN_ID)
+        self.assertIn(EVIDENCE_JSON_PATH, payload["generated_from"])
+        self.assertEqual(len(payload["records"]), 13)
+        self.assertEqual(
+            Counter(record["calculation_input_status"] for record in payload["records"]),
+            {
+                "annotated_candidate_not_calculation_safe": 9,
+                "parsed_range_not_single_value_calculation_safe": 4,
+            },
+        )
+
+    def test_candidate_records_preserve_non_scalar_wrappers(self) -> None:
+        payload = build_candidate_input_payload(_evidence_payload())
+        annotated = next(
+            record for record in payload["records"]
+            if record["calculation_input_status"] == "annotated_candidate_not_calculation_safe"
+        )
+        frame_range = next(
+            record for record in payload["records"]
+            if record["calculation_input_status"] == "parsed_range_not_single_value_calculation_safe"
+        )
+
+        self.assertEqual(annotated["parsed_value"]["kind"], "annotated_numeric_candidate")
+        self.assertIn("numeric_candidate", annotated["parsed_value"])
+        self.assertEqual(frame_range["parsed_value"]["kind"], "frame_range")
+        self.assertIn("start", frame_range["parsed_value"])
+        self.assertIn("end", frame_range["parsed_value"])
+
+    def test_pr365_evidence_identifier_is_reference_only(self) -> None:
+        payload = build_candidate_input_payload(_evidence_payload())
+
+        self.assertNotEqual(payload["run_id"], "20260525")
+        for record in payload["records"]:
+            self.assertEqual(record["evidence"]["public_reference"], EVIDENCE_JSON_PATH)
+            self.assertIn(EVIDENCE_JSON_PATH, record["source_review_refs"])
+            self.assertEqual(record["evidence"]["evidence_basis"], "source_review_summary")
+
+    def test_unreviewed_raw_value_expansion_is_rejected(self) -> None:
+        evidence = _evidence_payload()
+        mutated = copy.deepcopy(evidence)
+        target = next(record for record in mutated["evidence_records"] if record["raw_value"] == "※-2")
+        target["raw_value"] = "※1"
+
+        with self.assertRaises(CurrentFactCandidateGeneratorError):
+            build_candidate_input_payload(mutated)
+
+    def test_summary_is_boundary_only(self) -> None:
+        evidence = _evidence_payload()
+        payload = build_candidate_input_payload(evidence)
+        markdown = build_candidate_summary_markdown(payload, evidence)
+
+        self.assertIn("Total records: `13`", markdown)
+        self.assertIn("not calculation-safe", markdown)
+        self.assertNotIn(".local", markdown)
+        self.assertNotIn("data/exports/", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/validate_current_fact_export_generator.py
+++ b/tests/validation/validate_current_fact_export_generator.py
@@ -19,6 +19,10 @@ PRODUCTION_ARTIFACT_DIRS = (
     ROOT / "data/current-facts",
     ROOT / "docs/current-facts",
 )
+APPROVED_CANDIDATE_ARTIFACTS = {
+    "data/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.json",
+    "docs/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.md",
+}
 SIDECAR_FIELDS = {
     "raw_value_length",
     "raw_value_sha256",
@@ -166,9 +170,13 @@ def _validate_no_production_artifacts(errors: list[str]) -> None:
         if not directory.exists():
             continue
         files = sorted(path for path in directory.rglob("*") if path.is_file())
-        if files:
-            relative = [path.relative_to(ROOT).as_posix() for path in files]
-            errors.append(f"fixture-contract generator must not create production artifacts: {relative}")
+        unexpected = [
+            path.relative_to(ROOT).as_posix()
+            for path in files
+            if path.relative_to(ROOT).as_posix() not in APPROVED_CANDIDATE_ARTIFACTS
+        ]
+        if unexpected:
+            errors.append(f"fixture-contract generator must not create source-record/export artifacts: {unexpected}")
 
 
 def _finish(errors: list[str]) -> int:

--- a/tests/validation/validate_current_fact_row_move_cell_candidates.py
+++ b/tests/validation/validate_current_fact_row_move_cell_candidates.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import re
 import sys
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
@@ -17,6 +18,9 @@ from sf6_knowledge_coach.current_fact_guards import is_scalar_calculation_input
 ROOT = Path(__file__).resolve().parents[2]
 SCHEMA_DIR = ROOT / "contracts/current-facts"
 FIXTURE_DIR = ROOT / "tests/fixtures/current-facts/candidate-inputs"
+PRODUCTION_JSON = ROOT / "data/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.json"
+PRODUCTION_MD = ROOT / "docs/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.md"
+EVIDENCE_JSON = ROOT / "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json"
 CANDIDATE_SCHEMA_PATH = SCHEMA_DIR / "current_fact_row_move_cell_candidate_input.schema.json"
 SCHEMA_FILES = [
     "parsed_value.schema.json",
@@ -58,6 +62,20 @@ REFERENCE_ARRAY_FIELDS = (
     "coverage_refs",
     "source_review_refs",
 )
+EXPECTED_PRODUCTION_COUNT = 13
+EXPECTED_PRODUCTION_RUN_ID = "20260525T000000Z"
+EVIDENCE_JSON_REF = "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json"
+EVIDENCE_MD_REF = "docs/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.md"
+COVERAGE_REF = "data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json"
+EXPECTED_PRODUCTION_STATUS_COUNTS = {
+    "annotated_candidate_not_calculation_safe": 9,
+    "parsed_range_not_single_value_calculation_safe": 4,
+}
+EXPECTED_PRODUCTION_FIELD_COUNTS = {
+    "block_advantage": 5,
+    "hit_advantage": 4,
+    "startup": 4,
+}
 
 
 def main() -> int:
@@ -81,7 +99,7 @@ def main() -> int:
     _validate_invalid_fixtures(validator, errors)
     _validate_synthetic_boundary_rejections(validator, valid_payloads, errors)
     _scan_valid_public_fixtures(errors)
-    _validate_no_production_candidate_artifacts(errors)
+    _validate_approved_production_candidate_artifacts(validator, errors)
     return _finish(errors)
 
 
@@ -283,14 +301,167 @@ def _scan_valid_public_fixtures(errors: list[str]) -> None:
                 break
 
 
-def _validate_no_production_candidate_artifacts(errors: list[str]) -> None:
-    for relative in (
-        "data/current-facts/candidate-inputs",
-        "docs/current-facts/candidate-inputs",
-    ):
+def _validate_approved_production_candidate_artifacts(
+    validator: Draft202012Validator,
+    errors: list[str],
+) -> None:
+    approved = {
+        PRODUCTION_JSON.relative_to(ROOT).as_posix(),
+        PRODUCTION_MD.relative_to(ROOT).as_posix(),
+    }
+    for relative in ("data/current-facts", "docs/current-facts"):
         directory = ROOT / relative
-        if directory.exists() and any(directory.rglob("*")):
-            errors.append(f"production candidate artifact path must remain empty in this slice: {relative}")
+        if not directory.exists():
+            errors.append(f"Missing production candidate directory: {relative}")
+            continue
+        files = {
+            path.relative_to(ROOT).as_posix()
+            for path in directory.rglob("*")
+            if path.is_file()
+        }
+        unexpected = sorted(files - approved)
+        if unexpected:
+            errors.append(f"unexpected current-fact production artifacts: {unexpected}")
+    if not PRODUCTION_JSON.exists():
+        errors.append(f"Missing approved production candidate JSON: {PRODUCTION_JSON.relative_to(ROOT)}")
+        return
+    if not PRODUCTION_MD.exists():
+        errors.append(f"Missing approved production candidate summary: {PRODUCTION_MD.relative_to(ROOT)}")
+    if not EVIDENCE_JSON.exists():
+        errors.append(f"Missing source evidence artifact: {EVIDENCE_JSON.relative_to(ROOT)}")
+        return
+
+    payload = json.loads(PRODUCTION_JSON.read_text(encoding="utf-8"))
+    failures = _schema_errors(validator, payload)
+    semantic_failures = _semantic_errors(payload)
+    if failures or semantic_failures:
+        message = failures[0] if failures else semantic_failures[0]
+        errors.append(f"{PRODUCTION_JSON.relative_to(ROOT)} should be valid: {message}")
+        return
+
+    evidence_payload = json.loads(EVIDENCE_JSON.read_text(encoding="utf-8"))
+    _validate_production_payload_against_evidence(payload, evidence_payload, errors)
+    for path in (PRODUCTION_JSON, PRODUCTION_MD):
+        _scan_public_text(path, errors)
+
+
+def _validate_production_payload_against_evidence(
+    payload: dict[str, Any],
+    evidence_payload: dict[str, Any],
+    errors: list[str],
+) -> None:
+    if payload.get("run_id") != EXPECTED_PRODUCTION_RUN_ID:
+        errors.append(f"production candidate run_id must be {EXPECTED_PRODUCTION_RUN_ID}")
+    if payload.get("run_id") == evidence_payload.get("run_id"):
+        errors.append("production candidate run_id must not reuse date-only source-review evidence run_id")
+    generated_from = set(payload.get("generated_from", []))
+    for required in (EVIDENCE_JSON_REF, EVIDENCE_MD_REF, COVERAGE_REF):
+        if required not in generated_from:
+            errors.append(f"production generated_from missing {required}")
+
+    evidence_records = evidence_payload.get("evidence_records", [])
+    if not isinstance(evidence_records, list):
+        errors.append("source evidence records must be a list")
+        return
+    records = payload.get("records", [])
+    if not isinstance(records, list):
+        errors.append("production candidate records must be a list")
+        return
+    if len(records) != EXPECTED_PRODUCTION_COUNT:
+        errors.append(f"production candidate artifact must contain {EXPECTED_PRODUCTION_COUNT} records")
+    status_counts = Counter(record.get("calculation_input_status") for record in records if isinstance(record, dict))
+    field_counts = Counter(record.get("field_key") for record in records if isinstance(record, dict))
+    if dict(sorted(status_counts.items())) != EXPECTED_PRODUCTION_STATUS_COUNTS:
+        errors.append("production calculation status counts do not match approved evidence")
+    if dict(sorted(field_counts.items())) != EXPECTED_PRODUCTION_FIELD_COUNTS:
+        errors.append("production field counts do not match approved evidence")
+
+    evidence_by_id = {
+        record.get("candidate_record_id"): record
+        for record in evidence_records
+        if isinstance(record, dict)
+    }
+    record_ids = [record.get("candidate_record_id") for record in records if isinstance(record, dict)]
+    if len(set(record_ids)) != len(record_ids):
+        errors.append("production candidate_record_id values must be unique")
+    if set(record_ids) != set(evidence_by_id):
+        errors.append("production candidate records must exactly match PR #365 evidence ids")
+        return
+    for index, record in enumerate(records):
+        if not isinstance(record, dict):
+            errors.append(f"records[{index}] must be an object")
+            continue
+        evidence_record = evidence_by_id[record["candidate_record_id"]]
+        _validate_production_record(index, record, evidence_record, errors)
+
+
+def _validate_production_record(
+    index: int,
+    record: dict[str, Any],
+    evidence_record: dict[str, Any],
+    errors: list[str],
+) -> None:
+    copied_fields = (
+        "candidate_record_id",
+        "character_slug",
+        "display_label_ja",
+        "field_key",
+        "move_id",
+        "raw_value",
+        "raw_value_length",
+        "raw_value_sha256",
+        "source_cell_key",
+        "source_cell_order",
+        "source_family",
+        "source_header_path",
+        "source_label",
+        "source_name",
+        "source_role",
+        "source_row_key",
+        "source_row_order",
+        "source_value_key",
+    )
+    for field in copied_fields:
+        if record.get(field) != evidence_record.get(field):
+            errors.append(f"records[{index}].{field} does not match source evidence")
+    if record.get("authority_status") != "authority_candidate":
+        errors.append(f"records[{index}] official candidate authority must not be promoted")
+    if record.get("calculation_input_status") != evidence_record.get("calculation_input_status"):
+        errors.append(f"records[{index}] calculation_input_status does not match source evidence")
+    if record.get("parser_rule_ids") != evidence_record.get("parser_rule_ids"):
+        errors.append(f"records[{index}] parser_rule_ids does not match source evidence")
+    if record.get("coverage_refs") != [COVERAGE_REF]:
+        errors.append(f"records[{index}] coverage_refs must point to the public coverage artifact")
+    if EVIDENCE_JSON_REF not in record.get("source_review_refs", []):
+        errors.append(f"records[{index}] source_review_refs must include PR #365 evidence artifact")
+    for source_ref in evidence_record.get("source_review_refs", []):
+        if source_ref not in record.get("source_review_refs", []):
+            errors.append(f"records[{index}] missing carried source_review_ref {source_ref}")
+
+    value_shape = record.get("value_shape", {})
+    if value_shape.get("review_item_id") != evidence_record.get("coverage_refs", [None])[0]:
+        errors.append(f"records[{index}] value_shape.review_item_id must preserve source review item id")
+    if value_shape.get("parser_rule_id") != evidence_record.get("parser_rule_ids", [None])[0]:
+        errors.append(f"records[{index}] value_shape.parser_rule_id must match source evidence")
+    parsed_value = record.get("parsed_value", {})
+    if parsed_value.get("kind") != evidence_record.get("parsed_value_kind"):
+        errors.append(f"records[{index}] parsed_value kind must match source evidence")
+
+    evidence = record.get("evidence", {})
+    if evidence.get("evidence_basis") != "source_review_summary":
+        errors.append(f"records[{index}] evidence must use source_review_summary")
+    if evidence.get("public_reference") != EVIDENCE_JSON_REF:
+        errors.append(f"records[{index}] evidence.public_reference must point to PR #365 evidence JSON")
+    if evidence.get("run_id") != "20260521T025403Z":
+        errors.append(f"records[{index}] evidence.run_id must carry source acquisition/classifier run id")
+
+
+def _scan_public_text(path: Path, errors: list[str]) -> None:
+    text = path.read_text(encoding="utf-8")
+    for pattern in FORBIDDEN_PUBLIC_PATTERNS:
+        if pattern.search(text):
+            errors.append(f"{path.relative_to(ROOT)} contains forbidden public content")
+            break
 
 
 def _first_record(payload: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- Adds a docs-only ExecPlan for generating the first production current_fact_row_move_cell_candidate_input/v1 artifact.
- Uses PR #365 reviewed public candidate evidence as the sole input boundary.
- Keeps source-record generation, current-fact export generation, runtime lookup, parser/classifier behavior, retrieval/answer/calculator/SymPy, source acquisition, and live acquisition out of scope.

## Same-PR Flow
- Do not merge this plan-only PR after plan review.
- After mandatory plan review passes, implementation commits should be added to this same draft PR.
- If implementation needs files or schema changes beyond the ExecPlan, amend the ExecPlan in this PR first.

## Validation
- git diff --check
- uv lock --check
- validate_clean_slate.py
- validate_current_fact_schemas.py
- validate_current_fact_source_records.py
- validate_current_fact_row_move_cell_candidates.py
- validate_current_fact_candidate_evidence.py
- validate_current_fact_consumer_guards.py
- validate_current_fact_export_generator.py
- parsed_value_classifier validate

## Remaining Risks
- A schema enum addition may be needed for source_review_summary evidence basis.
- Production source-record/export artifacts remain blocked.
- Runtime remains legacy raw export backed.
- The first production candidate artifact will contain only non-scalar parsed values and is not calculation-safe.