### PR TITLE
Plan current-fact export artifact from source records

### DIFF
--- a/data/current-facts/20260525T000000Z-current-fact-export.json
+++ b/data/current-facts/20260525T000000Z-current-fact-export.json
@@ -1,0 +1,792 @@
+{
+  "artifact_schema_version": "current_fact_export/v2",
+  "authority_boundary": {
+    "official": "authority_candidate_only",
+    "supercombo": "enrichment_or_cross_reference_only"
+  },
+  "generated_from": [
+    "data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json"
+  ],
+  "records": [
+    {
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "parsed_range_not_single_value_calculation_safe",
+      "character_slug": "alex",
+      "display_label_ja": "フライングクロスチョップ（ジャンプ中に） 強",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "硬直差",
+          "ガード"
+        ],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "block_advantage",
+      "move_id": "official:alex:row-41:move-f09489ff6eaa",
+      "parsed_value": {
+        "end": -1,
+        "kind": "frame_range",
+        "start": -12,
+        "unit": "frame"
+      },
+      "raw_value": "-12～-1",
+      "record_id": "current-fact:official:alex:row-41:cell-5:value-520f8306db0f",
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ガード"
+      ],
+      "source_label": "ガード",
+      "source_name": "official",
+      "source_role": "authority_candidate",
+      "value_shape": {
+        "classes": [
+          "range"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "frame_range.official_signed_wave_dash.v1",
+        "review_item_id": "value-shape:official--unclassified_expression--u_c135db53355f--u_522ba9f47afb"
+      }
+    },
+    {
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "parsed_range_not_single_value_calculation_safe",
+      "character_slug": "cammy",
+      "display_label_ja": "リバースエッジ（フーリガンコンビネーション中に）",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "硬直差",
+          "ガード"
+        ],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "block_advantage",
+      "move_id": "official:cammy:row-52:move-003104ea0ff9",
+      "parsed_value": {
+        "end": -1,
+        "kind": "frame_range",
+        "start": -4,
+        "unit": "frame"
+      },
+      "raw_value": "-4～-1",
+      "record_id": "current-fact:official:cammy:row-52:cell-5:value-f3bd1df4c26d",
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ガード"
+      ],
+      "source_label": "ガード",
+      "source_name": "official",
+      "source_role": "authority_candidate",
+      "value_shape": {
+        "classes": [
+          "range"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "frame_range.official_signed_wave_dash.v1",
+        "review_item_id": "value-shape:official--unclassified_expression--u_c135db53355f--u_522ba9f47afb"
+      }
+    },
+    {
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "character_slug": "chunli",
+      "display_label_ja": "蘭華（行雲流水中に）弱",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "硬直差",
+          "ガード"
+        ],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "block_advantage",
+      "move_id": "official:chunli:row-32:move-278b4bdd0acb",
+      "parsed_value": {
+        "annotation": {
+          "marker_placement": "prefix",
+          "note_id": null,
+          "note_linkage_status": "same_row_note_candidates_available",
+          "note_marker": "※",
+          "note_scope": "row_block_advantage_condition",
+          "note_text_status": "structured_row_note_text_found",
+          "row_note_candidate_count": 1
+        },
+        "calculation": {
+          "calculation_input_status": "annotated_candidate_not_calculation_safe",
+          "reason": "condition_bound_by_official_note"
+        },
+        "kind": "annotated_numeric_candidate",
+        "numeric_candidate": {
+          "candidate_type": "signed_frame",
+          "unit": "frame",
+          "value": -4
+        },
+        "source_context": {
+          "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_522ba9f47afb",
+          "source_column_header_path": [
+            "硬直差",
+            "ガード"
+          ],
+          "source_review_id": "source-review:official-note-linkage-block-advantage"
+        }
+      },
+      "raw_value": "※-4",
+      "record_id": "current-fact:official:chunli:row-32:cell-5:value-b5112d05eab3",
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ガード"
+      ],
+      "source_label": "ガード",
+      "source_name": "official",
+      "source_role": "authority_candidate",
+      "value_shape": {
+        "classes": [
+          "note_prefixed"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "annotated_signed_frame.official_prefix_marker.negative.v1",
+        "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_522ba9f47afb"
+      }
+    },
+    {
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "character_slug": "chunli",
+      "display_label_ja": "蘭華（行雲流水中に）弱",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "硬直差",
+          "ヒット"
+        ],
+        "source_label": "ヒット",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "hit_advantage",
+      "move_id": "official:chunli:row-32:move-278b4bdd0acb",
+      "parsed_value": {
+        "annotation": {
+          "marker_placement": "prefix",
+          "note_id": null,
+          "note_linkage_status": "same_row_note_candidates_available",
+          "note_marker": "※",
+          "note_scope": "row_hit_advantage_condition",
+          "note_text_status": "structured_row_note_text_found",
+          "row_note_candidate_count": 1
+        },
+        "calculation": {
+          "calculation_input_status": "annotated_candidate_not_calculation_safe",
+          "reason": "condition_bound_by_official_note"
+        },
+        "kind": "annotated_numeric_candidate",
+        "numeric_candidate": {
+          "candidate_type": "signed_frame",
+          "unit": "frame",
+          "value": -3
+        },
+        "source_context": {
+          "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69",
+          "source_column_header_path": [
+            "硬直差",
+            "ヒット"
+          ],
+          "source_review_id": "source-review:official-note-linkage-hit-advantage"
+        }
+      },
+      "raw_value": "※-3",
+      "record_id": "current-fact:official:chunli:row-32:cell-4:value-38098349c914",
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ヒット"
+      ],
+      "source_label": "ヒット",
+      "source_name": "official",
+      "source_role": "authority_candidate",
+      "value_shape": {
+        "classes": [
+          "note_prefixed"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "annotated_signed_frame.official_prefix_marker.negative.v1",
+        "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69"
+      }
+    },
+    {
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "character_slug": "chunli",
+      "display_label_ja": "前突（行雲流水中に）弱",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "硬直差",
+          "ヒット"
+        ],
+        "source_label": "ヒット",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "hit_advantage",
+      "move_id": "official:chunli:row-35:move-2c6d449eb8a3",
+      "parsed_value": {
+        "annotation": {
+          "marker_placement": "prefix",
+          "note_id": null,
+          "note_linkage_status": "same_row_note_candidates_available",
+          "note_marker": "※",
+          "note_scope": "row_hit_advantage_condition",
+          "note_text_status": "structured_row_note_text_found",
+          "row_note_candidate_count": 1
+        },
+        "calculation": {
+          "calculation_input_status": "annotated_candidate_not_calculation_safe",
+          "reason": "condition_bound_by_official_note"
+        },
+        "kind": "annotated_numeric_candidate",
+        "numeric_candidate": {
+          "candidate_type": "signed_frame",
+          "unit": "frame",
+          "value": -1
+        },
+        "source_context": {
+          "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69",
+          "source_column_header_path": [
+            "硬直差",
+            "ヒット"
+          ],
+          "source_review_id": "source-review:official-note-linkage-hit-advantage"
+        }
+      },
+      "raw_value": "※-1",
+      "record_id": "current-fact:official:chunli:row-35:cell-4:value-dbdd09f8dbaa",
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ヒット"
+      ],
+      "source_label": "ヒット",
+      "source_name": "official",
+      "source_role": "authority_candidate",
+      "value_shape": {
+        "classes": [
+          "note_prefixed"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "annotated_signed_frame.official_prefix_marker.negative.v1",
+        "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69"
+      }
+    },
+    {
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "character_slug": "chunli",
+      "display_label_ja": "仙風（行雲流水中に）中",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "硬直差",
+          "ヒット"
+        ],
+        "source_label": "ヒット",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "hit_advantage",
+      "move_id": "official:chunli:row-36:move-f41b02dd87c4",
+      "parsed_value": {
+        "annotation": {
+          "marker_placement": "prefix",
+          "note_id": null,
+          "note_linkage_status": "same_row_note_candidates_available",
+          "note_marker": "※",
+          "note_scope": "row_hit_advantage_condition",
+          "note_text_status": "structured_row_note_text_found",
+          "row_note_candidate_count": 1
+        },
+        "calculation": {
+          "calculation_input_status": "annotated_candidate_not_calculation_safe",
+          "reason": "condition_bound_by_official_note"
+        },
+        "kind": "annotated_numeric_candidate",
+        "numeric_candidate": {
+          "candidate_type": "signed_frame",
+          "unit": "frame",
+          "value": -4
+        },
+        "source_context": {
+          "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69",
+          "source_column_header_path": [
+            "硬直差",
+            "ヒット"
+          ],
+          "source_review_id": "source-review:official-note-linkage-hit-advantage"
+        }
+      },
+      "raw_value": "※-4",
+      "record_id": "current-fact:official:chunli:row-36:cell-4:value-b5112d05eab3",
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ヒット"
+      ],
+      "source_label": "ヒット",
+      "source_name": "official",
+      "source_role": "authority_candidate",
+      "value_shape": {
+        "classes": [
+          "note_prefixed"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "annotated_signed_frame.official_prefix_marker.negative.v1",
+        "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_7acd6c7b6e69"
+      }
+    },
+    {
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "character_slug": "ed",
+      "display_label_ja": "サイコナックル(Lv1)強ホールド",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "硬直差",
+          "ガード"
+        ],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "block_advantage",
+      "move_id": "official:ed:row-21:move-a8a13087c217",
+      "parsed_value": {
+        "annotation": {
+          "marker_placement": "prefix",
+          "note_id": null,
+          "note_linkage_status": "same_row_note_candidates_available",
+          "note_marker": "※",
+          "note_scope": "row_block_advantage_condition",
+          "note_text_status": "structured_row_note_text_found",
+          "row_note_candidate_count": 1
+        },
+        "calculation": {
+          "calculation_input_status": "annotated_candidate_not_calculation_safe",
+          "reason": "condition_bound_by_official_note"
+        },
+        "kind": "annotated_numeric_candidate",
+        "numeric_candidate": {
+          "candidate_type": "signed_frame",
+          "unit": "frame",
+          "value": -2
+        },
+        "source_context": {
+          "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_522ba9f47afb",
+          "source_column_header_path": [
+            "硬直差",
+            "ガード"
+          ],
+          "source_review_id": "source-review:official-note-linkage-block-advantage"
+        }
+      },
+      "raw_value": "※-2",
+      "record_id": "current-fact:official:ed:row-21:cell-5:value-522076e6afe2",
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ガード"
+      ],
+      "source_label": "ガード",
+      "source_name": "official",
+      "source_role": "authority_candidate",
+      "value_shape": {
+        "classes": [
+          "note_prefixed"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "annotated_signed_frame.official_prefix_marker.negative.v1",
+        "review_item_id": "value-shape:official--source_specific_expression--u_c135db53355f--u_522ba9f47afb"
+      }
+    },
+    {
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "character_slug": "kimberly",
+      "display_label_ja": "弱 細工手裏剣（細工手裏剣ストックが1以上で） 弱",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "動作フレーム",
+          "発生"
+        ],
+        "source_label": "発生",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "startup",
+      "move_id": "official:kimberly:row-64:move-1ebd54eb85aa",
+      "parsed_value": {
+        "annotation": {
+          "marker_placement": "suffix",
+          "note_id": null,
+          "note_linkage_status": "same_row_note_candidates_available",
+          "note_marker": "※",
+          "note_scope": "row_startup_condition",
+          "note_text_status": "structured_row_note_text_found",
+          "row_note_candidate_count": 1
+        },
+        "calculation": {
+          "calculation_input_status": "annotated_candidate_not_calculation_safe",
+          "reason": "condition_bound_by_official_note"
+        },
+        "kind": "annotated_numeric_candidate",
+        "numeric_candidate": {
+          "candidate_type": "unsigned_frame",
+          "unit": "frame",
+          "value": 122
+        },
+        "source_context": {
+          "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100",
+          "source_column_header_path": [
+            "動作フレーム",
+            "発生"
+          ],
+          "source_review_id": "source-review:official-note-linkage-startup"
+        }
+      },
+      "raw_value": "122※",
+      "record_id": "current-fact:official:kimberly:row-64:cell-1:value-1a036dd4c06c",
+      "source_family": "timing",
+      "source_header_path": [
+        "動作フレーム",
+        "発生"
+      ],
+      "source_label": "発生",
+      "source_name": "official",
+      "source_role": "authority_candidate",
+      "value_shape": {
+        "classes": [
+          "note_suffixed"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "annotated_frame.official_suffix_marker.v1",
+        "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100"
+      }
+    },
+    {
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "character_slug": "kimberly",
+      "display_label_ja": "強 細工手裏剣（細工手裏剣ストックが1以上で） 強",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "動作フレーム",
+          "発生"
+        ],
+        "source_label": "発生",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "startup",
+      "move_id": "official:kimberly:row-66:move-035abd428c6f",
+      "parsed_value": {
+        "annotation": {
+          "marker_placement": "suffix",
+          "note_id": null,
+          "note_linkage_status": "same_row_note_candidates_available",
+          "note_marker": "※",
+          "note_scope": "row_startup_condition",
+          "note_text_status": "structured_row_note_text_found",
+          "row_note_candidate_count": 1
+        },
+        "calculation": {
+          "calculation_input_status": "annotated_candidate_not_calculation_safe",
+          "reason": "condition_bound_by_official_note"
+        },
+        "kind": "annotated_numeric_candidate",
+        "numeric_candidate": {
+          "candidate_type": "unsigned_frame",
+          "unit": "frame",
+          "value": 128
+        },
+        "source_context": {
+          "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100",
+          "source_column_header_path": [
+            "動作フレーム",
+            "発生"
+          ],
+          "source_review_id": "source-review:official-note-linkage-startup"
+        }
+      },
+      "raw_value": "128※",
+      "record_id": "current-fact:official:kimberly:row-66:cell-1:value-3c911b4c4f5d",
+      "source_family": "timing",
+      "source_header_path": [
+        "動作フレーム",
+        "発生"
+      ],
+      "source_label": "発生",
+      "source_name": "official",
+      "source_role": "authority_candidate",
+      "value_shape": {
+        "classes": [
+          "note_suffixed"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "annotated_frame.official_suffix_marker.v1",
+        "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100"
+      }
+    },
+    {
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "character_slug": "kimberly",
+      "display_label_ja": "弱 乱れ細工手裏剣（細工手裏剣ストックが2以上で） 弱中",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "動作フレーム",
+          "発生"
+        ],
+        "source_label": "発生",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "startup",
+      "move_id": "official:kimberly:row-67:move-c8f7890e80bb",
+      "parsed_value": {
+        "annotation": {
+          "marker_placement": "suffix",
+          "note_id": null,
+          "note_linkage_status": "same_row_note_candidates_available",
+          "note_marker": "※",
+          "note_scope": "row_startup_condition",
+          "note_text_status": "structured_row_note_text_found",
+          "row_note_candidate_count": 1
+        },
+        "calculation": {
+          "calculation_input_status": "annotated_candidate_not_calculation_safe",
+          "reason": "condition_bound_by_official_note"
+        },
+        "kind": "annotated_numeric_candidate",
+        "numeric_candidate": {
+          "candidate_type": "unsigned_frame",
+          "unit": "frame",
+          "value": 122
+        },
+        "source_context": {
+          "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100",
+          "source_column_header_path": [
+            "動作フレーム",
+            "発生"
+          ],
+          "source_review_id": "source-review:official-note-linkage-startup"
+        }
+      },
+      "raw_value": "122※",
+      "record_id": "current-fact:official:kimberly:row-67:cell-1:value-1a036dd4c06c",
+      "source_family": "timing",
+      "source_header_path": [
+        "動作フレーム",
+        "発生"
+      ],
+      "source_label": "発生",
+      "source_name": "official",
+      "source_role": "authority_candidate",
+      "value_shape": {
+        "classes": [
+          "note_suffixed"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "annotated_frame.official_suffix_marker.v1",
+        "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100"
+      }
+    },
+    {
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "annotated_candidate_not_calculation_safe",
+      "character_slug": "kimberly",
+      "display_label_ja": "中 乱れ細工手裏剣（細工手裏剣ストックが2以上で） 弱強",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "動作フレーム",
+          "発生"
+        ],
+        "source_label": "発生",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "startup",
+      "move_id": "official:kimberly:row-68:move-8683c9bcb338",
+      "parsed_value": {
+        "annotation": {
+          "marker_placement": "suffix",
+          "note_id": null,
+          "note_linkage_status": "same_row_note_candidates_available",
+          "note_marker": "※",
+          "note_scope": "row_startup_condition",
+          "note_text_status": "structured_row_note_text_found",
+          "row_note_candidate_count": 1
+        },
+        "calculation": {
+          "calculation_input_status": "annotated_candidate_not_calculation_safe",
+          "reason": "condition_bound_by_official_note"
+        },
+        "kind": "annotated_numeric_candidate",
+        "numeric_candidate": {
+          "candidate_type": "unsigned_frame",
+          "unit": "frame",
+          "value": 122
+        },
+        "source_context": {
+          "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100",
+          "source_column_header_path": [
+            "動作フレーム",
+            "発生"
+          ],
+          "source_review_id": "source-review:official-note-linkage-startup"
+        }
+      },
+      "raw_value": "122※",
+      "record_id": "current-fact:official:kimberly:row-68:cell-1:value-1a036dd4c06c",
+      "source_family": "timing",
+      "source_header_path": [
+        "動作フレーム",
+        "発生"
+      ],
+      "source_label": "発生",
+      "source_name": "official",
+      "source_role": "authority_candidate",
+      "value_shape": {
+        "classes": [
+          "note_suffixed"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "annotated_frame.official_suffix_marker.v1",
+        "review_item_id": "value-shape:official--source_specific_expression--u_fdb49a2113ba--u_a23f1a4e4100"
+      }
+    },
+    {
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "parsed_range_not_single_value_calculation_safe",
+      "character_slug": "vega_mbison",
+      "display_label_ja": "ヘッドプレス（シャドウライズ中に）",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "硬直差",
+          "ガード"
+        ],
+        "source_label": "ガード",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "block_advantage",
+      "move_id": "official:vega_mbison:row-53:move-268f9d662fa7",
+      "parsed_value": {
+        "end": -33,
+        "kind": "frame_range",
+        "start": -39,
+        "unit": "frame"
+      },
+      "raw_value": "-39～-33",
+      "record_id": "current-fact:official:vega_mbison:row-53:cell-5:value-1c461fc0a5e3",
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ガード"
+      ],
+      "source_label": "ガード",
+      "source_name": "official",
+      "source_role": "authority_candidate",
+      "value_shape": {
+        "classes": [
+          "range"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "frame_range.official_signed_wave_dash.v1",
+        "review_item_id": "value-shape:official--unclassified_expression--u_c135db53355f--u_522ba9f47afb"
+      }
+    },
+    {
+      "authority_status": "authority_candidate",
+      "calculation_input_status": "parsed_range_not_single_value_calculation_safe",
+      "character_slug": "vega_mbison",
+      "display_label_ja": "ヘッドプレス（シャドウライズ中に）",
+      "evidence": {
+        "evidence_basis": "source_review_summary",
+        "public_reference": "data/source-reviews/20260525-current-fact-row-move-cell-candidate-evidence.json",
+        "run_id": "20260521T025403Z",
+        "source_header_path": [
+          "硬直差",
+          "ヒット"
+        ],
+        "source_label": "ヒット",
+        "source_name": "official",
+        "source_role": "authority_candidate"
+      },
+      "field_key": "hit_advantage",
+      "move_id": "official:vega_mbison:row-53:move-268f9d662fa7",
+      "parsed_value": {
+        "end": -23,
+        "kind": "frame_range",
+        "start": -28,
+        "unit": "frame"
+      },
+      "raw_value": "-28～-23",
+      "record_id": "current-fact:official:vega_mbison:row-53:cell-4:value-1c81d53e6168",
+      "source_family": "advantage",
+      "source_header_path": [
+        "硬直差",
+        "ヒット"
+      ],
+      "source_label": "ヒット",
+      "source_name": "official",
+      "source_role": "authority_candidate",
+      "value_shape": {
+        "classes": [
+          "range"
+        ],
+        "classifier_status": "parsed",
+        "parser_rule_id": "frame_range.official_signed_wave_dash.v1",
+        "review_item_id": "value-shape:official--unclassified_expression--u_c135db53355f--u_7acd6c7b6e69"
+      }
+    }
+  ],
+  "run_id": "20260525T000000Z"
+}

--- a/data/validator-audits/20260523-validator-test-fact-source-audit.json
+++ b/data/validator-audits/20260523-validator-test-fact-source-audit.json
@@ -50,16 +50,18 @@
       "status": "accepted_with_limits"
     },
     {
-      "evidence_class": "synthetic_contract",
+      "evidence_class": "artifact_consistency",
       "file": "tests/test_current_fact_export_generator.py",
       "limitations": [
-        "uses source-record synthetic fixtures; does not generate production exports or prove source truth"
+        "uses source-record synthetic fixtures and approved production source-record input; checks deterministic export transform only and does not prove source truth or runtime behavior"
       ],
       "primary_evidence": [
         "contracts/current-facts/current_fact_export.schema.json",
         "contracts/current-facts/current_fact_source_record_input.schema.json",
+        "data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json",
         "tests/fixtures/current-facts/source-records",
-        "current-fact export generator fixture-contract implementation ExecPlan"
+        "current-fact export generator fixture-contract implementation ExecPlan",
+        "current-fact export artifact from source records ExecPlan"
       ],
       "status": "accepted_with_limits"
     },
@@ -157,15 +159,18 @@
       "evidence_class": "artifact_consistency",
       "file": "tests/validation/validate_current_fact_export_generator.py",
       "limitations": [
-        "checks fixture-contract generator output, guard boundaries, and absence of production current-fact export artifacts; approved candidate/source-record inputs are not export artifacts"
+        "checks fixture-contract generator output, guard boundaries, and approved production current-fact export consistency with reviewed source-record input; does not prove source truth or runtime behavior"
       ],
       "primary_evidence": [
         "contracts/current-facts/current_fact_export.schema.json",
         "contracts/current-facts/current_fact_source_record_input.schema.json",
+        "data/current-facts/20260525T000000Z-current-fact-export.json",
+        "data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json",
         "tests/fixtures/current-facts/source-records",
         "current-fact export generator fixture-contract implementation ExecPlan",
         "current-fact production candidate artifact ExecPlan",
-        "current-fact source-record artifact from candidates ExecPlan"
+        "current-fact source-record artifact from candidates ExecPlan",
+        "current-fact export artifact from source records ExecPlan"
       ],
       "status": "accepted_with_limits"
     },

--- a/docs/current-facts/20260525T000000Z-current-fact-export.md
+++ b/docs/current-facts/20260525T000000Z-current-fact-export.md
@@ -1,0 +1,26 @@
+# Current-Fact Export
+
+- JSON artifact: `data/current-facts/20260525T000000Z-current-fact-export.json`
+- Run ID: `20260525T000000Z`
+- Source-record input: `data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json`
+- Total records: `13`
+- Export boundary: source-record sidecar fields are excluded.
+- Calculation boundary: non-scalar values remain not calculation-safe.
+- Authority boundary: official values remain authority candidates only.
+- Runtime lookup and answer behavior are unchanged.
+
+## Counts
+
+| Dimension | Value | Count |
+| --- | --- | --- |
+| calculation_input_status | `annotated_candidate_not_calculation_safe` | 9 |
+| calculation_input_status | `parsed_range_not_single_value_calculation_safe` | 4 |
+| field_key | `block_advantage` | 5 |
+| field_key | `hit_advantage` | 4 |
+| field_key | `startup` | 4 |
+
+## Boundaries
+
+- No runtime current-fact lookup switch is included.
+- `annotated_numeric_candidate` and `frame_range` must not be flattened into scalar values.
+- Legacy raw exports, ignored local artifacts, raw source payloads, reviewer observations, and private data are excluded as authority.

--- a/docs/execplans/2026-05-25-current-fact-export-artifact-from-source-records.md
+++ b/docs/execplans/2026-05-25-current-fact-export-artifact-from-source-records.md
@@ -1,6 +1,6 @@
 # Current-Fact Export Artifact From Source Records
 
-Status: Drafted for review; validation passed.
+Status: Implementation complete; validation passed; mandatory review pending.
 
 ## Purpose
 
@@ -329,6 +329,13 @@ git status --short --branch
 - 2026-05-25: Drafted plan after PR #367 merged. No implementation or
   production current-fact export artifact generated yet.
 - 2026-05-26: Ran plan-only validation. All checks passed.
+- 2026-05-26: Added a production export helper path that uses the PR #367
+  source-record JSON as the only `generated_from` input boundary.
+- 2026-05-26: Generated the production `current_fact_export/v2` JSON and
+  summary Markdown artifacts from the PR #367 source-record JSON.
+- 2026-05-26: Updated focused tests, export validator, and validator audit
+  artifacts for the production export artifact boundary.
+- 2026-05-26: Ran implementation validation. All checks passed.
 
 ## Decision Log
 
@@ -340,6 +347,11 @@ git status --short --branch
   not the candidate artifacts that originally fed the source-record artifact.
 - 2026-05-25: Runtime lookup transition, answer behavior, and legacy raw export
   retirement remain out of scope.
+- 2026-05-26: The existing fixture-contract helper keeps its fixture behavior,
+  while the production helper overrides `generated_from` to the PR #367
+  source-record JSON only.
+- 2026-05-26: The production export summary is generated from the committed
+  production export JSON and remains summary-safe.
 
 ## Deviations
 
@@ -360,30 +372,35 @@ git status --short --branch
 
 | PLAN item | Implementation content | Changed files | Validation command | Result | Deviation | Incomplete | Risk |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Production current-fact export artifact plan | Draft plan only | `docs/execplans/2026-05-25-current-fact-export-artifact-from-source-records.md` | `git diff --check`; `uv lock --check` | Pass | None | Mandatory review pending | Runtime remains legacy raw export backed |
-| Input boundary | Plan restricts input to PR #367 source-record JSON | Same | `validate_current_fact_source_records.py` | Pass | None | Mandatory review pending | Export generation remains unimplemented |
-| Runtime/export boundary | Plan excludes runtime lookup and answer behavior changes | Same | current-fact validators | Pass | None | Mandatory review pending | Runtime remains legacy raw export backed |
+| Production current-fact export artifact plan | Implementation progress, decisions, and review prompt updated | `docs/execplans/2026-05-25-current-fact-export-artifact-from-source-records.md` | `git diff --check`; `uv lock --check` | Pass | None | None | Runtime remains legacy raw export backed |
+| Production export helper | Source-record payload to `current_fact_export/v2`; production path uses source-record JSON only | `src/sf6_knowledge_coach/current_fact_export_generator.py`; `tests/test_current_fact_export_generator.py` | `python -m unittest discover -s tests` | Pass | None | None | Helper does not switch runtime lookup |
+| Production export artifact | 13 current-fact export records generated from PR #367 source-record JSON | `data/current-facts/20260525T000000Z-current-fact-export.json`; `docs/current-facts/20260525T000000Z-current-fact-export.md` | `validate_current_fact_export_generator.py` | Pass | None | None | All 13 records remain non-scalar and not calculation-safe |
+| Input boundary | Export validator checks committed JSON/MD against deterministic helper output from source-record JSON | `tests/validation/validate_current_fact_export_generator.py` | `validate_current_fact_export_generator.py`; `validate_current_fact_source_records.py` | Pass | None | None | Runtime remains legacy raw export backed |
+| Validator audit | Audit records updated helper test and export validator evidence boundaries | `data/validator-audits/20260523-validator-test-fact-source-audit.json`; `docs/validator-audits/20260523-validator-test-fact-source-audit.md` | `validate_validator_test_audit.py` | Pass | None | None | Audit remains evidence-boundary metadata only |
 
 ## Next Reviewer Prompt
 
 ```text
-Review docs/execplans/2026-05-25-current-fact-export-artifact-from-source-records.md.
+Review PR #368 implementation for production current-fact export artifact from source records.
 
 Check:
-- PR diff initially contains exactly one ExecPlan file.
-- Plan uses only
+- PR diff contains only approved implementation files.
+- Implementation uses only
   data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json
   as production input.
-- Planned output is current_fact_export/v2 under data/current-facts/ with a
+- Output is current_fact_export/v2 under data/current-facts/ with a
   summary under docs/current-facts/.
-- Plan does not use legacy data/exports/*/official_raw.json.
-- Plan does not use candidate artifacts, .local, raw HTML, full rows,
+- Committed production export JSON and Markdown match deterministic generator
+  output.
+- Implementation does not use legacy data/exports/*/official_raw.json.
+- Implementation does not use candidate artifacts, .local, raw HTML, full rows,
   screenshots, VLM output, or private data as authority.
-- Plan includes no runtime lookup change, current_facts.py change,
+- Implementation includes no runtime lookup change, current_facts.py change,
   answering.py change, parser/classifier behavior change, retrieval, answer,
   calculator, SymPy, source acquisition, or live acquisition.
-- Planned production current-fact export artifact is exactly 13 records from
-  PR #367 source-record input.
+- Production current-fact export artifact is exactly 13 records from PR #367
+  source-record input.
+- `generated_from` points only to the PR #367 source-record JSON.
 - Source-record sidecar fields do not leak into export records.
 - annotated_numeric_candidate and frame_range remain non-scalar and not
   calculation-safe.
@@ -396,7 +413,10 @@ Run:
 - git status --short --branch
 - git show --name-status --oneline --no-renames HEAD
 - git diff --check origin/main...HEAD
+- git diff --cached --check
 - uv lock --check
+- PYTHONPATH=src uv run --locked python -m unittest discover -s tests
+- for f in tests/validation/validate_*.py; do PYTHONPATH=src uv run --locked python "$f" || exit $?; done
 - PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
 - PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py
 - PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py
@@ -406,5 +426,5 @@ Run:
 - PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
 
 Return blocking findings first, validation results, PLAN deviations, remaining
-risks, and whether docs-only plan is approved for same-PR implementation.
+risks, and whether PR #368 is ready to mark ready and merge.
 ```

--- a/docs/execplans/2026-05-25-current-fact-export-artifact-from-source-records.md
+++ b/docs/execplans/2026-05-25-current-fact-export-artifact-from-source-records.md
@@ -1,0 +1,410 @@
+# Current-Fact Export Artifact From Source Records
+
+Status: Drafted for review; validation passed.
+
+## Purpose
+
+Plan generation of the first production `current_fact_export/v2` artifact from
+the reviewed production source-record artifact added by PR #367.
+
+This plan is the next step after the production source-record artifact. It must
+not switch runtime lookup, answer behavior, retrieval, parser/classifier
+behavior, calculators, or legacy raw export retirement. It only defines how to
+transform the reviewed source-record input into a committed current-fact export
+artifact that can be reviewed before any runtime consumer uses it.
+
+## Draft PR Flow
+
+Use the same draft PR flow as PR #365 through PR #367:
+
+1. Commit this docs-only plan and open a draft PR.
+2. Complete mandatory plan review.
+3. Add implementation commits to the same draft PR only after plan review
+   passes.
+4. Complete mandatory implementation review.
+5. Ready and merge only after implementation review passes.
+
+The plan-only draft PR must not be merged.
+
+## Inputs
+
+- `docs/PLAN.md`
+- `AGENTS.md`
+- `docs/execplans/2026-05-25-current-fact-export-generator.md`
+- `docs/execplans/2026-05-25-current-fact-export-design-amendment.md`
+- `docs/execplans/2026-05-25-current-fact-calculation-status-schema.md`
+- `docs/execplans/2026-05-25-current-fact-export-generator-fixture-contract-implementation.md`
+- `docs/execplans/2026-05-25-current-fact-source-record-artifact-from-candidates.md`
+- `contracts/current-facts/current_fact_export.schema.json`
+- `contracts/current-facts/current_fact_record.schema.json`
+- `contracts/current-facts/current_fact_source_record_input.schema.json`
+- `contracts/current-facts/parsed_value.schema.json`
+- `contracts/current-facts/source_reference.schema.json`
+- `src/sf6_knowledge_coach/current_fact_export_generator.py`
+- `src/sf6_knowledge_coach/current_fact_guards.py`
+- `data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json`
+- `docs/current-facts/source-records/20260525T000000Z-current-fact-source-records.md`
+- `data/validator-audits/20260523-validator-test-fact-source-audit.json`
+- `docs/validator-audits/20260523-validator-test-fact-source-audit.md`
+
+## Context
+
+PR #367 produced one schema-valid production source-record artifact:
+
+- `data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json`;
+- `docs/current-facts/source-records/20260525T000000Z-current-fact-source-records.md`.
+
+It contains exactly 13 reviewed official source records:
+
+- 9 `annotated_numeric_candidate` records with
+  `annotated_candidate_not_calculation_safe`;
+- 4 `frame_range` records with
+  `parsed_range_not_single_value_calculation_safe`.
+
+Those records are lookup-ready source-record inputs, not scalar calculation
+inputs. Exporting them into `current_fact_export/v2` preserves reviewed
+metadata and makes the export artifact reviewable, but it does not make any
+record exact-answer-ready, calculation-safe, or runtime-selected.
+
+## Scope
+
+Included in this docs-only plan and future implementation slice:
+
+- generate one production `current_fact_export/v2` JSON artifact from the PR
+  #367 production source-record JSON only;
+- generate one summary-safe Markdown companion;
+- add a deterministic production export helper or generator entry point if
+  needed;
+- add focused unit tests for the helper if changed;
+- update `validate_current_fact_export_generator.py` to validate the approved
+  production current-fact export artifact;
+- update validator audit artifacts for changed tests/validators;
+- update this ExecPlan Progress, Decision Log, and Completion Review Table.
+
+Excluded:
+
+- No runtime lookup change.
+- No `current_facts.py` change.
+- No `answering.py` change.
+- No parser/classifier behavior change.
+- No parser/classifier expansion.
+- No retrieval implementation.
+- No answer implementation.
+- No calculator implementation.
+- No SymPy logic.
+- No source acquisition implementation.
+- No live acquisition.
+- No authority promotion.
+- No calculation-safe promotion.
+- No Issue #343 raw-value expansion.
+- No legacy raw export retirement.
+
+## Artifact Paths
+
+Planned production current-fact export JSON:
+
+- `data/current-facts/20260525T000000Z-current-fact-export.json`
+
+Planned summary Markdown:
+
+- `docs/current-facts/20260525T000000Z-current-fact-export.md`
+
+The export artifact top-level `run_id` should be `20260525T000000Z`, matching
+the reviewed source-record artifact lineage.
+
+## Allowed Source Inputs
+
+Allowed implementation input:
+
+- `data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json`.
+
+The implementation may use schemas and deterministic helper code to validate
+and transform that source-record JSON. It must not rebuild records from lower
+level source materials or from the candidate artifact.
+
+Forbidden implementation inputs:
+
+- legacy `data/exports/*/official_raw.json`;
+- `data/current-facts/candidate-inputs/*` as direct production export input;
+- ignored `.local` artifacts;
+- raw HTML;
+- full rows;
+- screenshots as authority;
+- ChatGPT/VLM output as authority;
+- cookies;
+- browser profiles;
+- request/response headers;
+- tokens;
+- traces;
+- debug dumps;
+- logs;
+- answer logs;
+- training logs;
+- private data;
+- SuperCombo numeric authority.
+
+The source-record Markdown companion may be referenced in public summaries, but
+the export artifact `generated_from` must use the source-record JSON as the
+production input boundary.
+
+## Export Mapping
+
+For the production export:
+
+- `artifact_schema_version == "current_fact_export/v2"`;
+- `run_id == "20260525T000000Z"`;
+- `generated_from == ["data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json"]`;
+- `authority_boundary` is copied from the source-record artifact;
+- `records` contains exactly 13 current-fact records copied from
+  `source_record.current_fact_record`;
+- records are deterministically sorted using the existing export generator
+  ordering contract;
+- source-record sidecar fields are not emitted in export records.
+
+For each exported record:
+
+- preserve `record_id`;
+- preserve `character_slug`;
+- preserve `move_id`;
+- preserve `field_key`;
+- preserve `display_label_ja`;
+- preserve `raw_value`;
+- preserve `parsed_value`;
+- preserve `value_shape`;
+- preserve `source_name`;
+- preserve `source_role`;
+- preserve `source_family`;
+- preserve `source_label`;
+- preserve `source_header_path`;
+- preserve `authority_status`;
+- preserve `evidence`;
+- preserve top-level `calculation_input_status`.
+
+The production export generator must not add facts, infer missing source
+context, reinterpret raw values, collapse ranges, flatten annotated numeric
+candidates, or promote authority/calculation status.
+
+## Admission Rules
+
+The first production current-fact export artifact must contain exactly the 13
+records from the PR #367 source-record artifact.
+
+Allowed records:
+
+- records present in the PR #367 source-record artifact;
+- records with `parsed_value`;
+- records with top-level `calculation_input_status`;
+- official records with `source_role == "authority_candidate"` and
+  `authority_status == "authority_candidate"`;
+- records whose `calculation_input_status` is either
+  `annotated_candidate_not_calculation_safe` or
+  `parsed_range_not_single_value_calculation_safe`;
+- records preserving `annotated_numeric_candidate` as a wrapper;
+- records preserving `frame_range` as a range.
+
+Forbidden records:
+
+- any value not present in the PR #367 source-record artifact;
+- review-required or blocked raw variants;
+- records with no `parsed_value`;
+- source-record sidecar fields in export records;
+- records sourced directly from candidate artifacts or legacy raw exports;
+- SuperCombo scalar numeric authority;
+- any raw-value expansion or changed semantics without the Issue #343 gate.
+
+This artifact is reviewed-export-ready, not scalar-calculation-ready. Exact
+scalar answer paths and calculators must still reject all 13 non-scalar records
+through `current_fact_guards`.
+
+## Validator Changes
+
+Required validator behavior:
+
+- `validate_current_fact_export_generator.py` must validate:
+  - synthetic fixture-contract generator behavior still passes;
+  - production current-fact export path contains only the approved JSON;
+  - Markdown summary path contains only the approved summary;
+  - production export artifact is schema-valid;
+  - production export has exactly 13 records;
+  - production export `generated_from` points only to the PR #367
+    source-record JSON;
+  - committed production export JSON matches deterministic generator output
+    from the PR #367 source-record JSON;
+  - source-record sidecar fields do not leak into export records;
+  - `annotated_numeric_candidate` remains wrapped;
+  - `frame_range` remains a range;
+  - non-scalar statuses are not scalar calculation inputs;
+  - all records remain official `authority_candidate`;
+  - no legacy raw exports, local paths, raw HTML, full rows, screenshots, VLM
+    output, or private data are referenced.
+- `validate_current_fact_source_records.py` must continue passing and must not
+  validate current-fact export semantics.
+- `validate_current_fact_row_move_cell_candidates.py` must continue passing
+  and must not validate current-fact export semantics.
+- `validate_validator_test_audit.py` must cover any new or modified
+  test/validator boundaries.
+
+## Issue #343 Gate
+
+Issue #343 remains mandatory for any future value-handling decision.
+
+This implementation must not add raw values beyond the 13 PR #367
+source-records. Because the implementation only transforms already-reviewed
+source-record current-fact records into export records, no new
+screenshot/ChatGPT/VLM double-check is required.
+
+If implementation attempts to include any additional raw value, same-grammar
+expansion, or changed semantics, it must stop and complete the Issue #343
+double-check gate first.
+
+## Acceptance Criteria
+
+- PR begins as docs-only and remains draft after plan review.
+- After mandatory plan review, implementation commits may be added to this
+  same draft PR if the reviewer approves that flow.
+- Production current-fact export artifact is generated only from the PR #367
+  production source-record JSON.
+- Production current-fact export artifact top-level `run_id` is
+  `20260525T000000Z`.
+- Production current-fact export artifact has exactly 13 records.
+- No runtime lookup, parser/classifier behavior, retrieval, answer,
+  calculator, SymPy, source acquisition, or live acquisition changes are made.
+- Legacy raw exports and private/local evidence are not used as replacement
+  source input.
+- `annotated_numeric_candidate` and `frame_range` remain non-scalar.
+- Official records remain `authority_candidate`.
+- Issue #343 gate remains required for future raw-value expansion.
+
+## Files / Interfaces
+
+Plan-only initial PR should change only:
+
+- `docs/execplans/2026-05-25-current-fact-export-artifact-from-source-records.md`
+
+Future implementation commits in the same draft PR may change only:
+
+- `docs/execplans/2026-05-25-current-fact-export-artifact-from-source-records.md`
+- `src/sf6_knowledge_coach/current_fact_export_generator.py` if helper changes
+  are needed
+- `tests/test_current_fact_export_generator.py` if helper changes are made
+- `tests/validation/validate_current_fact_export_generator.py`
+- `data/current-facts/20260525T000000Z-current-fact-export.json`
+- `docs/current-facts/20260525T000000Z-current-fact-export.md`
+- validator audit JSON/MD if tests or validators change
+
+Any additional file requires ExecPlan amendment and mandatory review before
+implementation continues.
+
+## Validation Commands
+
+Plan-only validation:
+
+```bash
+git diff --check
+uv lock --check
+PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_row_move_cell_candidates.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_export_generator.py
+PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
+git status --short --branch
+```
+
+Implementation validation:
+
+```bash
+git diff --check
+git diff --cached --check
+uv lock --check
+PYTHONPATH=src uv run --locked python -m unittest discover -s tests
+for f in tests/validation/validate_*.py; do PYTHONPATH=src uv run --locked python "$f" || exit $?; done
+PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
+git status --short --branch
+```
+
+## Progress
+
+- 2026-05-25: Drafted plan after PR #367 merged. No implementation or
+  production current-fact export artifact generated yet.
+- 2026-05-26: Ran plan-only validation. All checks passed.
+
+## Decision Log
+
+- 2026-05-25: The production current-fact export artifact will use the PR #367
+  source-record JSON as the only production input boundary.
+- 2026-05-25: The first production current-fact export artifact is limited to
+  the 13 source records already reviewed in PR #367.
+- 2026-05-25: Export `generated_from` will reference the source-record JSON,
+  not the candidate artifacts that originally fed the source-record artifact.
+- 2026-05-25: Runtime lookup transition, answer behavior, and legacy raw export
+  retirement remain out of scope.
+
+## Deviations
+
+- None.
+
+## Risks
+
+- Runtime remains legacy raw export backed.
+- The first production current-fact export artifact contains only non-scalar
+  parsed values and is not calculation-safe.
+- Export generation may reveal that the existing in-memory export helper needs
+  a narrow production `generated_from` override; if so, implementation must
+  stay within this plan's helper/test/validator scope.
+- Switching `current_facts.py` to the production export requires a future
+  lookup parity and rollback ExecPlan.
+
+## Completion Review Table
+
+| PLAN item | Implementation content | Changed files | Validation command | Result | Deviation | Incomplete | Risk |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Production current-fact export artifact plan | Draft plan only | `docs/execplans/2026-05-25-current-fact-export-artifact-from-source-records.md` | `git diff --check`; `uv lock --check` | Pass | None | Mandatory review pending | Runtime remains legacy raw export backed |
+| Input boundary | Plan restricts input to PR #367 source-record JSON | Same | `validate_current_fact_source_records.py` | Pass | None | Mandatory review pending | Export generation remains unimplemented |
+| Runtime/export boundary | Plan excludes runtime lookup and answer behavior changes | Same | current-fact validators | Pass | None | Mandatory review pending | Runtime remains legacy raw export backed |
+
+## Next Reviewer Prompt
+
+```text
+Review docs/execplans/2026-05-25-current-fact-export-artifact-from-source-records.md.
+
+Check:
+- PR diff initially contains exactly one ExecPlan file.
+- Plan uses only
+  data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json
+  as production input.
+- Planned output is current_fact_export/v2 under data/current-facts/ with a
+  summary under docs/current-facts/.
+- Plan does not use legacy data/exports/*/official_raw.json.
+- Plan does not use candidate artifacts, .local, raw HTML, full rows,
+  screenshots, VLM output, or private data as authority.
+- Plan includes no runtime lookup change, current_facts.py change,
+  answering.py change, parser/classifier behavior change, retrieval, answer,
+  calculator, SymPy, source acquisition, or live acquisition.
+- Planned production current-fact export artifact is exactly 13 records from
+  PR #367 source-record input.
+- Source-record sidecar fields do not leak into export records.
+- annotated_numeric_candidate and frame_range remain non-scalar and not
+  calculation-safe.
+- Official records remain authority_candidate.
+- validator boundary changes are explicitly planned.
+- Issue #343 double-check gate remains required for future raw-value
+  expansion.
+
+Run:
+- git status --short --branch
+- git show --name-status --oneline --no-renames HEAD
+- git diff --check origin/main...HEAD
+- uv lock --check
+- PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_row_move_cell_candidates.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_export_generator.py
+- PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
+
+Return blocking findings first, validation results, PLAN deviations, remaining
+risks, and whether docs-only plan is approved for same-PR implementation.
+```

--- a/docs/validator-audits/20260523-validator-test-fact-source-audit.md
+++ b/docs/validator-audits/20260523-validator-test-fact-source-audit.md
@@ -17,7 +17,7 @@ privacy/security boundary.
 | `tests/test_cli.py` | source-derived | accepted with limits | JP 5LP smoke only; not full roster validation |
 | `tests/test_current_fact_candidate_generator.py` | source-derived | accepted with limits | reviewed candidate evidence and deterministic classifier reproduction only |
 | `tests/test_current_fact_source_record_generator.py` | source-derived | accepted with limits | reviewed production candidate input and deterministic shape transformation only |
-| `tests/test_current_fact_export_generator.py` | synthetic contract | accepted with limits | source-record synthetic fixtures only; no production exports or source truth |
+| `tests/test_current_fact_export_generator.py` | artifact consistency | accepted with limits | source-record fixtures and approved production source-record input only; no source truth/runtime behavior |
 | `tests/test_current_fact_guards.py` | synthetic contract | accepted with limits | scalar/non-scalar guard fixtures only; no source truth or calculation correctness |
 | `tests/test_source_acquisition.py` | synthetic contract | accepted with limits | synthetic HTML tests parser/guard behavior, not live source truth |
 | `tests/test_supercombo_field_mapping.py` | policy-derived | accepted with limits | mapping counts are reviewed policy output, not live SuperCombo proof |
@@ -25,7 +25,7 @@ privacy/security boundary.
 | `tests/test_parsed_value_classifier.py` | policy-derived | accepted with limits | parser/classifier behavior is policy-derived and not calculation correctness |
 | `tests/test_value_shape_inventory.py` | source-derived | accepted with limits | representative shape checks are not parser semantics |
 | `tests/validation/validate_clean_slate.py` | governance boundary | accepted with limits | repo shape and approved contract file inventory only |
-| `tests/validation/validate_current_fact_export_generator.py` | artifact consistency | accepted with limits | fixture-contract generator output, guard boundaries, and absence of production current-fact export artifacts only |
+| `tests/validation/validate_current_fact_export_generator.py` | artifact consistency | accepted with limits | fixture-contract generator output, guard boundaries, and approved production export consistency only |
 | `tests/validation/validate_current_fact_row_move_cell_candidates.py` | source-derived | accepted with limits | candidate schema, synthetic fixtures, production candidate consistency, and approved source-record artifact coexistence only |
 | `tests/validation/validate_current_fact_candidate_evidence.py` | source-derived | accepted with limits | candidate evidence source-review summary; full v4 row context remains ignored local reviewer input |
 | `tests/validation/validate_current_fact_consumer_guards.py` | artifact consistency | accepted with limits | guard behavior against synthetic fixtures and coverage statuses only |

--- a/src/sf6_knowledge_coach/current_fact_export_generator.py
+++ b/src/sf6_knowledge_coach/current_fact_export_generator.py
@@ -4,6 +4,7 @@ import copy
 import hashlib
 import json
 import re
+from collections import Counter
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -67,13 +68,20 @@ FORBIDDEN_TEXT_PATTERNS = (
     re.compile(r"(?i)\b(?:cookie|authorization|bearer|token|password|secret)\b"),
     re.compile(r"(?i)\b(?:screenshot|chatgpt|vlm|trace|debug dump|answer[-_ ]?log|training[-_ ]?log|private[-_ ]?vault)\b"),
 )
+PRODUCTION_SOURCE_RECORD_JSON_PATH = "data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json"
+PRODUCTION_EXPORT_JSON_PATH = "data/current-facts/20260525T000000Z-current-fact-export.json"
+PRODUCTION_EXPORT_MD_PATH = "docs/current-facts/20260525T000000Z-current-fact-export.md"
 
 
 class CurrentFactExportGeneratorError(ValueError):
     """Raised when source-record input cannot build a valid current-fact export."""
 
 
-def build_current_fact_export(source_record_payload: Mapping[str, Any]) -> dict[str, Any]:
+def build_current_fact_export(
+    source_record_payload: Mapping[str, Any],
+    *,
+    generated_from: list[str] | None = None,
+) -> dict[str, Any]:
     errors = validate_source_record_payload(source_record_payload)
     if errors:
         raise CurrentFactExportGeneratorError(_format_errors("invalid source-record input", errors))
@@ -85,7 +93,7 @@ def build_current_fact_export(source_record_payload: Mapping[str, Any]) -> dict[
     export_payload = {
         "artifact_schema_version": "current_fact_export/v2",
         "authority_boundary": copy.deepcopy(source_record_payload["authority_boundary"]),
-        "generated_from": sorted(source_record_payload["generated_from"]),
+        "generated_from": sorted(generated_from if generated_from is not None else source_record_payload["generated_from"]),
         "records": sorted(records, key=_record_sort_key),
         "run_id": source_record_payload["run_id"],
     }
@@ -94,6 +102,63 @@ def build_current_fact_export(source_record_payload: Mapping[str, Any]) -> dict[
     if export_errors:
         raise CurrentFactExportGeneratorError(_format_errors("invalid generated current-fact export", export_errors))
     return export_payload
+
+
+def build_production_current_fact_export(source_record_payload: Mapping[str, Any]) -> dict[str, Any]:
+    return build_current_fact_export(
+        source_record_payload,
+        generated_from=[PRODUCTION_SOURCE_RECORD_JSON_PATH],
+    )
+
+
+def build_current_fact_export_summary_markdown(export_payload: Mapping[str, Any]) -> str:
+    records = export_payload.get("records", [])
+    if not isinstance(records, list):
+        raise CurrentFactExportGeneratorError("export payload records must be a list")
+    status_counts = Counter(
+        record.get("calculation_input_status")
+        for record in records
+        if isinstance(record, Mapping)
+    )
+    field_counts = Counter(
+        record.get("field_key")
+        for record in records
+        if isinstance(record, Mapping)
+    )
+    return "\n".join(
+        [
+            "# Current-Fact Export",
+            "",
+            f"- JSON artifact: `{PRODUCTION_EXPORT_JSON_PATH}`",
+            f"- Run ID: `{export_payload.get('run_id')}`",
+            f"- Source-record input: `{PRODUCTION_SOURCE_RECORD_JSON_PATH}`",
+            f"- Total records: `{len(records)}`",
+            "- Export boundary: source-record sidecar fields are excluded.",
+            "- Calculation boundary: non-scalar values remain not calculation-safe.",
+            "- Authority boundary: official values remain authority candidates only.",
+            "- Runtime lookup and answer behavior are unchanged.",
+            "",
+            "## Counts",
+            "",
+            "| Dimension | Value | Count |",
+            "| --- | --- | --- |",
+            *[
+                f"| calculation_input_status | `{status}` | {count} |"
+                for status, count in sorted(status_counts.items())
+            ],
+            *[
+                f"| field_key | `{field}` | {count} |"
+                for field, count in sorted(field_counts.items())
+            ],
+            "",
+            "## Boundaries",
+            "",
+            "- No runtime current-fact lookup switch is included.",
+            "- `annotated_numeric_candidate` and `frame_range` must not be flattened into scalar values.",
+            "- Legacy raw exports, ignored local artifacts, raw source payloads, reviewer observations, and private data are excluded as authority.",
+            "",
+        ]
+    )
 
 
 def validate_source_record_payload(source_record_payload: Mapping[str, Any]) -> list[str]:

--- a/tests/test_current_fact_export_generator.py
+++ b/tests/test_current_fact_export_generator.py
@@ -8,12 +8,16 @@ from pathlib import Path
 from sf6_knowledge_coach.current_fact_export_generator import (
     CurrentFactExportGeneratorError,
     build_current_fact_export,
+    build_current_fact_export_summary_markdown,
+    build_production_current_fact_export,
     validate_current_fact_export_payload,
 )
 
 
 ROOT = Path(__file__).resolve().parents[1]
 SOURCE_RECORD_FIXTURE_DIR = ROOT / "tests/fixtures/current-facts/source-records"
+PRODUCTION_SOURCE_RECORD_JSON = ROOT / "data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json"
+PRODUCTION_SOURCE_RECORD_JSON_REF = "data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json"
 SOURCE_RECORD_ONLY_FIELDS = {
     "raw_value_length",
     "raw_value_sha256",
@@ -137,6 +141,46 @@ class CurrentFactExportGeneratorTests(unittest.TestCase):
         errors = validate_current_fact_export_payload(export_payload)
 
         self.assertTrue(any("data/exports" in error for error in errors))
+
+    def test_production_export_uses_source_record_json_input_boundary(self) -> None:
+        source_payload = _fixture(PRODUCTION_SOURCE_RECORD_JSON)
+
+        export_payload = build_production_current_fact_export(source_payload)
+
+        self.assertEqual(export_payload["artifact_schema_version"], "current_fact_export/v2")
+        self.assertEqual(export_payload["run_id"], "20260525T000000Z")
+        self.assertEqual(export_payload["generated_from"], [PRODUCTION_SOURCE_RECORD_JSON_REF])
+        self.assertEqual(len(export_payload["records"]), 13)
+        self.assertEqual(validate_current_fact_export_payload(export_payload), [])
+
+    def test_production_export_keeps_non_scalar_values_wrapped(self) -> None:
+        source_payload = _fixture(PRODUCTION_SOURCE_RECORD_JSON)
+        export_payload = build_production_current_fact_export(source_payload)
+
+        statuses = {record["calculation_input_status"] for record in export_payload["records"]}
+        kinds = {record["parsed_value"]["kind"] for record in export_payload["records"]}
+
+        self.assertEqual(
+            statuses,
+            {
+                "annotated_candidate_not_calculation_safe",
+                "parsed_range_not_single_value_calculation_safe",
+            },
+        )
+        self.assertEqual(kinds, {"annotated_numeric_candidate", "frame_range"})
+        for record in export_payload["records"]:
+            self.assertFalse(SOURCE_RECORD_ONLY_FIELDS & set(record))
+
+    def test_export_summary_is_boundary_only(self) -> None:
+        source_payload = _fixture(PRODUCTION_SOURCE_RECORD_JSON)
+        export_payload = build_production_current_fact_export(source_payload)
+
+        markdown = build_current_fact_export_summary_markdown(export_payload)
+
+        self.assertIn("Total records: `13`", markdown)
+        self.assertIn(PRODUCTION_SOURCE_RECORD_JSON_REF, markdown)
+        self.assertNotIn(".local", markdown)
+        self.assertNotIn("data/exports/", markdown)
 
 
 if __name__ == "__main__":

--- a/tests/validation/validate_current_fact_export_generator.py
+++ b/tests/validation/validate_current_fact_export_generator.py
@@ -2,13 +2,17 @@ from __future__ import annotations
 
 import copy
 import json
+import re
 import sys
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
 from sf6_knowledge_coach.current_fact_export_generator import (
     CurrentFactExportGeneratorError,
+    build_current_fact_export_summary_markdown,
     build_current_fact_export,
+    build_production_current_fact_export,
     validate_current_fact_export_payload,
 )
 
@@ -21,9 +25,26 @@ PRODUCTION_ARTIFACT_DIRS = (
 )
 APPROVED_PRODUCTION_INPUT_ARTIFACTS = {
     "data/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.json",
+    "data/current-facts/20260525T000000Z-current-fact-export.json",
     "data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json",
+    "docs/current-facts/20260525T000000Z-current-fact-export.md",
     "docs/current-facts/candidate-inputs/20260525T000000Z-row-move-cell-candidates.md",
     "docs/current-facts/source-records/20260525T000000Z-current-fact-source-records.md",
+}
+PRODUCTION_SOURCE_RECORD_JSON = ROOT / "data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json"
+PRODUCTION_EXPORT_JSON = ROOT / "data/current-facts/20260525T000000Z-current-fact-export.json"
+PRODUCTION_EXPORT_MD = ROOT / "docs/current-facts/20260525T000000Z-current-fact-export.md"
+PRODUCTION_SOURCE_RECORD_JSON_REF = "data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json"
+EXPECTED_PRODUCTION_RUN_ID = "20260525T000000Z"
+EXPECTED_PRODUCTION_COUNT = 13
+EXPECTED_STATUS_COUNTS = {
+    "annotated_candidate_not_calculation_safe": 9,
+    "parsed_range_not_single_value_calculation_safe": 4,
+}
+EXPECTED_FIELD_COUNTS = {
+    "block_advantage": 5,
+    "hit_advantage": 4,
+    "startup": 4,
 }
 SIDECAR_FIELDS = {
     "raw_value_length",
@@ -35,6 +56,14 @@ SIDECAR_FIELDS = {
     "source_row_order",
     "source_value_key",
 }
+FORBIDDEN_PUBLIC_PATTERNS = [
+    re.compile(r"(?i)(?:^|[\s\"'`])(?:/[a-z0-9_.-]+)+"),
+    re.compile(r"(?i)(?:^|[\s\"'`(])[A-Z]:[\\/]"),
+    re.compile(r"(?i)\.local(?:/|\\)"),
+    re.compile(r"(?i)\b(?:cookie|authorization|bearer|token|password|secret)\b"),
+    re.compile(r"(?i)<html|</html|<!doctype|<table|</table|<tr|</tr|<td|</td|<th|</th"),
+    re.compile(r"(?i)\b(?:screenshot|chatgpt|vlm|trace|debug dump|answer[-_ ]?log|training[-_ ]?log|private[-_ ]?vault)\b"),
+]
 
 
 def main() -> int:
@@ -44,6 +73,7 @@ def main() -> int:
     _validate_invalid_fixture_rejections(errors)
     _validate_synthetic_export_boundary_mutations(valid_payloads, errors)
     _validate_no_production_artifacts(errors)
+    _validate_approved_production_export_artifacts(errors)
     return _finish(errors)
 
 
@@ -179,6 +209,90 @@ def _validate_no_production_artifacts(errors: list[str]) -> None:
         ]
         if unexpected:
             errors.append(f"fixture-contract generator must not create current-fact export artifacts: {unexpected}")
+
+
+def _validate_approved_production_export_artifacts(errors: list[str]) -> None:
+    if not PRODUCTION_SOURCE_RECORD_JSON.exists():
+        errors.append(f"Missing production source-record input: {PRODUCTION_SOURCE_RECORD_JSON.relative_to(ROOT)}")
+        return
+    if not PRODUCTION_EXPORT_JSON.exists():
+        errors.append(f"Missing approved production current-fact export JSON: {PRODUCTION_EXPORT_JSON.relative_to(ROOT)}")
+        return
+    if not PRODUCTION_EXPORT_MD.exists():
+        errors.append(f"Missing approved production current-fact export summary: {PRODUCTION_EXPORT_MD.relative_to(ROOT)}")
+        return
+
+    source_payload = json.loads(PRODUCTION_SOURCE_RECORD_JSON.read_text(encoding="utf-8"))
+    export_payload = json.loads(PRODUCTION_EXPORT_JSON.read_text(encoding="utf-8"))
+    expected_payload = build_production_current_fact_export(source_payload)
+    if export_payload != expected_payload:
+        errors.append("production current-fact export JSON must match deterministic generator output")
+
+    export_errors = validate_current_fact_export_payload(export_payload)
+    if export_errors:
+        errors.append(f"{PRODUCTION_EXPORT_JSON.relative_to(ROOT)} should be valid: {export_errors[0]}")
+        return
+    expected_markdown = build_current_fact_export_summary_markdown(export_payload)
+    if PRODUCTION_EXPORT_MD.read_text(encoding="utf-8") != expected_markdown:
+        errors.append("production current-fact export summary must match deterministic generator output")
+
+    _validate_production_export_payload(export_payload, source_payload, errors)
+    for path in (PRODUCTION_EXPORT_JSON, PRODUCTION_EXPORT_MD):
+        _scan_public_text(path, errors)
+
+
+def _validate_production_export_payload(
+    export_payload: dict[str, Any],
+    source_payload: dict[str, Any],
+    errors: list[str],
+) -> None:
+    if export_payload.get("artifact_schema_version") != "current_fact_export/v2":
+        errors.append("production export must use current_fact_export/v2")
+    if export_payload.get("run_id") != EXPECTED_PRODUCTION_RUN_ID:
+        errors.append(f"production export run_id must be {EXPECTED_PRODUCTION_RUN_ID}")
+    if export_payload.get("generated_from") != [PRODUCTION_SOURCE_RECORD_JSON_REF]:
+        errors.append("production export generated_from must point only to PR #367 source-record JSON")
+    records = export_payload.get("records", [])
+    source_records = source_payload.get("records", [])
+    if not isinstance(records, list) or not isinstance(source_records, list):
+        errors.append("production export and source-record records must be lists")
+        return
+    if len(records) != EXPECTED_PRODUCTION_COUNT:
+        errors.append(f"production export must contain {EXPECTED_PRODUCTION_COUNT} records")
+    status_counts = Counter(record.get("calculation_input_status") for record in records if isinstance(record, dict))
+    field_counts = Counter(record.get("field_key") for record in records if isinstance(record, dict))
+    if dict(sorted(status_counts.items())) != EXPECTED_STATUS_COUNTS:
+        errors.append("production export calculation status counts do not match approved source records")
+    if dict(sorted(field_counts.items())) != EXPECTED_FIELD_COUNTS:
+        errors.append("production export field counts do not match approved source records")
+
+    source_current_facts = [
+        record.get("current_fact_record")
+        for record in source_records
+        if isinstance(record, dict)
+    ]
+    if sorted(records, key=lambda record: record.get("record_id", "")) != sorted(
+        source_current_facts,
+        key=lambda record: record.get("record_id", "") if isinstance(record, dict) else "",
+    ):
+        errors.append("production export records must exactly match source-record current_fact_record payloads")
+    for index, record in enumerate(records):
+        if not isinstance(record, dict):
+            errors.append(f"records[{index}] must be an object")
+            continue
+        leaked = sorted(SIDECAR_FIELDS & set(record))
+        if leaked:
+            errors.append(f"records[{index}] leaked source-record sidecar fields: {leaked}")
+        if record.get("source_name") != "official" or record.get("authority_status") != "authority_candidate":
+            errors.append(f"records[{index}] must remain official authority_candidate")
+
+
+def _scan_public_text(path: Path, errors: list[str]) -> None:
+    text = path.read_text(encoding="utf-8")
+    for pattern in FORBIDDEN_PUBLIC_PATTERNS:
+        if pattern.search(text):
+            errors.append(f"{path.relative_to(ROOT)} contains forbidden public content")
+            break
 
 
 def _finish(errors: list[str]) -> int:


### PR DESCRIPTION
## Summary

- Adds a docs-only ExecPlan for generating the first production `current_fact_export/v2` artifact from the PR #367 source-record JSON.
- Keeps the same draft PR flow: plan review first, implementation commits only after mandatory plan review passes.
- Fixes the source boundary to `data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json` only.

## Boundaries

- No production current-fact export artifact is generated in this plan commit.
- No runtime lookup, `current_facts.py`, `answering.py`, parser/classifier, retrieval, answer, calculator, SymPy, source acquisition, or live acquisition changes.
- No legacy `data/exports/*/official_raw.json`, `.local`, raw HTML, full rows, screenshots/VLM, or private data as authority.

## Validation

- `git diff --check`
- `uv lock --check`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_row_move_cell_candidates.py`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_export_generator.py`
- `PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate`
