### PR TITLE
Plan current-fact source-record artifact from candidates

### DIFF
--- a/data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json
+++ b/data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json
@@ -1,0 +1,983 @@
+{
+  "artifact_schema_version": "current_fact_source_record_input/v1",
+  "authority_boundary": {
+    "official": "authority_candidate_only",
+    "supercombo": "enrichment_or_cross_reference_only"
+  },
+  "generated_from": [
+    "data/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.json",
+    "docs/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.md"
+  ],
+  "records": [
+    {
+      "current_fact_record": {
+        "authority_status": "authority_candidate",
+        "calculation_input_status": "parsed_range_not_single_value_calculation_safe",
+        "character_slug": "alex",
+        "display_label_ja": "フライングクロスチョップ（ジャンプ中に） 強",
+        "evidence": {
+          "evidence_basis": "source_review_summary",
+          "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+          "run_id": "20260521T025403Z",
+          "source_header_path": [
+            "硬直差",
+            "ガード"
+          ],
+          "source_label": "ガード",
+          "source_name": "official",
+          "source_role": "authority_candidate"
+        },
+        "field_key": "block_advantage",
+        "move_id": "official:alex:row-41:move-f09489ff6eaa",
+        "parsed_value": {
+          "end": -1,
+          "kind": "frame_range",
+          "start": -12,
+          "unit": "frame"
+        },
+        "raw_value": "-12～-1",
+        "record_id": "current-fact:official:alex:row-41:cell-5:value-520f8306db0f",
+        "source_family": "advantage",
+        "source_header_path": [
+          "硬直差",
+          "ガード"
+        ],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate",
+        "value_shape": {
+          "classes": [
+            "range"
+          ],
+          "classifier_status": "parsed",
+          "parser_rule_id": "frame_range.official_signed_wave_dash.v1",
+          "review_item_id": "value-shape:official--unclassified_expression--u_c135db53355f--u_522ba9f47afb"
+        }
+      },
+      "raw_value_length": 6,
+      "raw_value_sha256": "520f8306db0f00d860dfbf1f72aed57178586bbac1b4e2f2ceb6fa3c31284c35",
+      "source_cell_key": "official:alex:table-0:row-41:cell-5",
+      "source_cell_order": 5,
+      "source_header_path": [
+        "硬直差",
+        "ガード"
+      ],
+      "source_record_id": "source-record:official:alex:row-41:cell-5:value-520f8306db0f",
+      "source_row_key": "official:alex:table-0:row-41",
+      "source_row_order": 41,
+      "source_value_key": "official:alex:table-0:row-41:cell-5:value-520f8306db0f"
+    },
+    {
+      "current_fact_record": {
+        "authority_status": "authority_candidate",
+        "calculation_input_status": "parsed_range_not_single_value_calculation_safe",
+        "character_slug": "cammy",
+        "display_label_ja": "リバースエッジ（フーリガンコンビネーション中に）",
+        "evidence": {
+          "evidence_basis": "source_review_summary",
+          "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+          "run_id": "20260521T025403Z",
+          "source_header_path": [
+            "硬直差",
+            "ガード"
+          ],
+          "source_label": "ガード",
+          "source_name": "official",
+          "source_role": "authority_candidate"
+        },
+        "field_key": "block_advantage",
+        "move_id": "official:cammy:row-52:move-003104ea0ff9",
+        "parsed_value": {
+          "end": -1,
+          "kind": "frame_range",
+          "start": -4,
+          "unit": "frame"
+        },
+        "raw_value": "-4～-1",
+        "record_id": "current-fact:official:cammy:row-52:cell-5:value-f3bd1df4c26d",
+        "source_family": "advantage",
+        "source_header_path": [
+          "硬直差",
+          "ガード"
+        ],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate",
+        "value_shape": {
+          "classes": [
+            "range"
+          ],
+          "classifier_status": "parsed",
+          "parser_rule_id": "frame_range.official_signed_wave_dash.v1",
+          "review_item_id": "value-shape:official--unclassified_expression--u_c135db53355f--u_522ba9f47afb"
+        }
+      },
+      "raw_value_length": 5,
+      "raw_value_sha256": "f3bd1df4c26d078a592238ff898964a14b5859e74fe097da1bfae2a76be7c5a7",
+      "source_cell_key": "official:cammy:table-0:row-52:cell-5",
+      "source_cell_order": 5,
+      "source_header_path": [
+        "硬直差",
+        "ガード"
+      ],
+      "source_record_id": "source-record:official:cammy:row-52:cell-5:value-f3bd1df4c26d",
+      "source_row_key": "official:cammy:table-0:row-52",
+      "source_row_order": 52,
+      "source_value_key": "official:cammy:table-0:row-52:cell-5:value-f3bd1df4c26d"
+    },
+    {
+      "current_fact_record": {
+        "authority_status": "authority_candidate",
+        "calculation_input_status": "annotated_candidate_not_calculation_safe",
+        "character_slug": "chunli",
+        "display_label_ja": "蘭華（行雲流水中に）弱",
+        "evidence": {
+          "evidence_basis": "source_review_summary",
+          "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+          "run_id": "20260521T025403Z",
+          "source_header_path": [
+            "硬直差",
+            "ヒット"
+          ],
+          "source_label": "ヒット",
+          "source_name": "official",
+          "source_role": "authority_candidate"
+        },
+        "field_key": "hit_advantage",
+        "move_id": "official:chunli:row-32:move-278b4bdd0acb",
+        "parsed_value": {
+          "annotation": {
+            "marker_placement": "prefix",
+            "note_id": null,
+            "note_linkage_status": "same_row_note_candidates_available",
+            "note_marker": "※",
+            "note_scope": "row_hit_advantage_condition",
+            "note_text_status": "structured_row_note_text_found",
+            "row_note_candidate_count": 1
+          },
+          "calculation": {
+            "calculation_input_status": "annotated_candidate_not_calculation_safe",
+            "reason": "condition_bound_by_official_note"
+          },
+          "kind": "annotated_numeric_candidate",
+          "numeric_candidate": {
+            "candidate_type": "signed_frame",
+            "unit": "frame",
+            "value": -3
+          },
+          "source_context": {
+            "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69",
+            "source_column_header_path": [
+              "硬直差",
+              "ヒット"
+            ],
+            "source_review_id": "source-review:official-note-linkage-hit-advantage"
+          }
+        },
+        "raw_value": "※-3",
+        "record_id": "current-fact:official:chunli:row-32:cell-4:value-38098349c914",
+        "source_family": "advantage",
+        "source_header_path": [
+          "硬直差",
+          "ヒット"
+        ],
+        "source_label": "ヒット",
+        "source_name": "official",
+        "source_role": "authority_candidate",
+        "value_shape": {
+          "classes": [
+            "note_prefixed"
+          ],
+          "classifier_status": "parsed",
+          "parser_rule_id": "annotated_signed_frame.official_prefix_marker.negative.v1",
+          "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69"
+        }
+      },
+      "raw_value_length": 3,
+      "raw_value_sha256": "38098349c914433f0d197b466d52fc182309a3043e91d401f8c2a98b3b8917ca",
+      "source_cell_key": "official:chunli:table-0:row-32:cell-4",
+      "source_cell_order": 4,
+      "source_header_path": [
+        "硬直差",
+        "ヒット"
+      ],
+      "source_record_id": "source-record:official:chunli:row-32:cell-4:value-38098349c914",
+      "source_row_key": "official:chunli:table-0:row-32",
+      "source_row_order": 32,
+      "source_value_key": "official:chunli:table-0:row-32:cell-4:value-38098349c914"
+    },
+    {
+      "current_fact_record": {
+        "authority_status": "authority_candidate",
+        "calculation_input_status": "annotated_candidate_not_calculation_safe",
+        "character_slug": "chunli",
+        "display_label_ja": "蘭華（行雲流水中に）弱",
+        "evidence": {
+          "evidence_basis": "source_review_summary",
+          "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+          "run_id": "20260521T025403Z",
+          "source_header_path": [
+            "硬直差",
+            "ガード"
+          ],
+          "source_label": "ガード",
+          "source_name": "official",
+          "source_role": "authority_candidate"
+        },
+        "field_key": "block_advantage",
+        "move_id": "official:chunli:row-32:move-278b4bdd0acb",
+        "parsed_value": {
+          "annotation": {
+            "marker_placement": "prefix",
+            "note_id": null,
+            "note_linkage_status": "same_row_note_candidates_available",
+            "note_marker": "※",
+            "note_scope": "row_block_advantage_condition",
+            "note_text_status": "structured_row_note_text_found",
+            "row_note_candidate_count": 1
+          },
+          "calculation": {
+            "calculation_input_status": "annotated_candidate_not_calculation_safe",
+            "reason": "condition_bound_by_official_note"
+          },
+          "kind": "annotated_numeric_candidate",
+          "numeric_candidate": {
+            "candidate_type": "signed_frame",
+            "unit": "frame",
+            "value": -4
+          },
+          "source_context": {
+            "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_522ba9f47afb",
+            "source_column_header_path": [
+              "硬直差",
+              "ガード"
+            ],
+            "source_review_id": "source-review:official-note-linkage-block-advantage"
+          }
+        },
+        "raw_value": "※-4",
+        "record_id": "current-fact:official:chunli:row-32:cell-5:value-b5112d05eab3",
+        "source_family": "advantage",
+        "source_header_path": [
+          "硬直差",
+          "ガード"
+        ],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate",
+        "value_shape": {
+          "classes": [
+            "note_prefixed"
+          ],
+          "classifier_status": "parsed",
+          "parser_rule_id": "annotated_signed_frame.official_prefix_marker.negative.v1",
+          "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_522ba9f47afb"
+        }
+      },
+      "raw_value_length": 3,
+      "raw_value_sha256": "b5112d05eab37a8ef2062523ba1cce640a8350c6cba7ef40bf66072550f3609c",
+      "source_cell_key": "official:chunli:table-0:row-32:cell-5",
+      "source_cell_order": 5,
+      "source_header_path": [
+        "硬直差",
+        "ガード"
+      ],
+      "source_record_id": "source-record:official:chunli:row-32:cell-5:value-b5112d05eab3",
+      "source_row_key": "official:chunli:table-0:row-32",
+      "source_row_order": 32,
+      "source_value_key": "official:chunli:table-0:row-32:cell-5:value-b5112d05eab3"
+    },
+    {
+      "current_fact_record": {
+        "authority_status": "authority_candidate",
+        "calculation_input_status": "annotated_candidate_not_calculation_safe",
+        "character_slug": "chunli",
+        "display_label_ja": "前突（行雲流水中に）弱",
+        "evidence": {
+          "evidence_basis": "source_review_summary",
+          "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+          "run_id": "20260521T025403Z",
+          "source_header_path": [
+            "硬直差",
+            "ヒット"
+          ],
+          "source_label": "ヒット",
+          "source_name": "official",
+          "source_role": "authority_candidate"
+        },
+        "field_key": "hit_advantage",
+        "move_id": "official:chunli:row-35:move-2c6d449eb8a3",
+        "parsed_value": {
+          "annotation": {
+            "marker_placement": "prefix",
+            "note_id": null,
+            "note_linkage_status": "same_row_note_candidates_available",
+            "note_marker": "※",
+            "note_scope": "row_hit_advantage_condition",
+            "note_text_status": "structured_row_note_text_found",
+            "row_note_candidate_count": 1
+          },
+          "calculation": {
+            "calculation_input_status": "annotated_candidate_not_calculation_safe",
+            "reason": "condition_bound_by_official_note"
+          },
+          "kind": "annotated_numeric_candidate",
+          "numeric_candidate": {
+            "candidate_type": "signed_frame",
+            "unit": "frame",
+            "value": -1
+          },
+          "source_context": {
+            "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69",
+            "source_column_header_path": [
+              "硬直差",
+              "ヒット"
+            ],
+            "source_review_id": "source-review:official-note-linkage-hit-advantage"
+          }
+        },
+        "raw_value": "※-1",
+        "record_id": "current-fact:official:chunli:row-35:cell-4:value-dbdd09f8dbaa",
+        "source_family": "advantage",
+        "source_header_path": [
+          "硬直差",
+          "ヒット"
+        ],
+        "source_label": "ヒット",
+        "source_name": "official",
+        "source_role": "authority_candidate",
+        "value_shape": {
+          "classes": [
+            "note_prefixed"
+          ],
+          "classifier_status": "parsed",
+          "parser_rule_id": "annotated_signed_frame.official_prefix_marker.negative.v1",
+          "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69"
+        }
+      },
+      "raw_value_length": 3,
+      "raw_value_sha256": "dbdd09f8dbaacf8ce6a87b3f4b004af5a8185b47ed0b193adcf2afdd6bd8e0af",
+      "source_cell_key": "official:chunli:table-0:row-35:cell-4",
+      "source_cell_order": 4,
+      "source_header_path": [
+        "硬直差",
+        "ヒット"
+      ],
+      "source_record_id": "source-record:official:chunli:row-35:cell-4:value-dbdd09f8dbaa",
+      "source_row_key": "official:chunli:table-0:row-35",
+      "source_row_order": 35,
+      "source_value_key": "official:chunli:table-0:row-35:cell-4:value-dbdd09f8dbaa"
+    },
+    {
+      "current_fact_record": {
+        "authority_status": "authority_candidate",
+        "calculation_input_status": "annotated_candidate_not_calculation_safe",
+        "character_slug": "chunli",
+        "display_label_ja": "仙風（行雲流水中に）中",
+        "evidence": {
+          "evidence_basis": "source_review_summary",
+          "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+          "run_id": "20260521T025403Z",
+          "source_header_path": [
+            "硬直差",
+            "ヒット"
+          ],
+          "source_label": "ヒット",
+          "source_name": "official",
+          "source_role": "authority_candidate"
+        },
+        "field_key": "hit_advantage",
+        "move_id": "official:chunli:row-36:move-f41b02dd87c4",
+        "parsed_value": {
+          "annotation": {
+            "marker_placement": "prefix",
+            "note_id": null,
+            "note_linkage_status": "same_row_note_candidates_available",
+            "note_marker": "※",
+            "note_scope": "row_hit_advantage_condition",
+            "note_text_status": "structured_row_note_text_found",
+            "row_note_candidate_count": 1
+          },
+          "calculation": {
+            "calculation_input_status": "annotated_candidate_not_calculation_safe",
+            "reason": "condition_bound_by_official_note"
+          },
+          "kind": "annotated_numeric_candidate",
+          "numeric_candidate": {
+            "candidate_type": "signed_frame",
+            "unit": "frame",
+            "value": -4
+          },
+          "source_context": {
+            "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69",
+            "source_column_header_path": [
+              "硬直差",
+              "ヒット"
+            ],
+            "source_review_id": "source-review:official-note-linkage-hit-advantage"
+          }
+        },
+        "raw_value": "※-4",
+        "record_id": "current-fact:official:chunli:row-36:cell-4:value-b5112d05eab3",
+        "source_family": "advantage",
+        "source_header_path": [
+          "硬直差",
+          "ヒット"
+        ],
+        "source_label": "ヒット",
+        "source_name": "official",
+        "source_role": "authority_candidate",
+        "value_shape": {
+          "classes": [
+            "note_prefixed"
+          ],
+          "classifier_status": "parsed",
+          "parser_rule_id": "annotated_signed_frame.official_prefix_marker.negative.v1",
+          "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69"
+        }
+      },
+      "raw_value_length": 3,
+      "raw_value_sha256": "b5112d05eab37a8ef2062523ba1cce640a8350c6cba7ef40bf66072550f3609c",
+      "source_cell_key": "official:chunli:table-0:row-36:cell-4",
+      "source_cell_order": 4,
+      "source_header_path": [
+        "硬直差",
+        "ヒット"
+      ],
+      "source_record_id": "source-record:official:chunli:row-36:cell-4:value-b5112d05eab3",
+      "source_row_key": "official:chunli:table-0:row-36",
+      "source_row_order": 36,
+      "source_value_key": "official:chunli:table-0:row-36:cell-4:value-b5112d05eab3"
+    },
+    {
+      "current_fact_record": {
+        "authority_status": "authority_candidate",
+        "calculation_input_status": "annotated_candidate_not_calculation_safe",
+        "character_slug": "ed",
+        "display_label_ja": "サイコナックル(Lv1)強ホールド",
+        "evidence": {
+          "evidence_basis": "source_review_summary",
+          "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+          "run_id": "20260521T025403Z",
+          "source_header_path": [
+            "硬直差",
+            "ガード"
+          ],
+          "source_label": "ガード",
+          "source_name": "official",
+          "source_role": "authority_candidate"
+        },
+        "field_key": "block_advantage",
+        "move_id": "official:ed:row-21:move-a8a13087c217",
+        "parsed_value": {
+          "annotation": {
+            "marker_placement": "prefix",
+            "note_id": null,
+            "note_linkage_status": "same_row_note_candidates_available",
+            "note_marker": "※",
+            "note_scope": "row_block_advantage_condition",
+            "note_text_status": "structured_row_note_text_found",
+            "row_note_candidate_count": 1
+          },
+          "calculation": {
+            "calculation_input_status": "annotated_candidate_not_calculation_safe",
+            "reason": "condition_bound_by_official_note"
+          },
+          "kind": "annotated_numeric_candidate",
+          "numeric_candidate": {
+            "candidate_type": "signed_frame",
+            "unit": "frame",
+            "value": -2
+          },
+          "source_context": {
+            "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_522ba9f47afb",
+            "source_column_header_path": [
+              "硬直差",
+              "ガード"
+            ],
+            "source_review_id": "source-review:official-note-linkage-block-advantage"
+          }
+        },
+        "raw_value": "※-2",
+        "record_id": "current-fact:official:ed:row-21:cell-5:value-522076e6afe2",
+        "source_family": "advantage",
+        "source_header_path": [
+          "硬直差",
+          "ガード"
+        ],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate",
+        "value_shape": {
+          "classes": [
+            "note_prefixed"
+          ],
+          "classifier_status": "parsed",
+          "parser_rule_id": "annotated_signed_frame.official_prefix_marker.negative.v1",
+          "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_522ba9f47afb"
+        }
+      },
+      "raw_value_length": 3,
+      "raw_value_sha256": "522076e6afe25969ab0fe38642fcf471a681152e0f919f489622873b188357e6",
+      "source_cell_key": "official:ed:table-0:row-21:cell-5",
+      "source_cell_order": 5,
+      "source_header_path": [
+        "硬直差",
+        "ガード"
+      ],
+      "source_record_id": "source-record:official:ed:row-21:cell-5:value-522076e6afe2",
+      "source_row_key": "official:ed:table-0:row-21",
+      "source_row_order": 21,
+      "source_value_key": "official:ed:table-0:row-21:cell-5:value-522076e6afe2"
+    },
+    {
+      "current_fact_record": {
+        "authority_status": "authority_candidate",
+        "calculation_input_status": "annotated_candidate_not_calculation_safe",
+        "character_slug": "kimberly",
+        "display_label_ja": "弱 細工手裏剣（細工手裏剣ストックが1以上で） 弱",
+        "evidence": {
+          "evidence_basis": "source_review_summary",
+          "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+          "run_id": "20260521T025403Z",
+          "source_header_path": [
+            "動作フレーム",
+            "発生"
+          ],
+          "source_label": "発生",
+          "source_name": "official",
+          "source_role": "authority_candidate"
+        },
+        "field_key": "startup",
+        "move_id": "official:kimberly:row-64:move-1ebd54eb85aa",
+        "parsed_value": {
+          "annotation": {
+            "marker_placement": "suffix",
+            "note_id": null,
+            "note_linkage_status": "same_row_note_candidates_available",
+            "note_marker": "※",
+            "note_scope": "row_startup_condition",
+            "note_text_status": "structured_row_note_text_found",
+            "row_note_candidate_count": 1
+          },
+          "calculation": {
+            "calculation_input_status": "annotated_candidate_not_calculation_safe",
+            "reason": "condition_bound_by_official_note"
+          },
+          "kind": "annotated_numeric_candidate",
+          "numeric_candidate": {
+            "candidate_type": "unsigned_frame",
+            "unit": "frame",
+            "value": 122
+          },
+          "source_context": {
+            "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100",
+            "source_column_header_path": [
+              "動作フレーム",
+              "発生"
+            ],
+            "source_review_id": "source-review:official-note-linkage-startup"
+          }
+        },
+        "raw_value": "122※",
+        "record_id": "current-fact:official:kimberly:row-64:cell-1:value-1a036dd4c06c",
+        "source_family": "timing",
+        "source_header_path": [
+          "動作フレーム",
+          "発生"
+        ],
+        "source_label": "発生",
+        "source_name": "official",
+        "source_role": "authority_candidate",
+        "value_shape": {
+          "classes": [
+            "note_suffixed"
+          ],
+          "classifier_status": "parsed",
+          "parser_rule_id": "annotated_frame.official_suffix_marker.v1",
+          "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100"
+        }
+      },
+      "raw_value_length": 4,
+      "raw_value_sha256": "1a036dd4c06cd18cde9b72d219f3bf9ff2c41ec171022dbe1058e162cf96df7c",
+      "source_cell_key": "official:kimberly:table-0:row-64:cell-1",
+      "source_cell_order": 1,
+      "source_header_path": [
+        "動作フレーム",
+        "発生"
+      ],
+      "source_record_id": "source-record:official:kimberly:row-64:cell-1:value-1a036dd4c06c",
+      "source_row_key": "official:kimberly:table-0:row-64",
+      "source_row_order": 64,
+      "source_value_key": "official:kimberly:table-0:row-64:cell-1:value-1a036dd4c06c"
+    },
+    {
+      "current_fact_record": {
+        "authority_status": "authority_candidate",
+        "calculation_input_status": "annotated_candidate_not_calculation_safe",
+        "character_slug": "kimberly",
+        "display_label_ja": "強 細工手裏剣（細工手裏剣ストックが1以上で） 強",
+        "evidence": {
+          "evidence_basis": "source_review_summary",
+          "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+          "run_id": "20260521T025403Z",
+          "source_header_path": [
+            "動作フレーム",
+            "発生"
+          ],
+          "source_label": "発生",
+          "source_name": "official",
+          "source_role": "authority_candidate"
+        },
+        "field_key": "startup",
+        "move_id": "official:kimberly:row-66:move-035abd428c6f",
+        "parsed_value": {
+          "annotation": {
+            "marker_placement": "suffix",
+            "note_id": null,
+            "note_linkage_status": "same_row_note_candidates_available",
+            "note_marker": "※",
+            "note_scope": "row_startup_condition",
+            "note_text_status": "structured_row_note_text_found",
+            "row_note_candidate_count": 1
+          },
+          "calculation": {
+            "calculation_input_status": "annotated_candidate_not_calculation_safe",
+            "reason": "condition_bound_by_official_note"
+          },
+          "kind": "annotated_numeric_candidate",
+          "numeric_candidate": {
+            "candidate_type": "unsigned_frame",
+            "unit": "frame",
+            "value": 128
+          },
+          "source_context": {
+            "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100",
+            "source_column_header_path": [
+              "動作フレーム",
+              "発生"
+            ],
+            "source_review_id": "source-review:official-note-linkage-startup"
+          }
+        },
+        "raw_value": "128※",
+        "record_id": "current-fact:official:kimberly:row-66:cell-1:value-3c911b4c4f5d",
+        "source_family": "timing",
+        "source_header_path": [
+          "動作フレーム",
+          "発生"
+        ],
+        "source_label": "発生",
+        "source_name": "official",
+        "source_role": "authority_candidate",
+        "value_shape": {
+          "classes": [
+            "note_suffixed"
+          ],
+          "classifier_status": "parsed",
+          "parser_rule_id": "annotated_frame.official_suffix_marker.v1",
+          "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100"
+        }
+      },
+      "raw_value_length": 4,
+      "raw_value_sha256": "3c911b4c4f5d473c3e4bd988a924818f3c760adbd14fd241a7fdccf42c99b814",
+      "source_cell_key": "official:kimberly:table-0:row-66:cell-1",
+      "source_cell_order": 1,
+      "source_header_path": [
+        "動作フレーム",
+        "発生"
+      ],
+      "source_record_id": "source-record:official:kimberly:row-66:cell-1:value-3c911b4c4f5d",
+      "source_row_key": "official:kimberly:table-0:row-66",
+      "source_row_order": 66,
+      "source_value_key": "official:kimberly:table-0:row-66:cell-1:value-3c911b4c4f5d"
+    },
+    {
+      "current_fact_record": {
+        "authority_status": "authority_candidate",
+        "calculation_input_status": "annotated_candidate_not_calculation_safe",
+        "character_slug": "kimberly",
+        "display_label_ja": "弱 乱れ細工手裏剣（細工手裏剣ストックが2以上で） 弱中",
+        "evidence": {
+          "evidence_basis": "source_review_summary",
+          "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+          "run_id": "20260521T025403Z",
+          "source_header_path": [
+            "動作フレーム",
+            "発生"
+          ],
+          "source_label": "発生",
+          "source_name": "official",
+          "source_role": "authority_candidate"
+        },
+        "field_key": "startup",
+        "move_id": "official:kimberly:row-67:move-c8f7890e80bb",
+        "parsed_value": {
+          "annotation": {
+            "marker_placement": "suffix",
+            "note_id": null,
+            "note_linkage_status": "same_row_note_candidates_available",
+            "note_marker": "※",
+            "note_scope": "row_startup_condition",
+            "note_text_status": "structured_row_note_text_found",
+            "row_note_candidate_count": 1
+          },
+          "calculation": {
+            "calculation_input_status": "annotated_candidate_not_calculation_safe",
+            "reason": "condition_bound_by_official_note"
+          },
+          "kind": "annotated_numeric_candidate",
+          "numeric_candidate": {
+            "candidate_type": "unsigned_frame",
+            "unit": "frame",
+            "value": 122
+          },
+          "source_context": {
+            "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100",
+            "source_column_header_path": [
+              "動作フレーム",
+              "発生"
+            ],
+            "source_review_id": "source-review:official-note-linkage-startup"
+          }
+        },
+        "raw_value": "122※",
+        "record_id": "current-fact:official:kimberly:row-67:cell-1:value-1a036dd4c06c",
+        "source_family": "timing",
+        "source_header_path": [
+          "動作フレーム",
+          "発生"
+        ],
+        "source_label": "発生",
+        "source_name": "official",
+        "source_role": "authority_candidate",
+        "value_shape": {
+          "classes": [
+            "note_suffixed"
+          ],
+          "classifier_status": "parsed",
+          "parser_rule_id": "annotated_frame.official_suffix_marker.v1",
+          "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100"
+        }
+      },
+      "raw_value_length": 4,
+      "raw_value_sha256": "1a036dd4c06cd18cde9b72d219f3bf9ff2c41ec171022dbe1058e162cf96df7c",
+      "source_cell_key": "official:kimberly:table-0:row-67:cell-1",
+      "source_cell_order": 1,
+      "source_header_path": [
+        "動作フレーム",
+        "発生"
+      ],
+      "source_record_id": "source-record:official:kimberly:row-67:cell-1:value-1a036dd4c06c",
+      "source_row_key": "official:kimberly:table-0:row-67",
+      "source_row_order": 67,
+      "source_value_key": "official:kimberly:table-0:row-67:cell-1:value-1a036dd4c06c"
+    },
+    {
+      "current_fact_record": {
+        "authority_status": "authority_candidate",
+        "calculation_input_status": "annotated_candidate_not_calculation_safe",
+        "character_slug": "kimberly",
+        "display_label_ja": "中 乱れ細工手裏剣（細工手裏剣ストックが2以上で） 弱強",
+        "evidence": {
+          "evidence_basis": "source_review_summary",
+          "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+          "run_id": "20260521T025403Z",
+          "source_header_path": [
+            "動作フレーム",
+            "発生"
+          ],
+          "source_label": "発生",
+          "source_name": "official",
+          "source_role": "authority_candidate"
+        },
+        "field_key": "startup",
+        "move_id": "official:kimberly:row-68:move-8683c9bcb338",
+        "parsed_value": {
+          "annotation": {
+            "marker_placement": "suffix",
+            "note_id": null,
+            "note_linkage_status": "same_row_note_candidates_available",
+            "note_marker": "※",
+            "note_scope": "row_startup_condition",
+            "note_text_status": "structured_row_note_text_found",
+            "row_note_candidate_count": 1
+          },
+          "calculation": {
+            "calculation_input_status": "annotated_candidate_not_calculation_safe",
+            "reason": "condition_bound_by_official_note"
+          },
+          "kind": "annotated_numeric_candidate",
+          "numeric_candidate": {
+            "candidate_type": "unsigned_frame",
+            "unit": "frame",
+            "value": 122
+          },
+          "source_context": {
+            "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100",
+            "source_column_header_path": [
+              "動作フレーム",
+              "発生"
+            ],
+            "source_review_id": "source-review:official-note-linkage-startup"
+          }
+        },
+        "raw_value": "122※",
+        "record_id": "current-fact:official:kimberly:row-68:cell-1:value-1a036dd4c06c",
+        "source_family": "timing",
+        "source_header_path": [
+          "動作フレーム",
+          "発生"
+        ],
+        "source_label": "発生",
+        "source_name": "official",
+        "source_role": "authority_candidate",
+        "value_shape": {
+          "classes": [
+            "note_suffixed"
+          ],
+          "classifier_status": "parsed",
+          "parser_rule_id": "annotated_frame.official_suffix_marker.v1",
+          "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100"
+        }
+      },
+      "raw_value_length": 4,
+      "raw_value_sha256": "1a036dd4c06cd18cde9b72d219f3bf9ff2c41ec171022dbe1058e162cf96df7c",
+      "source_cell_key": "official:kimberly:table-0:row-68:cell-1",
+      "source_cell_order": 1,
+      "source_header_path": [
+        "動作フレーム",
+        "発生"
+      ],
+      "source_record_id": "source-record:official:kimberly:row-68:cell-1:value-1a036dd4c06c",
+      "source_row_key": "official:kimberly:table-0:row-68",
+      "source_row_order": 68,
+      "source_value_key": "official:kimberly:table-0:row-68:cell-1:value-1a036dd4c06c"
+    },
+    {
+      "current_fact_record": {
+        "authority_status": "authority_candidate",
+        "calculation_input_status": "parsed_range_not_single_value_calculation_safe",
+        "character_slug": "vega_mbison",
+        "display_label_ja": "ヘッドプレス（シャドウライズ中に）",
+        "evidence": {
+          "evidence_basis": "source_review_summary",
+          "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+          "run_id": "20260521T025403Z",
+          "source_header_path": [
+            "硬直差",
+            "ヒット"
+          ],
+          "source_label": "ヒット",
+          "source_name": "official",
+          "source_role": "authority_candidate"
+        },
+        "field_key": "hit_advantage",
+        "move_id": "official:vega_mbison:row-53:move-268f9d662fa7",
+        "parsed_value": {
+          "end": -23,
+          "kind": "frame_range",
+          "start": -28,
+          "unit": "frame"
+        },
+        "raw_value": "-28～-23",
+        "record_id": "current-fact:official:vega_mbison:row-53:cell-4:value-1c81d53e6168",
+        "source_family": "advantage",
+        "source_header_path": [
+          "硬直差",
+          "ヒット"
+        ],
+        "source_label": "ヒット",
+        "source_name": "official",
+        "source_role": "authority_candidate",
+        "value_shape": {
+          "classes": [
+            "range"
+          ],
+          "classifier_status": "parsed",
+          "parser_rule_id": "frame_range.official_signed_wave_dash.v1",
+          "review_item_id": "value-shape:official--unclassified_expression--u_c135db53355f--u_7acd6c7b6e69"
+        }
+      },
+      "raw_value_length": 7,
+      "raw_value_sha256": "1c81d53e6168526120e54c0d776c9dd883e1d484832eca4b59e829d0ab5ad285",
+      "source_cell_key": "official:vega_mbison:table-0:row-53:cell-4",
+      "source_cell_order": 4,
+      "source_header_path": [
+        "硬直差",
+        "ヒット"
+      ],
+      "source_record_id": "source-record:official:vega_mbison:row-53:cell-4:value-1c81d53e6168",
+      "source_row_key": "official:vega_mbison:table-0:row-53",
+      "source_row_order": 53,
+      "source_value_key": "official:vega_mbison:table-0:row-53:cell-4:value-1c81d53e6168"
+    },
+    {
+      "current_fact_record": {
+        "authority_status": "authority_candidate",
+        "calculation_input_status": "parsed_range_not_single_value_calculation_safe",
+        "character_slug": "vega_mbison",
+        "display_label_ja": "ヘッドプレス（シャドウライズ中に）",
+        "evidence": {
+          "evidence_basis": "source_review_summary",
+          "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+          "run_id": "20260521T025403Z",
+          "source_header_path": [
+            "硬直差",
+            "ガード"
+          ],
+          "source_label": "ガード",
+          "source_name": "official",
+          "source_role": "authority_candidate"
+        },
+        "field_key": "block_advantage",
+        "move_id": "official:vega_mbison:row-53:move-268f9d662fa7",
+        "parsed_value": {
+          "end": -33,
+          "kind": "frame_range",
+          "start": -39,
+          "unit": "frame"
+        },
+        "raw_value": "-39～-33",
+        "record_id": "current-fact:official:vega_mbison:row-53:cell-5:value-1c461fc0a5e3",
+        "source_family": "advantage",
+        "source_header_path": [
+          "硬直差",
+          "ガード"
+        ],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate",
+        "value_shape": {
+          "classes": [
+            "range"
+          ],
+          "classifier_status": "parsed",
+          "parser_rule_id": "frame_range.official_signed_wave_dash.v1",
+          "review_item_id": "value-shape:official--unclassified_expression--u_c135db53355f--u_522ba9f47afb"
+        }
+      },
+      "raw_value_length": 7,
+      "raw_value_sha256": "1c461fc0a5e3e3e6877d22bc8de7fd0165119dcb255b70232e90bb70268e5fab",
+      "source_cell_key": "official:vega_mbison:table-0:row-53:cell-5",
+      "source_cell_order": 5,
+      "source_header_path": [
+        "硬直差",
+        "ガード"
+      ],
+      "source_record_id": "source-record:official:vega_mbison:row-53:cell-5:value-1c461fc0a5e3",
+      "source_row_key": "official:vega_mbison:table-0:row-53",
+      "source_row_order": 53,
+      "source_value_key": "official:vega_mbison:table-0:row-53:cell-5:value-1c461fc0a5e3"
+    }
+  ],
+  "run_id": "20260525T000000Z",
+  "source_record_boundary": {
+    "blocked_records": "excluded_to_classifier_or_source_review",
+    "legacy_raw_exports": "excluded_as_source_input",
+    "local_source_payloads": "excluded_from_public_artifact",
+    "lookup_ready_records": "parsed_value_only",
+    "reviewer_observations": "observation_candidate_only_not_authority",
+    "supercombo": "enrichment_or_cross_reference_only"
+  }
+}

--- a/data/validator-audits/20260523-validator-test-fact-source-audit.json
+++ b/data/validator-audits/20260523-validator-test-fact-source-audit.json
@@ -37,6 +37,19 @@
       "status": "accepted_with_limits"
     },
     {
+      "evidence_class": "source_derived",
+      "file": "tests/test_current_fact_source_record_generator.py",
+      "limitations": [
+        "uses reviewed production candidate artifact as input; checks deterministic shape transformation only and does not prove new source truth"
+      ],
+      "primary_evidence": [
+        "data/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.json",
+        "contracts/current-facts/current_fact_source_record_input.schema.json",
+        "current-fact source-record artifact from candidates ExecPlan"
+      ],
+      "status": "accepted_with_limits"
+    },
+    {
       "evidence_class": "synthetic_contract",
       "file": "tests/test_current_fact_export_generator.py",
       "limitations": [
@@ -144,14 +157,15 @@
       "evidence_class": "artifact_consistency",
       "file": "tests/validation/validate_current_fact_export_generator.py",
       "limitations": [
-        "checks fixture-contract generator output, guard boundaries, and absence of production source-record/export artifacts; does not prove source truth"
+        "checks fixture-contract generator output, guard boundaries, and absence of production current-fact export artifacts; approved candidate/source-record inputs are not export artifacts"
       ],
       "primary_evidence": [
         "contracts/current-facts/current_fact_export.schema.json",
         "contracts/current-facts/current_fact_source_record_input.schema.json",
         "tests/fixtures/current-facts/source-records",
         "current-fact export generator fixture-contract implementation ExecPlan",
-        "current-fact production candidate artifact ExecPlan"
+        "current-fact production candidate artifact ExecPlan",
+        "current-fact source-record artifact from candidates ExecPlan"
       ],
       "status": "accepted_with_limits"
     },
@@ -159,7 +173,7 @@
       "evidence_class": "source_derived",
       "file": "tests/validation/validate_current_fact_row_move_cell_candidates.py",
       "limitations": [
-        "checks row/move/cell candidate schema, synthetic fixture contracts, source-boundary guard mutations, and production candidate consistency with reviewed public evidence; does not prove source truth beyond reviewed evidence"
+        "checks row/move/cell candidate schema, synthetic fixture contracts, source-boundary guard mutations, production candidate consistency with reviewed public evidence, and candidate-input coexistence with approved source-record artifacts; does not prove source truth beyond reviewed evidence"
       ],
       "primary_evidence": [
         "contracts/current-facts/current_fact_row_move_cell_candidate_input.schema.json",
@@ -167,7 +181,8 @@
         "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
         "tests/fixtures/current-facts/candidate-inputs",
         "current-fact row/move/cell candidate schema ExecPlan",
-        "current-fact production candidate artifact ExecPlan"
+        "current-fact production candidate artifact ExecPlan",
+        "current-fact source-record artifact from candidates ExecPlan"
       ],
       "status": "accepted_with_limits"
     },
@@ -199,15 +214,18 @@
       "status": "accepted_with_limits"
     },
     {
-      "evidence_class": "synthetic_contract",
+      "evidence_class": "source_derived",
       "file": "tests/validation/validate_current_fact_source_records.py",
       "limitations": [
-        "checks source-record schema, fixture contracts, and source-boundary guard mutations; does not produce production source records or prove source truth"
+        "checks source-record schema, fixture contracts, source-boundary guard mutations, and approved production source-record consistency with reviewed candidate input; does not prove source truth beyond reviewed public evidence"
       ],
       "primary_evidence": [
         "contracts/current-facts/current_fact_source_record_input.schema.json",
+        "data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json",
+        "data/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.json",
         "tests/fixtures/current-facts/source-records",
-        "current-fact source-record input artifact ExecPlan"
+        "current-fact source-record input artifact ExecPlan",
+        "current-fact source-record artifact from candidates ExecPlan"
       ],
       "status": "accepted_with_limits"
     },

--- a/docs/current-facts/source-records/20260525T000000Z-current-fact-source-records.md
+++ b/docs/current-facts/source-records/20260525T000000Z-current-fact-source-records.md
@@ -1,0 +1,25 @@
+# Current-Fact Source-Record Input
+
+- JSON artifact: `data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json`
+- Run ID: `20260525T000000Z`
+- Source candidate input: `data/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.json`
+- Total records: `13`
+- Source-record boundary: parsed-value-only, non-scalar values remain not calculation-safe.
+- Authority boundary: official values remain authority candidates only.
+- Legacy raw exports, ignored local artifacts, raw source payloads, reviewer observations, and private data are excluded as authority.
+
+## Counts
+
+| Dimension | Value | Count |
+| --- | --- | --- |
+| calculation_input_status | `annotated_candidate_not_calculation_safe` | 9 |
+| calculation_input_status | `parsed_range_not_single_value_calculation_safe` | 4 |
+| field_key | `block_advantage` | 5 |
+| field_key | `hit_advantage` | 4 |
+| field_key | `startup` | 4 |
+
+## Boundaries
+
+- No production current-fact export artifact is generated.
+- Runtime lookup and answer behavior are unchanged.
+- `annotated_numeric_candidate` and `frame_range` must not be flattened into scalar values.

--- a/docs/execplans/2026-05-25-current-fact-source-record-artifact-from-candidates.md
+++ b/docs/execplans/2026-05-25-current-fact-source-record-artifact-from-candidates.md
@@ -1,6 +1,6 @@
 # Current-Fact Source-Record Artifact From Candidates
 
-Status: Plan amended for review; implementation paused.
+Status: Implementation complete; validation passed; mandatory review pending.
 
 ## Purpose
 
@@ -358,6 +358,11 @@ git status --short --branch
   The candidate validator's responsibility remains candidate artifact
   validation; source-record artifact validation remains in
   `validate_current_fact_source_records.py`.
+- 2026-05-26: Implemented the deterministic source-record generator helper,
+  focused unit tests, production source-record JSON/Markdown artifacts, source
+  record validator checks, export-generator coexistence guard, candidate
+  validator coexistence compatibility, and validator audit updates.
+- 2026-05-26: Ran implementation validation. All checks passed.
 
 ## Decision Log
 
@@ -384,6 +389,11 @@ git status --short --branch
   allowing the approved source-record artifacts. This file was not listed in
   the approved implementation file set and therefore requires amendment before
   editing.
+- 2026-05-26: The candidate validator coexistence update is limited to scanning
+  `data/current-facts/candidate-inputs/` and
+  `docs/current-facts/candidate-inputs/` for approved candidate artifacts.
+  Source-record artifact validation remains exclusively in
+  `validate_current_fact_source_records.py`.
 
 ## Deviations
 
@@ -403,37 +413,44 @@ git status --short --branch
 
 | PLAN item | Implementation content | Changed files | Validation command | Result | Deviation | Incomplete | Risk |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Production source-record artifact plan | Amended plan only | `docs/execplans/2026-05-25-current-fact-source-record-artifact-from-candidates.md` | `git diff --check`; `uv lock --check` | Pass | None | Amendment review pending | Runtime remains legacy raw export backed |
-| Candidate validator compatibility | Planned narrow coexistence update for approved source-record artifacts | Same | `validate_current_fact_row_move_cell_candidates.py` after implementation | Pending | None | Amendment review pending | Candidate validator must not validate source-record semantics |
-| Runtime/export boundary | Plan still excludes current-fact export and runtime changes | Same | current-fact validators | Pending | None | Implementation paused | Production current-fact export remains blocked |
+| Production source-record artifact plan | Implementation progress, decisions, and review prompt updated | `docs/execplans/2026-05-25-current-fact-source-record-artifact-from-candidates.md` | `git diff --check`; `uv lock --check` | Pass | None | None | Runtime remains legacy raw export backed |
+| Deterministic source-record helper | Candidate artifact to source-record artifact shape transform only | `src/sf6_knowledge_coach/current_fact_source_record_generator.py`; `tests/test_current_fact_source_record_generator.py` | `python -m unittest discover -s tests` | Pass | None | None | Helper does not prove source truth |
+| Production source-record artifact | 13 source records generated from PR #366 candidate artifact | `data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json`; `docs/current-facts/source-records/20260525T000000Z-current-fact-source-records.md` | `validate_current_fact_source_records.py` | Pass | None | None | All 13 records remain non-scalar and not calculation-safe |
+| Candidate validator compatibility | Candidate validator scans candidate-inputs directories only; source-record semantics remain elsewhere | `tests/validation/validate_current_fact_row_move_cell_candidates.py` | `validate_current_fact_row_move_cell_candidates.py` | Pass | None | None | Candidate validator must not validate source-record semantics |
+| Runtime/export boundary | Export-generator validator allows approved input artifacts but no current-fact export artifact | `tests/validation/validate_current_fact_export_generator.py` | `validate_current_fact_export_generator.py` | Pass | None | None | Production current-fact export remains blocked |
+| Validator audit | Audit records new helper test and updated validator evidence boundaries | `data/validator-audits/20260523-validator-test-fact-source-audit.json`; `docs/validator-audits/20260523-validator-test-fact-source-audit.md` | `validate_validator_test_audit.py` | Pass | None | None | Audit remains evidence-boundary metadata only |
 
 ## Next Reviewer Prompt
 
 ```text
-Review PR #367 ExecPlan amendment for current-fact source-record artifact from candidates.
+Review PR #367 implementation for current-fact source-record artifact from candidates.
 
 Check:
-- PR diff for this amendment contains only the ExecPlan file.
-- Approved implementation file list now includes
-  `tests/validation/validate_current_fact_row_move_cell_candidates.py` only for
-  approved source-record artifact coexistence compatibility.
+- PR diff contains only approved implementation files.
+- Source-record artifact uses PR #366 production candidate artifact as the
+  input boundary.
+- Source-record generator output and committed JSON match.
+- `tests/validation/validate_current_fact_row_move_cell_candidates.py` changes
+  are limited to approved source-record artifact coexistence compatibility.
 - Candidate validator responsibility remains limited to candidate artifact and
   `candidate-inputs/` boundary validation.
 - Source-record artifact semantics remain assigned to
   `validate_current_fact_source_records.py`.
-- Unexpected current-fact export/artifact blocking remains in
-  `validate_current_fact_export_generator.py` and source-record validator
-  boundaries.
-- No legacy data/exports/*/official_raw.json is allowed.
+- No legacy data/exports/*/official_raw.json is used.
 - No .local, raw HTML, full rows, screenshots, VLM output, or private data is
-  allowed as authority.
+  used as authority.
 - No current-fact export artifact, runtime lookup change, parser/classifier
   behavior change, retrieval, answer, calculator, SymPy, source acquisition, or
-  live acquisition is planned.
-- Planned source-record artifact remains exactly 13 records from PR #366
+  live acquisition is included.
+- Production source-record artifact has exactly 13 records from PR #366
   candidate input.
+- Source-record artifact top-level run_id is schema-valid `20260525T000000Z`;
+  PR #365's `20260525` evidence ID is retained only in references.
 - `annotated_numeric_candidate` and `frame_range` remain non-scalar and not
   calculation-safe.
+- Official records remain `authority_candidate`.
+- Validator boundary changes are evidence-first and audit entries match the
+  new helper/validator scope.
 - Issue #343 double-check gate remains required for future raw-value
   expansion.
 
@@ -441,7 +458,10 @@ Run:
 - git status --short --branch
 - git show --name-status --oneline --no-renames HEAD
 - git diff --check origin/main...HEAD
+- git diff --cached --check
 - uv lock --check
+- PYTHONPATH=src uv run --locked python -m unittest discover -s tests
+- for f in tests/validation/validate_*.py; do PYTHONPATH=src uv run --locked python "$f" || exit $?; done
 - PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
 - PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py
 - PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py
@@ -451,6 +471,5 @@ Run:
 - PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
 
 Return blocking findings first, validation results, PLAN deviations, remaining
-risks, and whether the amended plan is approved for same-PR implementation
-continuation.
+risks, and whether PR #367 is ready to mark ready and merge.
 ```

--- a/docs/execplans/2026-05-25-current-fact-source-record-artifact-from-candidates.md
+++ b/docs/execplans/2026-05-25-current-fact-source-record-artifact-from-candidates.md
@@ -1,6 +1,6 @@
 # Current-Fact Source-Record Artifact From Candidates
 
-Status: Drafted for review; validation passed.
+Status: Plan amended for review; implementation paused.
 
 ## Purpose
 
@@ -251,7 +251,12 @@ Required validator behavior:
 - `validate_current_fact_export_generator.py` must continue rejecting
   production current-fact export artifacts, but must not reject the approved
   source-record input artifact.
-- `validate_current_fact_row_move_cell_candidates.py` must continue passing.
+- `validate_current_fact_row_move_cell_candidates.py` must continue validating
+  the approved candidate artifact and its `candidate-inputs/` boundary. It may
+  be narrowly updated to allow the approved source-record artifact to coexist
+  under `data/current-facts/source-records/` and
+  `docs/current-facts/source-records/`; source-record artifact semantics remain
+  the responsibility of `validate_current_fact_source_records.py`.
 - `validate_validator_test_audit.py` must cover any new or modified
   test/validator boundaries.
 
@@ -300,6 +305,8 @@ Future implementation commits in the same draft PR may change only:
 - `tests/test_current_fact_source_record_generator.py` if helper is added
 - `tests/validation/validate_current_fact_source_records.py`
 - `tests/validation/validate_current_fact_export_generator.py` if needed
+- `tests/validation/validate_current_fact_row_move_cell_candidates.py` only
+  for approved source-record artifact coexistence compatibility
 - `data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json`
 - `docs/current-facts/source-records/20260525T000000Z-current-fact-source-records.md`
 - validator audit JSON/MD if tests or validators change
@@ -341,6 +348,16 @@ git status --short --branch
 - 2026-05-25: Drafted plan after PR #366 merged. No implementation or
   production source-record artifact generated yet.
 - 2026-05-25: Ran plan-only validation. All checks passed.
+- 2026-05-26: During local implementation, full validation exposed that
+  `validate_current_fact_row_move_cell_candidates.py` treats the new approved
+  source-record artifacts as unexpected production artifacts. That validator
+  was not in this plan's approved implementation file list, so implementation
+  was paused.
+- 2026-05-26: Amended the plan to allow a narrow
+  `validate_current_fact_row_move_cell_candidates.py` compatibility update.
+  The candidate validator's responsibility remains candidate artifact
+  validation; source-record artifact validation remains in
+  `validate_current_fact_source_records.py`.
 
 ## Decision Log
 
@@ -353,6 +370,20 @@ git status --short --branch
 - 2026-05-25: Source-record `run_id` will use the schema-valid candidate run
   ID `20260525T000000Z`; PR #365's `20260525` remains only a source-review
   evidence reference.
+- 2026-05-26: Source-record IDs and current-fact record IDs are derived by
+  replacing the candidate prefix with `source-record:` and `current-fact:`;
+  no source facts or value semantics are inferred.
+- 2026-05-26: The committed production source-record JSON must match the
+  deterministic generator output from the PR #366 candidate artifact.
+- 2026-05-26: `validate_current_fact_export_generator.py` may allow the
+  approved candidate/source-record input artifacts under `data/current-facts`
+  and `docs/current-facts`, but still rejects production current-fact export
+  artifacts.
+- 2026-05-26: `validate_current_fact_row_move_cell_candidates.py` also needs a
+  narrow compatibility update to continue validating candidate artifacts while
+  allowing the approved source-record artifacts. This file was not listed in
+  the approved implementation file set and therefore requires amendment before
+  editing.
 
 ## Deviations
 
@@ -372,31 +403,37 @@ git status --short --branch
 
 | PLAN item | Implementation content | Changed files | Validation command | Result | Deviation | Incomplete | Risk |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Production source-record artifact plan | Draft plan only | `docs/execplans/2026-05-25-current-fact-source-record-artifact-from-candidates.md` | `git diff --check`; `uv lock --check` | Pass | None | Mandatory review pending | Source-record generation remains unimplemented |
-| Input boundary | Plan restricts input to PR #366 candidate artifact | Same | `validate_current_fact_row_move_cell_candidates.py` | Pass | None | Mandatory review pending | Candidate-to-source-record generation remains unimplemented |
-| Runtime/export boundary | No current-fact export or runtime changes | Same | current-fact validators | Pass | None | Mandatory review pending | Runtime remains legacy raw export backed |
+| Production source-record artifact plan | Amended plan only | `docs/execplans/2026-05-25-current-fact-source-record-artifact-from-candidates.md` | `git diff --check`; `uv lock --check` | Pass | None | Amendment review pending | Runtime remains legacy raw export backed |
+| Candidate validator compatibility | Planned narrow coexistence update for approved source-record artifacts | Same | `validate_current_fact_row_move_cell_candidates.py` after implementation | Pending | None | Amendment review pending | Candidate validator must not validate source-record semantics |
+| Runtime/export boundary | Plan still excludes current-fact export and runtime changes | Same | current-fact validators | Pending | None | Implementation paused | Production current-fact export remains blocked |
 
 ## Next Reviewer Prompt
 
 ```text
-Review docs/execplans/2026-05-25-current-fact-source-record-artifact-from-candidates.md.
+Review PR #367 ExecPlan amendment for current-fact source-record artifact from candidates.
 
 Check:
-- PR diff initially contains exactly one ExecPlan file.
-- Plan uses PR #366 production candidate artifact as the input boundary.
-- Plan does not use legacy data/exports/*/official_raw.json.
-- Plan does not use .local, raw HTML, full rows, screenshots, VLM output, or
-  private data as authority.
-- Plan generates no current-fact export artifact, runtime lookup change,
-  parser/classifier behavior change, retrieval, answer, calculator, SymPy,
-  source acquisition, or live acquisition.
-- Planned production source-record artifact is exactly 13 records from PR #366
+- PR diff for this amendment contains only the ExecPlan file.
+- Approved implementation file list now includes
+  `tests/validation/validate_current_fact_row_move_cell_candidates.py` only for
+  approved source-record artifact coexistence compatibility.
+- Candidate validator responsibility remains limited to candidate artifact and
+  `candidate-inputs/` boundary validation.
+- Source-record artifact semantics remain assigned to
+  `validate_current_fact_source_records.py`.
+- Unexpected current-fact export/artifact blocking remains in
+  `validate_current_fact_export_generator.py` and source-record validator
+  boundaries.
+- No legacy data/exports/*/official_raw.json is allowed.
+- No .local, raw HTML, full rows, screenshots, VLM output, or private data is
+  allowed as authority.
+- No current-fact export artifact, runtime lookup change, parser/classifier
+  behavior change, retrieval, answer, calculator, SymPy, source acquisition, or
+  live acquisition is planned.
+- Planned source-record artifact remains exactly 13 records from PR #366
   candidate input.
-- Source-record artifact top-level run_id is schema-valid `20260525T000000Z`;
-  PR #365's `20260525` evidence ID is retained only in references.
-- annotated_numeric_candidate and frame_range remain non-scalar and not
+- `annotated_numeric_candidate` and `frame_range` remain non-scalar and not
   calculation-safe.
-- validator boundary changes are explicitly planned.
 - Issue #343 double-check gate remains required for future raw-value
   expansion.
 
@@ -414,5 +451,6 @@ Run:
 - PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
 
 Return blocking findings first, validation results, PLAN deviations, remaining
-risks, and whether docs-only plan is approved for same-PR implementation.
+risks, and whether the amended plan is approved for same-PR implementation
+continuation.
 ```

--- a/docs/execplans/2026-05-25-current-fact-source-record-artifact-from-candidates.md
+++ b/docs/execplans/2026-05-25-current-fact-source-record-artifact-from-candidates.md
@@ -1,0 +1,418 @@
+# Current-Fact Source-Record Artifact From Candidates
+
+Status: Drafted for review; validation passed.
+
+## Purpose
+
+Plan generation of the first production
+`current_fact_source_record_input/v1` artifact from the reviewed production
+row/move/cell candidate artifact added by PR #366.
+
+This plan is the next step after the candidate artifact. It must not jump to
+`current_fact_export/v2` generation, runtime lookup, answer behavior, or
+legacy raw export retirement. It only defines how to transform the reviewed
+candidate input into a source-record input artifact that can later feed the
+already-reviewed fixture-contract export generator path.
+
+## Inputs
+
+- `docs/PLAN.md`
+- `AGENTS.md`
+- `docs/execplans/2026-05-25-current-fact-source-record-input-artifact.md`
+- `docs/execplans/2026-05-25-current-fact-production-source-record-artifact.md`
+- `docs/execplans/2026-05-25-current-fact-row-move-cell-candidate-input.md`
+- `docs/execplans/2026-05-25-current-fact-production-candidate-artifact.md`
+- `contracts/current-facts/current_fact_source_record_input.schema.json`
+- `contracts/current-facts/current_fact_record.schema.json`
+- `contracts/current-facts/current_fact_row_move_cell_candidate_input.schema.json`
+- `contracts/current-facts/current_fact_export.schema.json`
+- `contracts/current-facts/parsed_value.schema.json`
+- `contracts/current-facts/source_reference.schema.json`
+- `src/sf6_knowledge_coach/current_fact_candidate_generator.py`
+- `src/sf6_knowledge_coach/current_fact_export_generator.py`
+- `src/sf6_knowledge_coach/current_fact_guards.py`
+- `data/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.json`
+- `docs/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.md`
+- `data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json`
+- `data/value-shape-policies/20260521T025403Z-parsed-value-classifier-coverage.json`
+- `docs/acquisition-reports/20260521T025403Z-current-source-acquisition.md`
+- `data/validator-audits/20260523-validator-test-fact-source-audit.json`
+- `docs/validator-audits/20260523-validator-test-fact-source-audit.md`
+
+## Context
+
+PR #366 produced one schema-valid production candidate artifact:
+
+- `data/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.json`;
+- `docs/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.md`.
+
+It contains exactly 13 reviewed official records from PR #365 evidence:
+
+- 9 `annotated_numeric_candidate` records with
+  `annotated_candidate_not_calculation_safe`;
+- 4 `frame_range` records with
+  `parsed_range_not_single_value_calculation_safe`.
+
+Those records have reviewed row/move/cell identity and parsed values, but they
+are candidate input records, not source-record input records. The next safe
+step is to generate a production `current_fact_source_record_input/v1`
+artifact from that candidate artifact while preserving non-scalar, authority,
+privacy, and source-boundary contracts.
+
+## Scope
+
+Included in this docs-only plan and future implementation slice:
+
+- generate one production `current_fact_source_record_input/v1` JSON artifact
+  from the PR #366 production candidate artifact;
+- generate one summary-safe Markdown companion;
+- add a deterministic in-memory source-record generator/helper if needed;
+- add focused unit tests for the helper if added;
+- update `validate_current_fact_source_records.py` to validate the approved
+  production source-record artifact;
+- update `validate_current_fact_export_generator.py` only to stop treating the
+  approved source-record artifact as a forbidden current-fact export artifact;
+- update validator audit artifacts for changed tests/validators;
+- update this ExecPlan Progress, Decision Log, and Completion Review Table.
+
+Excluded:
+
+- No production current-fact export artifact generation.
+- No runtime lookup change.
+- No `current_facts.py` change.
+- No `answering.py` change.
+- No parser/classifier behavior change.
+- No parser/classifier expansion.
+- No retrieval implementation.
+- No answer implementation.
+- No calculator implementation.
+- No SymPy logic.
+- No source acquisition implementation.
+- No live acquisition.
+- No authority promotion.
+- No calculation-safe promotion.
+- No Issue #343 raw-value expansion.
+- No legacy raw export retirement.
+
+## Artifact Paths
+
+Planned production source-record JSON:
+
+- `data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json`
+
+Planned summary Markdown:
+
+- `docs/current-facts/source-records/20260525T000000Z-current-fact-source-records.md`
+
+The source-record artifact top-level `run_id` should be `20260525T000000Z`,
+matching the already schema-valid candidate artifact run ID. This keeps the
+candidate-to-source-record transformation in one reviewed artifact lineage. PR
+#365's date-only evidence identifier `20260525` remains a referenced
+source-review artifact identity only; it must not become a source-record
+artifact `run_id`.
+
+## Allowed Source Inputs
+
+Allowed implementation inputs:
+
+- `data/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.json`;
+- `docs/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.md`;
+- `contracts/current-facts/current_fact_source_record_input.schema.json`;
+- current-fact schemas and guard helpers;
+- public reviewed artifacts already carried by the candidate artifact.
+
+The implementation must not rebuild facts from lower-level raw source
+materials. Candidate records are the reviewed public input boundary for this
+slice.
+
+Forbidden implementation inputs:
+
+- legacy `data/exports/*/official_raw.json`;
+- ignored `.local` artifacts;
+- raw HTML;
+- full rows;
+- screenshots as authority;
+- ChatGPT/VLM output as authority;
+- cookies;
+- browser profiles;
+- request/response headers;
+- tokens;
+- traces;
+- debug dumps;
+- logs;
+- answer logs;
+- training logs;
+- private data;
+- SuperCombo numeric authority.
+
+## Source-Record Mapping
+
+For each production candidate record, the source-record generator or artifact
+builder must create one source-record object.
+
+Top-level source-record artifact fields:
+
+- `artifact_schema_version == "current_fact_source_record_input/v1"`;
+- `run_id == "20260525T000000Z"`;
+- `generated_from` includes the PR #366 candidate JSON and summary;
+- `authority_boundary` is copied from the candidate artifact;
+- `source_record_boundary` preserves parsed-value-only, legacy/raw/local
+  exclusion, reviewer-observation, and SuperCombo enrichment boundaries;
+- `records` contains exactly 13 source-record objects.
+
+For each record:
+
+- set `source_record_id` deterministically from `candidate_record_id`, for
+  example by replacing the `candidate:` prefix with `source-record:`;
+- copy source-record sidecar fields:
+  - `source_row_key`;
+  - `source_cell_key`;
+  - `source_value_key`;
+  - `source_row_order`;
+  - `source_cell_order`;
+  - `source_header_path`;
+  - `raw_value_length`;
+  - `raw_value_sha256`;
+- create `current_fact_record` with:
+  - `record_id` deterministically derived from the candidate identity, for
+    example by replacing the `candidate:` prefix with `current-fact:`;
+  - `character_slug`;
+  - `move_id`;
+  - `field_key`;
+  - `display_label_ja`;
+  - `raw_value`;
+  - `parsed_value`;
+  - `value_shape`;
+  - `source_name`;
+  - `source_role`;
+  - `source_family`;
+  - `source_label`;
+  - `source_header_path`;
+  - `authority_status`;
+  - `evidence`;
+  - `calculation_input_status`.
+
+The source-record generator must not add facts, infer missing source context,
+or reinterpret raw values. It is a deterministic shape transformation from
+candidate records into source-record records.
+
+## Admission Rules
+
+The first production source-record artifact must contain exactly the 13 records
+from the PR #366 production candidate artifact.
+
+Allowed records:
+
+- records present in the PR #366 candidate artifact;
+- records with `parsed_value`;
+- records with top-level `calculation_input_status`;
+- official records with `source_role == "authority_candidate"` and
+  `authority_status == "authority_candidate"`;
+- records whose `calculation_input_status` is either
+  `annotated_candidate_not_calculation_safe` or
+  `parsed_range_not_single_value_calculation_safe`;
+- records preserving `annotated_numeric_candidate` as a wrapper;
+- records preserving `frame_range` as a range.
+
+Forbidden records:
+
+- any value not present in the PR #366 candidate artifact;
+- review-required or blocked raw variants;
+- records with no `parsed_value`;
+- records sourced from legacy raw exports;
+- SuperCombo scalar numeric authority;
+- any raw-value expansion or changed semantics without the Issue #343 gate.
+
+This artifact is source-record-ready, not scalar-calculation-ready. Exact scalar
+answer paths and calculators must still reject the 13 non-scalar records
+through `current_fact_guards`.
+
+## Validator Changes
+
+Required validator behavior:
+
+- `validate_current_fact_source_records.py` must validate:
+  - synthetic fixture contracts still pass;
+  - production source-record path contains only the approved JSON;
+  - Markdown summary path contains only the approved summary;
+  - production artifact is schema-valid;
+  - production artifact has exactly 13 records;
+  - all records come from the PR #366 candidate artifact;
+  - raw hashes and lengths match;
+  - source-record IDs, row/cell/value keys, and current-fact record IDs are
+    stable and unique;
+  - `current_fact_record` payloads validate against the current-fact record
+    schema;
+  - `annotated_numeric_candidate` remains wrapped;
+  - `frame_range` remains a range;
+  - non-scalar statuses are not scalar calculation inputs;
+  - no legacy raw exports, local paths, raw HTML, full rows, screenshots, VLM
+    output, or private data are referenced.
+- `validate_current_fact_export_generator.py` must continue rejecting
+  production current-fact export artifacts, but must not reject the approved
+  source-record input artifact.
+- `validate_current_fact_row_move_cell_candidates.py` must continue passing.
+- `validate_validator_test_audit.py` must cover any new or modified
+  test/validator boundaries.
+
+## Issue #343 Gate
+
+Issue #343 remains mandatory for any future value-handling decision.
+
+This implementation must not add raw values beyond the 13 PR #366 candidate
+records. Because the implementation only transforms already-reviewed candidate
+records into source-record records, no new screenshot/ChatGPT/VLM double-check
+is required.
+
+If implementation attempts to include any additional raw value, same-grammar
+expansion, or changed semantics, it must stop and complete the Issue #343
+double-check gate first.
+
+## Acceptance Criteria
+
+- PR begins as docs-only and remains draft after plan review.
+- After mandatory plan review, implementation commits may be added to this
+  same draft PR if the reviewer approves that flow.
+- Production source-record artifact is generated only from PR #366 production
+  candidate artifact.
+- Production source-record artifact top-level `run_id` is `20260525T000000Z`.
+- Production source-record artifact has exactly 13 records.
+- No production current-fact export artifact is generated.
+- No runtime lookup, parser/classifier behavior, retrieval, answer,
+  calculator, SymPy, source acquisition, or live acquisition changes are made.
+- Legacy raw exports and private/local evidence are not used as replacement
+  source input.
+- `annotated_numeric_candidate` and `frame_range` remain non-scalar.
+- Official records remain `authority_candidate`.
+- Issue #343 gate remains required for future raw-value expansion.
+
+## Files / Interfaces
+
+Plan-only initial PR should change only:
+
+- `docs/execplans/2026-05-25-current-fact-source-record-artifact-from-candidates.md`
+
+Future implementation commits in the same draft PR may change only:
+
+- `docs/execplans/2026-05-25-current-fact-source-record-artifact-from-candidates.md`
+- `src/sf6_knowledge_coach/current_fact_source_record_generator.py` if helper
+  is needed
+- `tests/test_current_fact_source_record_generator.py` if helper is added
+- `tests/validation/validate_current_fact_source_records.py`
+- `tests/validation/validate_current_fact_export_generator.py` if needed
+- `data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json`
+- `docs/current-facts/source-records/20260525T000000Z-current-fact-source-records.md`
+- validator audit JSON/MD if tests or validators change
+
+Any additional file requires ExecPlan amendment and mandatory review before
+implementation continues.
+
+## Validation Commands
+
+Plan-only validation:
+
+```bash
+git diff --check
+uv lock --check
+PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_row_move_cell_candidates.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_export_generator.py
+PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
+git status --short --branch
+```
+
+Implementation validation:
+
+```bash
+git diff --check
+git diff --cached --check
+uv lock --check
+PYTHONPATH=src uv run --locked python -m unittest discover -s tests
+for f in tests/validation/validate_*.py; do PYTHONPATH=src uv run --locked python "$f" || exit $?; done
+PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
+git status --short --branch
+```
+
+## Progress
+
+- 2026-05-25: Drafted plan after PR #366 merged. No implementation or
+  production source-record artifact generated yet.
+- 2026-05-25: Ran plan-only validation. All checks passed.
+
+## Decision Log
+
+- 2026-05-25: The production source-record artifact will use the PR #366
+  candidate artifact as the input boundary.
+- 2026-05-25: The first production source-record artifact is limited to the 13
+  candidate records already reviewed in PR #366.
+- 2026-05-25: Current-fact export generation and runtime lookup transition
+  remain out of scope.
+- 2026-05-25: Source-record `run_id` will use the schema-valid candidate run
+  ID `20260525T000000Z`; PR #365's `20260525` remains only a source-review
+  evidence reference.
+
+## Deviations
+
+- None.
+
+## Risks
+
+- Production current-fact export artifact remains blocked.
+- Runtime remains legacy raw export backed.
+- The first production source-record artifact contains only non-scalar parsed
+  values and is not calculation-safe.
+- Source-record generation may reveal that candidate-to-source-record ID
+  derivation needs review; if so, implementation must stop and amend this
+  ExecPlan.
+
+## Completion Review Table
+
+| PLAN item | Implementation content | Changed files | Validation command | Result | Deviation | Incomplete | Risk |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Production source-record artifact plan | Draft plan only | `docs/execplans/2026-05-25-current-fact-source-record-artifact-from-candidates.md` | `git diff --check`; `uv lock --check` | Pass | None | Mandatory review pending | Source-record generation remains unimplemented |
+| Input boundary | Plan restricts input to PR #366 candidate artifact | Same | `validate_current_fact_row_move_cell_candidates.py` | Pass | None | Mandatory review pending | Candidate-to-source-record generation remains unimplemented |
+| Runtime/export boundary | No current-fact export or runtime changes | Same | current-fact validators | Pass | None | Mandatory review pending | Runtime remains legacy raw export backed |
+
+## Next Reviewer Prompt
+
+```text
+Review docs/execplans/2026-05-25-current-fact-source-record-artifact-from-candidates.md.
+
+Check:
+- PR diff initially contains exactly one ExecPlan file.
+- Plan uses PR #366 production candidate artifact as the input boundary.
+- Plan does not use legacy data/exports/*/official_raw.json.
+- Plan does not use .local, raw HTML, full rows, screenshots, VLM output, or
+  private data as authority.
+- Plan generates no current-fact export artifact, runtime lookup change,
+  parser/classifier behavior change, retrieval, answer, calculator, SymPy,
+  source acquisition, or live acquisition.
+- Planned production source-record artifact is exactly 13 records from PR #366
+  candidate input.
+- Source-record artifact top-level run_id is schema-valid `20260525T000000Z`;
+  PR #365's `20260525` evidence ID is retained only in references.
+- annotated_numeric_candidate and frame_range remain non-scalar and not
+  calculation-safe.
+- validator boundary changes are explicitly planned.
+- Issue #343 double-check gate remains required for future raw-value
+  expansion.
+
+Run:
+- git status --short --branch
+- git show --name-status --oneline --no-renames HEAD
+- git diff --check origin/main...HEAD
+- uv lock --check
+- PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_row_move_cell_candidates.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_export_generator.py
+- PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
+
+Return blocking findings first, validation results, PLAN deviations, remaining
+risks, and whether docs-only plan is approved for same-PR implementation.
+```

--- a/docs/validator-audits/20260523-validator-test-fact-source-audit.md
+++ b/docs/validator-audits/20260523-validator-test-fact-source-audit.md
@@ -16,6 +16,7 @@ privacy/security boundary.
 | --- | --- | --- | --- |
 | `tests/test_cli.py` | source-derived | accepted with limits | JP 5LP smoke only; not full roster validation |
 | `tests/test_current_fact_candidate_generator.py` | source-derived | accepted with limits | reviewed candidate evidence and deterministic classifier reproduction only |
+| `tests/test_current_fact_source_record_generator.py` | source-derived | accepted with limits | reviewed production candidate input and deterministic shape transformation only |
 | `tests/test_current_fact_export_generator.py` | synthetic contract | accepted with limits | source-record synthetic fixtures only; no production exports or source truth |
 | `tests/test_current_fact_guards.py` | synthetic contract | accepted with limits | scalar/non-scalar guard fixtures only; no source truth or calculation correctness |
 | `tests/test_source_acquisition.py` | synthetic contract | accepted with limits | synthetic HTML tests parser/guard behavior, not live source truth |
@@ -24,11 +25,11 @@ privacy/security boundary.
 | `tests/test_parsed_value_classifier.py` | policy-derived | accepted with limits | parser/classifier behavior is policy-derived and not calculation correctness |
 | `tests/test_value_shape_inventory.py` | source-derived | accepted with limits | representative shape checks are not parser semantics |
 | `tests/validation/validate_clean_slate.py` | governance boundary | accepted with limits | repo shape and approved contract file inventory only |
-| `tests/validation/validate_current_fact_export_generator.py` | artifact consistency | accepted with limits | fixture-contract generator output, guard boundaries, and absence of production source-record/export artifacts only |
-| `tests/validation/validate_current_fact_row_move_cell_candidates.py` | source-derived | accepted with limits | candidate schema, synthetic fixtures, and production candidate consistency with reviewed public evidence only |
+| `tests/validation/validate_current_fact_export_generator.py` | artifact consistency | accepted with limits | fixture-contract generator output, guard boundaries, and absence of production current-fact export artifacts only |
+| `tests/validation/validate_current_fact_row_move_cell_candidates.py` | source-derived | accepted with limits | candidate schema, synthetic fixtures, production candidate consistency, and approved source-record artifact coexistence only |
 | `tests/validation/validate_current_fact_candidate_evidence.py` | source-derived | accepted with limits | candidate evidence source-review summary; full v4 row context remains ignored local reviewer input |
 | `tests/validation/validate_current_fact_consumer_guards.py` | artifact consistency | accepted with limits | guard behavior against synthetic fixtures and coverage statuses only |
-| `tests/validation/validate_current_fact_source_records.py` | synthetic contract | accepted with limits | source-record schema, fixture contracts, and source-boundary guard mutations only; no production source records or source truth |
+| `tests/validation/validate_current_fact_source_records.py` | source-derived | accepted with limits | source-record schema, fixtures, and approved production source-record consistency with reviewed candidate input only |
 | `tests/validation/validate_current_fact_schemas.py` | synthetic contract | accepted with limits | schema and fixture contracts only; no parser/source truth |
 | `tests/validation/validate_official_note_linkage_source_review.py` | source-derived | accepted with limits | source-review summary; full row-note context remains ignored local evidence |
 | `tests/validation/validate_parsed_value_classifier.py` | artifact consistency | accepted with limits | coverage artifact, mechanics anchors, and schema-compatible samples only |

--- a/src/sf6_knowledge_coach/current_fact_source_record_generator.py
+++ b/src/sf6_knowledge_coach/current_fact_source_record_generator.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import copy
+from collections import Counter
+from collections.abc import Mapping
+from typing import Any
+
+from .current_fact_candidate_generator import CANDIDATE_JSON_PATH, CANDIDATE_MD_PATH, CANDIDATE_RUN_ID
+
+
+SOURCE_RECORD_JSON_PATH = f"data/current-facts/source-records/{CANDIDATE_RUN_ID}-current-fact-source-records.json"
+SOURCE_RECORD_MD_PATH = f"docs/current-facts/source-records/{CANDIDATE_RUN_ID}-current-fact-source-records.md"
+ALLOWED_STATUSES = frozenset(
+    {
+        "annotated_candidate_not_calculation_safe",
+        "parsed_range_not_single_value_calculation_safe",
+    }
+)
+
+
+class CurrentFactSourceRecordGeneratorError(ValueError):
+    """Raised when candidate input cannot build source-record input."""
+
+
+def build_source_record_input_payload(candidate_payload: Mapping[str, Any]) -> dict[str, Any]:
+    _validate_candidate_payload(candidate_payload)
+    records = [_source_record(record) for record in candidate_payload["records"]]
+    return {
+        "artifact_schema_version": "current_fact_source_record_input/v1",
+        "authority_boundary": copy.deepcopy(candidate_payload["authority_boundary"]),
+        "generated_from": [CANDIDATE_JSON_PATH, CANDIDATE_MD_PATH],
+        "records": sorted(records, key=_source_record_sort_key),
+        "run_id": CANDIDATE_RUN_ID,
+        "source_record_boundary": {
+            "blocked_records": "excluded_to_classifier_or_source_review",
+            "legacy_raw_exports": "excluded_as_source_input",
+            "local_source_payloads": "excluded_from_public_artifact",
+            "lookup_ready_records": "parsed_value_only",
+            "reviewer_observations": "observation_candidate_only_not_authority",
+            "supercombo": "enrichment_or_cross_reference_only",
+        },
+    }
+
+
+def build_source_record_summary_markdown(source_record_payload: Mapping[str, Any]) -> str:
+    records = source_record_payload.get("records", [])
+    if not isinstance(records, list):
+        raise CurrentFactSourceRecordGeneratorError("source-record payload records must be a list")
+    status_counts = Counter(
+        record.get("current_fact_record", {}).get("calculation_input_status")
+        for record in records
+        if isinstance(record, Mapping)
+    )
+    field_counts = Counter(
+        record.get("current_fact_record", {}).get("field_key")
+        for record in records
+        if isinstance(record, Mapping)
+    )
+    return "\n".join(
+        [
+            "# Current-Fact Source-Record Input",
+            "",
+            f"- JSON artifact: `{SOURCE_RECORD_JSON_PATH}`",
+            f"- Run ID: `{source_record_payload.get('run_id')}`",
+            f"- Source candidate input: `{CANDIDATE_JSON_PATH}`",
+            f"- Total records: `{len(records)}`",
+            "- Source-record boundary: parsed-value-only, non-scalar values remain not calculation-safe.",
+            "- Authority boundary: official values remain authority candidates only.",
+            "- Legacy raw exports, ignored local artifacts, raw source payloads, reviewer observations, and private data are excluded as authority.",
+            "",
+            "## Counts",
+            "",
+            "| Dimension | Value | Count |",
+            "| --- | --- | --- |",
+            *[
+                f"| calculation_input_status | `{status}` | {count} |"
+                for status, count in sorted(status_counts.items())
+            ],
+            *[
+                f"| field_key | `{field}` | {count} |"
+                for field, count in sorted(field_counts.items())
+            ],
+            "",
+            "## Boundaries",
+            "",
+            "- No production current-fact export artifact is generated.",
+            "- Runtime lookup and answer behavior are unchanged.",
+            "- `annotated_numeric_candidate` and `frame_range` must not be flattened into scalar values.",
+            "",
+        ]
+    )
+
+
+def _validate_candidate_payload(candidate_payload: Mapping[str, Any]) -> None:
+    expected = {
+        "artifact_schema_version": "current_fact_row_move_cell_candidate_input/v1",
+        "run_id": CANDIDATE_RUN_ID,
+    }
+    for key, value in expected.items():
+        if candidate_payload.get(key) != value:
+            raise CurrentFactSourceRecordGeneratorError(f"unexpected candidate {key}: {candidate_payload.get(key)!r}")
+    records = candidate_payload.get("records")
+    if not isinstance(records, list) or len(records) != 13:
+        raise CurrentFactSourceRecordGeneratorError("candidate records must contain exactly 13 records")
+
+
+def _source_record(candidate_record: Mapping[str, Any]) -> dict[str, Any]:
+    _validate_candidate_record(candidate_record)
+    return {
+        "current_fact_record": {
+            "authority_status": copy.deepcopy(candidate_record["authority_status"]),
+            "calculation_input_status": copy.deepcopy(candidate_record["calculation_input_status"]),
+            "character_slug": copy.deepcopy(candidate_record["character_slug"]),
+            "display_label_ja": copy.deepcopy(candidate_record["display_label_ja"]),
+            "evidence": copy.deepcopy(candidate_record["evidence"]),
+            "field_key": copy.deepcopy(candidate_record["field_key"]),
+            "move_id": copy.deepcopy(candidate_record["move_id"]),
+            "parsed_value": copy.deepcopy(candidate_record["parsed_value"]),
+            "raw_value": copy.deepcopy(candidate_record["raw_value"]),
+            "record_id": _replace_prefix(str(candidate_record["candidate_record_id"]), "candidate:", "current-fact:"),
+            "source_family": copy.deepcopy(candidate_record["source_family"]),
+            "source_header_path": copy.deepcopy(candidate_record["source_header_path"]),
+            "source_label": copy.deepcopy(candidate_record["source_label"]),
+            "source_name": copy.deepcopy(candidate_record["source_name"]),
+            "source_role": copy.deepcopy(candidate_record["source_role"]),
+            "value_shape": copy.deepcopy(candidate_record["value_shape"]),
+        },
+        "raw_value_length": copy.deepcopy(candidate_record["raw_value_length"]),
+        "raw_value_sha256": copy.deepcopy(candidate_record["raw_value_sha256"]),
+        "source_cell_key": copy.deepcopy(candidate_record["source_cell_key"]),
+        "source_cell_order": copy.deepcopy(candidate_record["source_cell_order"]),
+        "source_header_path": copy.deepcopy(candidate_record["source_header_path"]),
+        "source_record_id": _replace_prefix(str(candidate_record["candidate_record_id"]), "candidate:", "source-record:"),
+        "source_row_key": copy.deepcopy(candidate_record["source_row_key"]),
+        "source_row_order": copy.deepcopy(candidate_record["source_row_order"]),
+        "source_value_key": copy.deepcopy(candidate_record["source_value_key"]),
+    }
+
+
+def _validate_candidate_record(candidate_record: Mapping[str, Any]) -> None:
+    if candidate_record.get("source_name") != "official":
+        raise CurrentFactSourceRecordGeneratorError("first source-record slice accepts official candidate records only")
+    if candidate_record.get("source_role") != "authority_candidate":
+        raise CurrentFactSourceRecordGeneratorError("official source role must remain authority_candidate")
+    if candidate_record.get("authority_status") != "authority_candidate":
+        raise CurrentFactSourceRecordGeneratorError("official authority status must remain authority_candidate")
+    if candidate_record.get("calculation_input_status") not in ALLOWED_STATUSES:
+        raise CurrentFactSourceRecordGeneratorError(f"unsupported calculation status: {candidate_record.get('calculation_input_status')}")
+    parsed_value = candidate_record.get("parsed_value")
+    if not isinstance(parsed_value, Mapping):
+        raise CurrentFactSourceRecordGeneratorError("candidate records must include parsed_value")
+    parsed_kind = parsed_value.get("kind")
+    status = candidate_record.get("calculation_input_status")
+    if status == "annotated_candidate_not_calculation_safe" and parsed_kind != "annotated_numeric_candidate":
+        raise CurrentFactSourceRecordGeneratorError("annotated status must keep annotated_numeric_candidate wrapper")
+    if status == "parsed_range_not_single_value_calculation_safe" and parsed_kind != "frame_range":
+        raise CurrentFactSourceRecordGeneratorError("range status must keep frame_range wrapper")
+
+
+def _replace_prefix(value: str, old: str, new: str) -> str:
+    if not value.startswith(old):
+        raise CurrentFactSourceRecordGeneratorError(f"expected {old} prefix: {value}")
+    return new + value[len(old):]
+
+
+def _source_record_sort_key(record: Mapping[str, Any]) -> tuple[str, str, int, int, str]:
+    current_fact = record.get("current_fact_record", {})
+    return (
+        str(current_fact.get("source_name", "")) if isinstance(current_fact, Mapping) else "",
+        str(current_fact.get("character_slug", "")) if isinstance(current_fact, Mapping) else "",
+        int(record.get("source_row_order", 0)),
+        int(record.get("source_cell_order", 0)),
+        str(record.get("source_value_key", "")),
+    )

--- a/tests/test_current_fact_source_record_generator.py
+++ b/tests/test_current_fact_source_record_generator.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import copy
+import json
+import unittest
+from collections import Counter
+from pathlib import Path
+
+from sf6_knowledge_coach.current_fact_candidate_generator import CANDIDATE_JSON_PATH, CANDIDATE_RUN_ID
+from sf6_knowledge_coach.current_fact_source_record_generator import (
+    CurrentFactSourceRecordGeneratorError,
+    build_source_record_input_payload,
+    build_source_record_summary_markdown,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _candidate_payload() -> dict:
+    return json.loads((ROOT / CANDIDATE_JSON_PATH).read_text(encoding="utf-8"))
+
+
+class CurrentFactSourceRecordGeneratorTests(unittest.TestCase):
+    def test_builds_source_record_payload_from_candidate_input(self) -> None:
+        payload = build_source_record_input_payload(_candidate_payload())
+
+        self.assertEqual(payload["artifact_schema_version"], "current_fact_source_record_input/v1")
+        self.assertEqual(payload["run_id"], CANDIDATE_RUN_ID)
+        self.assertIn(CANDIDATE_JSON_PATH, payload["generated_from"])
+        self.assertEqual(len(payload["records"]), 13)
+        self.assertEqual(
+            Counter(record["current_fact_record"]["calculation_input_status"] for record in payload["records"]),
+            {
+                "annotated_candidate_not_calculation_safe": 9,
+                "parsed_range_not_single_value_calculation_safe": 4,
+            },
+        )
+
+    def test_current_fact_record_contains_no_source_record_sidecar_fields(self) -> None:
+        payload = build_source_record_input_payload(_candidate_payload())
+
+        for record in payload["records"]:
+            current_fact = record["current_fact_record"]
+            self.assertTrue(record["source_record_id"].startswith("source-record:"))
+            self.assertTrue(current_fact["record_id"].startswith("current-fact:"))
+            self.assertNotIn("source_record_id", current_fact)
+            self.assertNotIn("source_row_key", current_fact)
+            self.assertNotIn("source_cell_key", current_fact)
+            self.assertNotIn("source_value_key", current_fact)
+
+    def test_non_scalar_wrappers_are_preserved(self) -> None:
+        payload = build_source_record_input_payload(_candidate_payload())
+        parsed_by_status = {
+            record["current_fact_record"]["calculation_input_status"]: record["current_fact_record"]["parsed_value"]
+            for record in payload["records"]
+        }
+
+        self.assertEqual(
+            parsed_by_status["annotated_candidate_not_calculation_safe"]["kind"],
+            "annotated_numeric_candidate",
+        )
+        self.assertIn("numeric_candidate", parsed_by_status["annotated_candidate_not_calculation_safe"])
+        self.assertEqual(
+            parsed_by_status["parsed_range_not_single_value_calculation_safe"]["kind"],
+            "frame_range",
+        )
+        self.assertIn("start", parsed_by_status["parsed_range_not_single_value_calculation_safe"])
+        self.assertIn("end", parsed_by_status["parsed_range_not_single_value_calculation_safe"])
+
+    def test_candidate_run_id_is_carried_to_source_record_artifact(self) -> None:
+        payload = build_source_record_input_payload(_candidate_payload())
+
+        self.assertEqual(payload["run_id"], "20260525T000000Z")
+        self.assertNotEqual(payload["run_id"], "20260525")
+
+    def test_rejects_raw_value_expansion_not_in_candidate_input(self) -> None:
+        candidate = _candidate_payload()
+        mutated = copy.deepcopy(candidate)
+        mutated["records"][0]["calculation_input_status"] = "review_required_not_calculation_safe"
+
+        with self.assertRaises(CurrentFactSourceRecordGeneratorError):
+            build_source_record_input_payload(mutated)
+
+    def test_summary_is_boundary_only(self) -> None:
+        payload = build_source_record_input_payload(_candidate_payload())
+        markdown = build_source_record_summary_markdown(payload)
+
+        self.assertIn("Total records: `13`", markdown)
+        self.assertIn("not calculation-safe", markdown)
+        self.assertNotIn(".local", markdown)
+        self.assertNotIn("data/exports/", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validation/validate_current_fact_export_generator.py
+++ b/tests/validation/validate_current_fact_export_generator.py
@@ -19,9 +19,11 @@ PRODUCTION_ARTIFACT_DIRS = (
     ROOT / "data/current-facts",
     ROOT / "docs/current-facts",
 )
-APPROVED_CANDIDATE_ARTIFACTS = {
+APPROVED_PRODUCTION_INPUT_ARTIFACTS = {
     "data/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.json",
+    "data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json",
     "docs/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.md",
+    "docs/current-facts/source-records/20260525T000000Z-current-fact-source-records.md",
 }
 SIDECAR_FIELDS = {
     "raw_value_length",
@@ -173,10 +175,10 @@ def _validate_no_production_artifacts(errors: list[str]) -> None:
         unexpected = [
             path.relative_to(ROOT).as_posix()
             for path in files
-            if path.relative_to(ROOT).as_posix() not in APPROVED_CANDIDATE_ARTIFACTS
+            if path.relative_to(ROOT).as_posix() not in APPROVED_PRODUCTION_INPUT_ARTIFACTS
         ]
         if unexpected:
-            errors.append(f"fixture-contract generator must not create source-record/export artifacts: {unexpected}")
+            errors.append(f"fixture-contract generator must not create current-fact export artifacts: {unexpected}")
 
 
 def _finish(errors: list[str]) -> int:

--- a/tests/validation/validate_current_fact_row_move_cell_candidates.py
+++ b/tests/validation/validate_current_fact_row_move_cell_candidates.py
@@ -309,7 +309,7 @@ def _validate_approved_production_candidate_artifacts(
         PRODUCTION_JSON.relative_to(ROOT).as_posix(),
         PRODUCTION_MD.relative_to(ROOT).as_posix(),
     }
-    for relative in ("data/current-facts", "docs/current-facts"):
+    for relative in ("data/current-facts/candidate-inputs", "docs/current-facts/candidate-inputs"):
         directory = ROOT / relative
         if not directory.exists():
             errors.append(f"Missing production candidate directory: {relative}")

--- a/tests/validation/validate_current_fact_source_records.py
+++ b/tests/validation/validate_current_fact_source_records.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import re
 import sys
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
@@ -12,11 +13,17 @@ from jsonschema import Draft202012Validator
 from referencing import Registry, Resource
 
 from sf6_knowledge_coach.current_fact_guards import is_scalar_calculation_input
+from sf6_knowledge_coach.current_fact_source_record_generator import build_source_record_input_payload
 
 
 ROOT = Path(__file__).resolve().parents[2]
 SCHEMA_DIR = ROOT / "contracts/current-facts"
 FIXTURE_DIR = ROOT / "tests/fixtures/current-facts/source-records"
+PRODUCTION_JSON = ROOT / "data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json"
+PRODUCTION_MD = ROOT / "docs/current-facts/source-records/20260525T000000Z-current-fact-source-records.md"
+CANDIDATE_JSON = ROOT / "data/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.json"
+CANDIDATE_JSON_REF = "data/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.json"
+CANDIDATE_MD_REF = "docs/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.md"
 SOURCE_RECORD_SCHEMA_PATH = SCHEMA_DIR / "current_fact_source_record_input.schema.json"
 SOURCE_RECORD_SCHEMA_ID = (
     "https://sf6-knowledge-coach.local/schemas/current-facts/current_fact_source_record_input.schema.json"
@@ -31,6 +38,17 @@ SCHEMA_FILES = [
 LOOKUP_READY_BLOCKED_STATUSES = {
     "review_required_not_calculation_safe",
     "out_of_scope_not_emitted",
+}
+EXPECTED_PRODUCTION_COUNT = 13
+EXPECTED_PRODUCTION_RUN_ID = "20260525T000000Z"
+EXPECTED_PRODUCTION_STATUS_COUNTS = {
+    "annotated_candidate_not_calculation_safe": 9,
+    "parsed_range_not_single_value_calculation_safe": 4,
+}
+EXPECTED_PRODUCTION_FIELD_COUNTS = {
+    "block_advantage": 5,
+    "hit_advantage": 4,
+    "startup": 4,
 }
 FORBIDDEN_PUBLIC_PATTERNS = [
     re.compile(r"(?i)(?:^|[\s\"'`])(?:/[a-z0-9_.-]+)+"),
@@ -74,11 +92,13 @@ def main() -> int:
             errors.append(f"{path.relative_to(ROOT)} is not a valid Draft 2020-12 schema: {exc}")
 
     validator = Draft202012Validator(schemas[SOURCE_RECORD_SCHEMA_PATH], registry=registry)
+    record_validator = Draft202012Validator(schemas[SCHEMA_DIR / "current_fact_record.schema.json"], registry=registry)
     _validate_schema_contract(schemas[SOURCE_RECORD_SCHEMA_PATH], errors)
     valid_payloads = _validate_valid_fixtures(validator, errors)
     _validate_invalid_fixtures(validator, errors)
     _validate_synthetic_boundary_rejections(validator, valid_payloads, errors)
     _scan_valid_public_fixtures(errors)
+    _validate_approved_production_source_record_artifacts(validator, record_validator, errors)
     return _finish(errors)
 
 
@@ -281,6 +301,199 @@ def _scan_valid_public_fixtures(errors: list[str]) -> None:
             if pattern.search(text):
                 errors.append(f"{path.relative_to(ROOT)} contains forbidden public content")
                 break
+
+
+def _validate_approved_production_source_record_artifacts(
+    validator: Draft202012Validator,
+    record_validator: Draft202012Validator,
+    errors: list[str],
+) -> None:
+    approved = {
+        PRODUCTION_JSON.relative_to(ROOT).as_posix(),
+        PRODUCTION_MD.relative_to(ROOT).as_posix(),
+    }
+    for relative in ("data/current-facts/source-records", "docs/current-facts/source-records"):
+        directory = ROOT / relative
+        if not directory.exists():
+            errors.append(f"Missing production source-record directory: {relative}")
+            continue
+        files = {
+            path.relative_to(ROOT).as_posix()
+            for path in directory.rglob("*")
+            if path.is_file()
+        }
+        unexpected = sorted(files - approved)
+        if unexpected:
+            errors.append(f"unexpected source-record production artifacts: {unexpected}")
+    if not PRODUCTION_JSON.exists():
+        errors.append(f"Missing approved production source-record JSON: {PRODUCTION_JSON.relative_to(ROOT)}")
+        return
+    if not PRODUCTION_MD.exists():
+        errors.append(f"Missing approved production source-record summary: {PRODUCTION_MD.relative_to(ROOT)}")
+    if not CANDIDATE_JSON.exists():
+        errors.append(f"Missing candidate input artifact: {CANDIDATE_JSON.relative_to(ROOT)}")
+        return
+
+    payload = json.loads(PRODUCTION_JSON.read_text(encoding="utf-8"))
+    failures = _schema_errors(validator, payload)
+    semantic_failures = _semantic_errors(payload)
+    if failures or semantic_failures:
+        message = failures[0] if failures else semantic_failures[0]
+        errors.append(f"{PRODUCTION_JSON.relative_to(ROOT)} should be valid: {message}")
+        return
+    candidate_payload = json.loads(CANDIDATE_JSON.read_text(encoding="utf-8"))
+    generated_payload = build_source_record_input_payload(candidate_payload)
+    if payload != generated_payload:
+        errors.append("production source-record JSON must match deterministic generator output")
+    _validate_production_payload_against_candidates(payload, candidate_payload, record_validator, errors)
+    for path in (PRODUCTION_JSON, PRODUCTION_MD):
+        _scan_public_text(path, errors)
+
+
+def _validate_production_payload_against_candidates(
+    payload: dict[str, Any],
+    candidate_payload: dict[str, Any],
+    record_validator: Draft202012Validator,
+    errors: list[str],
+) -> None:
+    if payload.get("run_id") != EXPECTED_PRODUCTION_RUN_ID:
+        errors.append(f"production source-record run_id must be {EXPECTED_PRODUCTION_RUN_ID}")
+    if payload.get("run_id") != candidate_payload.get("run_id"):
+        errors.append("production source-record run_id must match production candidate run_id")
+    if payload.get("generated_from") != [CANDIDATE_JSON_REF, CANDIDATE_MD_REF]:
+        errors.append("production source-record generated_from must point only to PR #366 candidate artifacts")
+    candidate_records = candidate_payload.get("records", [])
+    records = payload.get("records", [])
+    if not isinstance(candidate_records, list) or not isinstance(records, list):
+        errors.append("production source-record and candidate records must be lists")
+        return
+    if len(records) != EXPECTED_PRODUCTION_COUNT:
+        errors.append(f"production source-record artifact must contain {EXPECTED_PRODUCTION_COUNT} records")
+    status_counts = Counter(
+        record.get("current_fact_record", {}).get("calculation_input_status")
+        for record in records
+        if isinstance(record, dict)
+    )
+    field_counts = Counter(
+        record.get("current_fact_record", {}).get("field_key")
+        for record in records
+        if isinstance(record, dict)
+    )
+    if dict(sorted(status_counts.items())) != EXPECTED_PRODUCTION_STATUS_COUNTS:
+        errors.append("production source-record calculation status counts do not match approved candidates")
+    if dict(sorted(field_counts.items())) != EXPECTED_PRODUCTION_FIELD_COUNTS:
+        errors.append("production source-record field counts do not match approved candidates")
+
+    candidates_by_source_record_id = {
+        _source_record_id(candidate.get("candidate_record_id")): candidate
+        for candidate in candidate_records
+        if isinstance(candidate, dict)
+    }
+    source_record_ids = [record.get("source_record_id") for record in records if isinstance(record, dict)]
+    if len(set(source_record_ids)) != len(source_record_ids):
+        errors.append("production source_record_id values must be unique")
+    if set(source_record_ids) != set(candidates_by_source_record_id):
+        errors.append("production source records must exactly match PR #366 candidate ids")
+        return
+    current_fact_record_ids: set[str] = set()
+    for index, record in enumerate(records):
+        if not isinstance(record, dict):
+            errors.append(f"records[{index}] must be an object")
+            continue
+        candidate = candidates_by_source_record_id[record["source_record_id"]]
+        current_fact = record.get("current_fact_record", {})
+        record_failures = _schema_errors(record_validator, current_fact) if isinstance(current_fact, dict) else ["current_fact_record must be an object"]
+        if record_failures:
+            errors.append(f"records[{index}].current_fact_record should be valid: {record_failures[0]}")
+            continue
+        current_fact_record_id = current_fact.get("record_id")
+        if current_fact_record_id in current_fact_record_ids:
+            errors.append(f"current_fact_record.record_id must be unique: {current_fact_record_id}")
+        if isinstance(current_fact_record_id, str):
+            current_fact_record_ids.add(current_fact_record_id)
+        _validate_production_record(index, record, current_fact, candidate, errors)
+
+
+def _validate_production_record(
+    index: int,
+    source_record: dict[str, Any],
+    current_fact: dict[str, Any],
+    candidate: dict[str, Any],
+    errors: list[str],
+) -> None:
+    sidecar_fields = (
+        "raw_value_length",
+        "raw_value_sha256",
+        "source_cell_key",
+        "source_cell_order",
+        "source_header_path",
+        "source_row_key",
+        "source_row_order",
+        "source_value_key",
+    )
+    for field in sidecar_fields:
+        if source_record.get(field) != candidate.get(field):
+            errors.append(f"records[{index}].{field} does not match candidate artifact")
+    if source_record.get("source_record_id") != _source_record_id(candidate.get("candidate_record_id")):
+        errors.append(f"records[{index}].source_record_id must be derived from candidate_record_id")
+    if current_fact.get("record_id") != _current_fact_record_id(candidate.get("candidate_record_id")):
+        errors.append(f"records[{index}].current_fact_record.record_id must be derived from candidate_record_id")
+
+    copied_current_fact_fields = (
+        "authority_status",
+        "calculation_input_status",
+        "character_slug",
+        "display_label_ja",
+        "evidence",
+        "field_key",
+        "move_id",
+        "parsed_value",
+        "raw_value",
+        "source_family",
+        "source_header_path",
+        "source_label",
+        "source_name",
+        "source_role",
+        "value_shape",
+    )
+    for field in copied_current_fact_fields:
+        if current_fact.get(field) != candidate.get(field):
+            errors.append(f"records[{index}].current_fact_record.{field} does not match candidate artifact")
+    forbidden_sidecars = {
+        "candidate_record_id",
+        "parser_rule_ids",
+        "source_record_id",
+        "source_row_key",
+        "source_cell_key",
+        "source_value_key",
+        "source_row_order",
+        "source_cell_order",
+        "raw_value_length",
+        "raw_value_sha256",
+    }
+    leaked = sorted(forbidden_sidecars & set(current_fact))
+    if leaked:
+        errors.append(f"records[{index}].current_fact_record leaked sidecar fields: {leaked}")
+
+
+def _source_record_id(candidate_record_id: object) -> str:
+    if not isinstance(candidate_record_id, str):
+        return ""
+    return candidate_record_id.replace("candidate:", "source-record:", 1)
+
+
+def _current_fact_record_id(candidate_record_id: object) -> str:
+    if not isinstance(candidate_record_id, str):
+        return ""
+    return candidate_record_id.replace("candidate:", "current-fact:", 1)
+
+
+def _scan_public_text(path: Path, errors: list[str]) -> None:
+    text = path.read_text(encoding="utf-8")
+    for pattern in FORBIDDEN_PUBLIC_PATTERNS:
+        if pattern.search(text):
+            errors.append(f"{path.relative_to(ROOT)} contains forbidden public content")
+            break
 
 
 def _first_record(payload: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- plan the first production current-fact source-record artifact from the reviewed PR #366 candidate artifact
- keep the artifact path, mapping, validator, and same-draft-PR implementation boundaries docs-only
- keep export generation, runtime lookup, parser/classifier behavior, retrieval, answer, calculator, SymPy, source acquisition, and live acquisition out of scope

## Validation
- git diff --check
- uv lock --check
- PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py
- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py
- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_row_move_cell_candidates.py
- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py
- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_export_generator.py
- PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
