### PR TITLE
Plan current-fact lookup parity rollback

### DIFF
--- a/data/validator-audits/20260523-validator-test-fact-source-audit.json
+++ b/data/validator-audits/20260523-validator-test-fact-source-audit.json
@@ -175,6 +175,21 @@
       "status": "accepted_with_limits"
     },
     {
+      "evidence_class": "artifact_consistency",
+      "file": "tests/validation/validate_current_fact_lookup_parity.py",
+      "limitations": [
+        "checks production export invariants, expected non-parity with the legacy JP raw comparison surface, and source-text runtime boundary markers; does not switch runtime or prove source truth/calculation safety"
+      ],
+      "primary_evidence": [
+        "data/current-facts/20260525T000000Z-current-fact-export.json",
+        "data/exports/jp/official_raw.json",
+        "src/sf6_knowledge_coach/current_facts.py",
+        "src/sf6_knowledge_coach/answering.py",
+        "current-fact lookup parity rollback ExecPlan"
+      ],
+      "status": "accepted_with_limits"
+    },
+    {
       "evidence_class": "source_derived",
       "file": "tests/validation/validate_current_fact_row_move_cell_candidates.py",
       "limitations": [

--- a/docs/execplans/2026-05-25-current-fact-lookup-parity-rollback.md
+++ b/docs/execplans/2026-05-25-current-fact-lookup-parity-rollback.md
@@ -1,0 +1,402 @@
+# Current-Fact Lookup Parity And Rollback
+
+Status: Drafted for review; validation passed.
+
+## Purpose
+
+Plan the parity and rollback criteria required before any runtime lookup switch
+from legacy `data/exports/<character>/official_raw.json` to the reviewed
+production `current_fact_export/v2` artifact.
+
+This plan must not switch `current_facts.py`, `answering.py`, retrieval,
+answers, parsers, classifiers, calculators, or source acquisition. It defines
+what must be true before a future runtime switch can be safely considered, and
+what must cause an immediate rollback if a future switch is attempted.
+
+## Draft PR Flow
+
+Use the same draft PR flow as PR #365 through PR #368:
+
+1. Commit this docs-only plan and open a draft PR.
+2. Complete mandatory plan review.
+3. Add implementation commits to the same draft PR only if this plan is
+   amended to authorize a validator-only implementation and mandatory plan
+   review passes.
+4. Complete mandatory implementation review.
+5. Ready and merge only after the relevant review passes.
+
+The plan-only draft PR must not be merged if the reviewer requires an
+implementation slice in the same PR.
+
+## Inputs
+
+- `docs/PLAN.md`
+- `AGENTS.md`
+- `docs/execplans/2026-05-25-current-fact-lookup-parsed-value-transition.md`
+- `docs/execplans/2026-05-25-current-fact-export-design-amendment.md`
+- `docs/execplans/2026-05-25-current-fact-calculation-status-schema.md`
+- `docs/execplans/2026-05-25-current-fact-export-artifact-from-source-records.md`
+- `src/sf6_knowledge_coach/current_facts.py`
+- `src/sf6_knowledge_coach/answering.py`
+- `src/sf6_knowledge_coach/current_fact_guards.py`
+- `contracts/current-facts/current_fact_export.schema.json`
+- `contracts/current-facts/current_fact_record.schema.json`
+- `data/current-facts/20260525T000000Z-current-fact-export.json`
+- `docs/current-facts/20260525T000000Z-current-fact-export.md`
+- `data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json`
+- `data/exports/jp/official_raw.json` as legacy comparison input only
+- current validator audit artifacts
+
+## Context
+
+Current runtime lookup behavior is still legacy raw export backed:
+
+- `current_facts.py` loads `data/exports/<character>/official_raw.json`;
+- `lookup_current_fact(character_slug, move_input, field)` normalizes
+  `move_input` to uppercase, scans records by `input`, and returns the field
+  value directly from the raw record;
+- returned evidence reports `authority == "data/exports official_raw"` and a
+  legacy raw export `source_path`;
+- `answering.py` calls `lookup_current_fact` for numeric/current-fact queries
+  and formats the returned raw value as an answered packet.
+
+The reviewed production current-fact export now exists:
+
+- `data/current-facts/20260525T000000Z-current-fact-export.json`;
+- artifact schema `current_fact_export/v2`;
+- 13 records total;
+- 9 `annotated_numeric_candidate` records with
+  `annotated_candidate_not_calculation_safe`;
+- 4 `frame_range` records with
+  `parsed_range_not_single_value_calculation_safe`;
+- 0 scalar eligible records;
+- all records remain official `authority_candidate`.
+
+Because all 13 export records are non-scalar and not calculation-safe, they
+cannot be used as exact scalar answers. Parity must therefore distinguish:
+
+- lookup identity and evidence parity that can be validated now;
+- answer-value parity that is expected to fail or be held for non-scalar
+  current-fact records;
+- runtime switch criteria that remain blocked until exact-answer behavior,
+  fallback behavior, and rollback behavior are reviewed.
+
+## Scope
+
+Included in this docs-only plan:
+
+- inventory current legacy lookup and answer behavior;
+- define comparison surfaces between legacy raw-backed lookup and the reviewed
+  production current-fact export;
+- define expected parity, non-parity, and hold cases;
+- define rollback criteria for any future runtime lookup switch;
+- define guard requirements for `annotated_numeric_candidate` and
+  `frame_range`;
+- define future validator-only implementation slices if review approves them;
+- keep runtime lookup unchanged.
+
+Excluded:
+
+- No runtime lookup switch.
+- No `current_facts.py` behavior change.
+- No `answering.py` behavior change.
+- No retrieval implementation.
+- No answer implementation.
+- No parser/classifier behavior change.
+- No parser/classifier expansion.
+- No calculator implementation.
+- No SymPy logic.
+- No source acquisition implementation.
+- No live acquisition.
+- No legacy raw export retirement.
+- No authority promotion.
+- No calculation-safe promotion.
+- No Issue #343 raw-value expansion.
+
+## Comparison Inputs And Boundaries
+
+Allowed comparison inputs:
+
+- `data/current-facts/20260525T000000Z-current-fact-export.json`;
+- `data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json`;
+- current-fact JSON Schemas and guard helpers;
+- `data/exports/jp/official_raw.json` only as the current legacy runtime
+  comparison surface, not as replacement source input and not as proof that the
+  reviewed export should add or promote facts.
+
+Forbidden as authority or replacement input:
+
+- legacy `data/exports/*/official_raw.json` for new reviewed export records;
+- ignored `.local` artifacts;
+- raw HTML;
+- full rows;
+- screenshots as authority;
+- ChatGPT/VLM output as authority;
+- cookies;
+- browser profiles;
+- request/response headers;
+- tokens;
+- traces;
+- debug dumps;
+- logs;
+- answer logs;
+- training logs;
+- private data;
+- SuperCombo numeric authority.
+
+## Parity Criteria
+
+Parity checks must be explicit about what is being compared.
+
+Required export invariants:
+
+- production export is schema-valid `current_fact_export/v2`;
+- production export has `run_id == "20260525T000000Z"`;
+- production export has exactly 13 records;
+- `generated_from` points only to
+  `data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json`;
+- every record has `parsed_value`;
+- every record has top-level `calculation_input_status`;
+- all records remain official `authority_candidate`;
+- `annotated_numeric_candidate` remains wrapped;
+- `frame_range` remains a range;
+- `current_fact_guards.is_scalar_calculation_input` rejects all 13 records;
+- source-record sidecar fields do not appear in export records.
+
+Required legacy comparison inventory:
+
+- enumerate which export records can be mapped to a legacy raw record by
+  character, move identity, raw value, source header/field context, or another
+  deterministic reviewed key;
+- record which export records have no deterministic legacy lookup key because
+  current legacy lookup is input/field-oriented while export records are
+  row/move/cell-record-oriented;
+- record whether any future lookup compatibility requires an alias/input
+  bridge and whether that bridge is reviewed or missing.
+
+Required answer behavior parity:
+
+- current legacy lookup may answer raw scalar-looking values directly;
+- reviewed export records must not produce exact scalar answers because all 13
+  records are non-scalar and not calculation-safe;
+- for the 13 reviewed records, a future export-backed runtime should hold or
+  display non-scalar metadata with caveat only after a separate answer behavior
+  ExecPlan approves that behavior;
+- no parity test may treat an `annotated_numeric_candidate` nested numeric
+  candidate or `frame_range` endpoint as a scalar answer.
+
+## Expected Non-Parity
+
+The following gaps are expected and must not be papered over:
+
+- legacy lookup is keyed by `character_slug`, `move_input`, and field name;
+- production export records are keyed by `record_id`, `move_id`, field key, and
+  source/evidence metadata;
+- legacy raw records include broad current raw fields; production export
+  contains only 13 reviewed parsed records;
+- legacy raw values can be returned as answer text; production export values
+  are all non-scalar/not calculation-safe and cannot be exact scalar answers;
+- `authority` and evidence strings differ by design;
+- no current production export record is `eligible_only_after_domain_source_and_unit_checks`.
+
+These expected gaps mean a runtime switch is not approved by this plan.
+
+## Rollback Criteria
+
+Any future runtime lookup switch must include rollback conditions before it is
+approved. At minimum, rollback is required if:
+
+- answered packet count changes for existing legacy-covered smoke queries
+  without an approved expected-gap entry;
+- numeric/current-fact queries that should hold begin answering without
+  deterministic scalar-safe evidence;
+- `annotated_numeric_candidate` is flattened into `signed_frame`, `integer`, or
+  exact scalar answer text;
+- `frame_range` is collapsed into a single frame value, endpoint, best/worst,
+  or scalar advantage without a reviewed range-aware contract;
+- `calculation_input_status` is missing or ignored;
+- official `authority_candidate` is promoted to current-fact authority without
+  review;
+- legacy raw exports are silently used as replacement source input;
+- private/local evidence paths or reviewer observations appear in runtime
+  evidence;
+- answer packet evidence changes from deterministic reviewed data to raw
+  unreviewed paths;
+- CI or local validators fail.
+
+## Guard Requirements
+
+Any future lookup implementation must prove:
+
+- it carries `calculation_input_status` through the lookup path;
+- it calls `current_fact_guards.is_scalar_calculation_input` or an equivalent
+  validator before exact scalar answer use;
+- it rejects all 13 current export records for scalar calculation/exact-answer
+  use;
+- it preserves `parsed_value.kind`;
+- it does not flatten `annotated_numeric_candidate`;
+- it does not collapse `frame_range`;
+- it preserves source/evidence/authority fields;
+- it can fall back to legacy behavior only under an explicitly reviewed
+  fallback contract;
+- it can be disabled or reverted without deleting reviewed export artifacts.
+
+## Future Implementation Slices
+
+This docs-only plan does not authorize implementation by itself unless the
+mandatory plan review explicitly approves a validator-only implementation
+commit in the same draft PR.
+
+Possible future validator-only implementation in this same draft PR:
+
+- add a focused parity/rollback validator such as
+  `tests/validation/validate_current_fact_lookup_parity.py`;
+- compare the production export artifact with selected legacy raw lookup
+  behavior without changing runtime code;
+- assert the export has 13 records and zero scalar-eligible records;
+- assert non-scalar guard rejection for all export records;
+- assert expected non-parity is recorded rather than treated as a failure;
+- assert no runtime lookup, answer, parser/classifier, retrieval, calculator,
+  SymPy, source acquisition, live acquisition, or legacy raw retirement files
+  changed.
+
+Any helper, fixture, or validator file not listed in an amended file list
+requires ExecPlan amendment and mandatory review before editing.
+
+## Acceptance Criteria
+
+- PR begins as docs-only and remains draft after plan review.
+- Runtime lookup remains unchanged.
+- `current_facts.py` remains unchanged.
+- `answering.py` remains unchanged.
+- No parser/classifier behavior change.
+- No retrieval, answer, calculator, SymPy, source acquisition, or live
+  acquisition changes.
+- Legacy raw exports are not retired.
+- Parity criteria, expected non-parity, rollback criteria, and guard
+  requirements are explicit.
+- All 13 production export records remain non-scalar and not calculation-safe.
+- Issue #343 gate remains required for future raw-value expansion.
+
+## Files / Interfaces
+
+Plan-only initial PR should change only:
+
+- `docs/execplans/2026-05-25-current-fact-lookup-parity-rollback.md`
+
+Possible future implementation commits in the same draft PR may change only
+after mandatory plan review explicitly approves implementation:
+
+- `docs/execplans/2026-05-25-current-fact-lookup-parity-rollback.md`
+- a focused parity validator under `tests/validation/` if approved
+- validator audit JSON/MD if a validator is added or changed
+
+Any additional file requires ExecPlan amendment and mandatory review before
+implementation continues.
+
+## Validation Commands
+
+Plan-only validation:
+
+```bash
+git diff --check
+uv lock --check
+PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_row_move_cell_candidates.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_export_generator.py
+PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
+git status --short --branch
+```
+
+Implementation validation, if a later implementation is approved:
+
+```bash
+git diff --check
+git diff --cached --check
+uv lock --check
+PYTHONPATH=src uv run --locked python -m unittest discover -s tests
+for f in tests/validation/validate_*.py; do PYTHONPATH=src uv run --locked python "$f" || exit $?; done
+PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
+git status --short --branch
+```
+
+## Progress
+
+- 2026-05-26: Drafted plan after PR #368 merged. No runtime lookup switch,
+  validator implementation, or legacy raw export retirement yet.
+- 2026-05-26: Ran plan-only validation. All checks passed.
+
+## Decision Log
+
+- 2026-05-26: Runtime lookup switch remains blocked until parity criteria,
+  expected gaps, rollback behavior, and guard behavior are reviewed.
+- 2026-05-26: The production current-fact export is a reviewed artifact, but
+  not an exact-answer runtime source yet.
+- 2026-05-26: The 13 current export records must be treated as non-scalar and
+  not calculation-safe for parity purposes.
+- 2026-05-26: Legacy raw exports may be compared as the current runtime surface
+  but must not become replacement source input for reviewed export records.
+
+## Deviations
+
+- None.
+
+## Risks
+
+- Runtime remains legacy raw export backed.
+- A future lookup switch may require an input/alias bridge because legacy
+  lookup is input-oriented and current export records are row/move/cell-record
+  oriented.
+- Parity may be mostly expected non-parity until scalar-safe reviewed records
+  exist.
+- Legacy raw export retirement remains future work.
+
+## Completion Review Table
+
+| PLAN item | Implementation content | Changed files | Validation command | Result | Deviation | Incomplete | Risk |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Lookup parity/rollback plan | Draft plan only | `docs/execplans/2026-05-25-current-fact-lookup-parity-rollback.md` | `git diff --check`; `uv lock --check` | Pass | None | Mandatory review pending | Runtime remains legacy raw export backed |
+| Runtime boundary | Plan excludes runtime lookup and answer behavior changes | Same | current-fact validators | Pass | None | Mandatory review pending | Future switch still needs review |
+| Guard boundary | Plan requires non-scalar guard rejection for all 13 export records | Same | `validate_current_fact_consumer_guards.py`; `validate_current_fact_export_generator.py` | Pass | None | Mandatory review pending | No scalar-safe export records yet |
+
+## Next Reviewer Prompt
+
+```text
+Review docs/execplans/2026-05-25-current-fact-lookup-parity-rollback.md.
+
+Check:
+- PR diff initially contains exactly one ExecPlan file.
+- Plan compares current legacy raw-backed lookup behavior with the reviewed
+  production current-fact export artifact.
+- Plan defines parity criteria, expected non-parity, rollback criteria, and
+  guard requirements.
+- Runtime lookup remains unchanged.
+- No current_facts.py / answering.py behavior switch is planned.
+- No parser/classifier, retrieval, answer, calculator, SymPy, source/live
+  acquisition changes are planned.
+- Legacy raw exports are not retired.
+- Legacy data/exports/*/official_raw.json is comparison input only, not
+  replacement source input.
+- All 13 export records remain non-scalar / not calculation-safe.
+- Issue #343 double-check gate remains required for future raw-value expansion.
+
+Run:
+- git status --short --branch
+- git show --name-status --oneline --no-renames HEAD
+- git diff --check origin/main...HEAD
+- uv lock --check
+- PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_row_move_cell_candidates.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_export_generator.py
+- PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
+
+Return blocking findings first, validation results, PLAN deviations, remaining
+risks, and whether docs-only plan is approved for same-PR implementation or
+docs-only merge.
+```

--- a/docs/execplans/2026-05-25-current-fact-lookup-parity-rollback.md
+++ b/docs/execplans/2026-05-25-current-fact-lookup-parity-rollback.md
@@ -1,6 +1,6 @@
 # Current-Fact Lookup Parity And Rollback
 
-Status: Drafted for review; validation passed.
+Status: Plan amended for review; validation passed.
 
 ## Purpose
 
@@ -19,9 +19,8 @@ Use the same draft PR flow as PR #365 through PR #368:
 
 1. Commit this docs-only plan and open a draft PR.
 2. Complete mandatory plan review.
-3. Add implementation commits to the same draft PR only if this plan is
-   amended to authorize a validator-only implementation and mandatory plan
-   review passes.
+3. Add validator-only implementation commits to the same draft PR only after
+   mandatory review of this amended plan passes.
 4. Complete mandatory implementation review.
 5. Ready and merge only after the relevant review passes.
 
@@ -83,7 +82,7 @@ cannot be used as exact scalar answers. Parity must therefore distinguish:
 
 ## Scope
 
-Included in this docs-only plan:
+Included in this plan:
 
 - inventory current legacy lookup and answer behavior;
 - define comparison surfaces between legacy raw-backed lookup and the reviewed
@@ -92,7 +91,8 @@ Included in this docs-only plan:
 - define rollback criteria for any future runtime lookup switch;
 - define guard requirements for `annotated_numeric_candidate` and
   `frame_range`;
-- define future validator-only implementation slices if review approves them;
+- authorize one focused validator-only implementation slice in this same draft
+  PR after mandatory review passes;
 - keep runtime lookup unchanged.
 
 Excluded:
@@ -241,13 +241,10 @@ Any future lookup implementation must prove:
   fallback contract;
 - it can be disabled or reverted without deleting reviewed export artifacts.
 
-## Future Implementation Slices
+## Validator-Only Implementation Slice
 
-This docs-only plan does not authorize implementation by itself unless the
-mandatory plan review explicitly approves a validator-only implementation
-commit in the same draft PR.
-
-Possible future validator-only implementation in this same draft PR:
+After mandatory review of this amended plan passes, this same draft PR may add
+one validator-only implementation slice:
 
 - add a focused parity/rollback validator such as
   `tests/validation/validate_current_fact_lookup_parity.py`;
@@ -260,8 +257,14 @@ Possible future validator-only implementation in this same draft PR:
   SymPy, source acquisition, live acquisition, or legacy raw retirement files
   changed.
 
-Any helper, fixture, or validator file not listed in an amended file list
-requires ExecPlan amendment and mandatory review before editing.
+The validator must be evidence-first and must not call runtime lookup as a new
+authority path. It may inspect `current_facts.py`, `answering.py`, the
+production export artifact, current-fact guards, and `data/exports/jp/official_raw.json`
+as the existing runtime comparison surface only.
+
+No helper, fixture, runtime, parser/classifier, retrieval, answer, calculator,
+SymPy, source/live acquisition, schema, or generated data file may be added or
+changed by this implementation slice.
 
 ## Acceptance Criteria
 
@@ -284,12 +287,13 @@ Plan-only initial PR should change only:
 
 - `docs/execplans/2026-05-25-current-fact-lookup-parity-rollback.md`
 
-Possible future implementation commits in the same draft PR may change only
-after mandatory plan review explicitly approves implementation:
+Future implementation commits in the same draft PR may change only after
+mandatory review of this amended plan passes:
 
 - `docs/execplans/2026-05-25-current-fact-lookup-parity-rollback.md`
-- a focused parity validator under `tests/validation/` if approved
-- validator audit JSON/MD if a validator is added or changed
+- `tests/validation/validate_current_fact_lookup_parity.py`
+- `data/validator-audits/20260523-validator-test-fact-source-audit.json`
+- `docs/validator-audits/20260523-validator-test-fact-source-audit.md`
 
 Any additional file requires ExecPlan amendment and mandatory review before
 implementation continues.
@@ -318,6 +322,8 @@ git diff --check
 git diff --cached --check
 uv lock --check
 PYTHONPATH=src uv run --locked python -m unittest discover -s tests
+PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_lookup_parity.py
+PYTHONPATH=src uv run --locked python tests/validation/validate_validator_test_audit.py
 for f in tests/validation/validate_*.py; do PYTHONPATH=src uv run --locked python "$f" || exit $?; done
 PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
 git status --short --branch
@@ -328,6 +334,9 @@ git status --short --branch
 - 2026-05-26: Drafted plan after PR #368 merged. No runtime lookup switch,
   validator implementation, or legacy raw export retirement yet.
 - 2026-05-26: Ran plan-only validation. All checks passed.
+- 2026-05-26: Amended plan to authorize a same-PR validator-only
+  implementation slice after amended plan review passes, with exact file list
+  limited to the ExecPlan, one focused validator, and validator audit JSON/MD.
 
 ## Decision Log
 
@@ -339,6 +348,10 @@ git status --short --branch
   not calculation-safe for parity purposes.
 - 2026-05-26: Legacy raw exports may be compared as the current runtime surface
   but must not become replacement source input for reviewed export records.
+- 2026-05-26: Same-PR implementation is limited to validator-only parity and
+  rollback evidence. Runtime lookup, answer behavior, export generation,
+  parser/classifier, retrieval, calculator, SymPy, source/live acquisition,
+  schemas, fixtures, and generated data remain out of scope.
 
 ## Deviations
 
@@ -361,6 +374,7 @@ git status --short --branch
 | Lookup parity/rollback plan | Draft plan only | `docs/execplans/2026-05-25-current-fact-lookup-parity-rollback.md` | `git diff --check`; `uv lock --check` | Pass | None | Mandatory review pending | Runtime remains legacy raw export backed |
 | Runtime boundary | Plan excludes runtime lookup and answer behavior changes | Same | current-fact validators | Pass | None | Mandatory review pending | Future switch still needs review |
 | Guard boundary | Plan requires non-scalar guard rejection for all 13 export records | Same | `validate_current_fact_consumer_guards.py`; `validate_current_fact_export_generator.py` | Pass | None | Mandatory review pending | No scalar-safe export records yet |
+| Validator-only implementation authorization | Allows exactly one focused parity validator plus audit updates after amended plan review | Same | `validate_current_fact_lookup_parity.py` after implementation | Pending | None | Amended plan review pending | Validator must not switch runtime |
 
 ## Next Reviewer Prompt
 
@@ -369,6 +383,13 @@ Review docs/execplans/2026-05-25-current-fact-lookup-parity-rollback.md.
 
 Check:
 - PR diff initially contains exactly one ExecPlan file.
+- Plan clearly authorizes same-PR validator-only implementation after amended
+  plan review passes.
+- Authorized implementation files are fixed to:
+  - docs/execplans/2026-05-25-current-fact-lookup-parity-rollback.md
+  - tests/validation/validate_current_fact_lookup_parity.py
+  - data/validator-audits/20260523-validator-test-fact-source-audit.json
+  - docs/validator-audits/20260523-validator-test-fact-source-audit.md
 - Plan compares current legacy raw-backed lookup behavior with the reviewed
   production current-fact export artifact.
 - Plan defines parity criteria, expected non-parity, rollback criteria, and
@@ -397,6 +418,6 @@ Run:
 - PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
 
 Return blocking findings first, validation results, PLAN deviations, remaining
-risks, and whether docs-only plan is approved for same-PR implementation or
-docs-only merge.
+risks, and whether amended plan is approved for same-PR validator-only
+implementation.
 ```

--- a/docs/execplans/2026-05-25-current-fact-lookup-parity-rollback.md
+++ b/docs/execplans/2026-05-25-current-fact-lookup-parity-rollback.md
@@ -1,6 +1,6 @@
 # Current-Fact Lookup Parity And Rollback
 
-Status: Plan amended for review; validation passed.
+Status: Validator-only implementation complete; validation passed.
 
 ## Purpose
 
@@ -337,6 +337,13 @@ git status --short --branch
 - 2026-05-26: Amended plan to authorize a same-PR validator-only
   implementation slice after amended plan review passes, with exact file list
   limited to the ExecPlan, one focused validator, and validator audit JSON/MD.
+- 2026-05-26: Implemented
+  `tests/validation/validate_current_fact_lookup_parity.py` and validator audit
+  entries. The validator checks production export invariants, expected
+  non-parity with the legacy JP raw comparison surface, non-scalar guard
+  rejection for all 13 records, source-record sidecar exclusion, and source-text
+  runtime boundary markers without calling runtime lookup or switching behavior.
+- 2026-05-26: Ran implementation validation. All checks passed.
 
 ## Decision Log
 
@@ -352,6 +359,10 @@ git status --short --branch
   rollback evidence. Runtime lookup, answer behavior, export generation,
   parser/classifier, retrieval, calculator, SymPy, source/live acquisition,
   schemas, fixtures, and generated data remain out of scope.
+- 2026-05-26: The parity validator treats legacy JP raw export as comparison
+  surface only. It records expected non-parity because current runtime lookup is
+  input/field-oriented while reviewed production export records are
+  row/move/cell-oriented and all non-scalar/not calculation-safe.
 
 ## Deviations
 
@@ -371,33 +382,35 @@ git status --short --branch
 
 | PLAN item | Implementation content | Changed files | Validation command | Result | Deviation | Incomplete | Risk |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Lookup parity/rollback plan | Draft plan only | `docs/execplans/2026-05-25-current-fact-lookup-parity-rollback.md` | `git diff --check`; `uv lock --check` | Pass | None | Mandatory review pending | Runtime remains legacy raw export backed |
-| Runtime boundary | Plan excludes runtime lookup and answer behavior changes | Same | current-fact validators | Pass | None | Mandatory review pending | Future switch still needs review |
-| Guard boundary | Plan requires non-scalar guard rejection for all 13 export records | Same | `validate_current_fact_consumer_guards.py`; `validate_current_fact_export_generator.py` | Pass | None | Mandatory review pending | No scalar-safe export records yet |
-| Validator-only implementation authorization | Allows exactly one focused parity validator plus audit updates after amended plan review | Same | `validate_current_fact_lookup_parity.py` after implementation | Pending | None | Amended plan review pending | Validator must not switch runtime |
+| Lookup parity/rollback plan | Draft plan and implementation authorization | `docs/execplans/2026-05-25-current-fact-lookup-parity-rollback.md` | `git diff --check`; `uv lock --check` | Pass | None | Implementation review pending | Runtime remains legacy raw export backed |
+| Runtime boundary | Plan and validator exclude runtime lookup and answer behavior changes | Same | current-fact validators | Pass | None | Implementation review pending | Future switch still needs review |
+| Guard boundary | Plan and validator require non-scalar guard rejection for all 13 export records | Same | `validate_current_fact_consumer_guards.py`; `validate_current_fact_export_generator.py`; `validate_current_fact_lookup_parity.py` | Pass | None | Implementation review pending | No scalar-safe export records yet |
+| Validator-only implementation authorization | Allows exactly one focused parity validator plus audit updates after amended plan review | Same | `validate_current_fact_lookup_parity.py` | Pass | None | Implementation review pending | Validator must not switch runtime |
+| Lookup parity validator | Checks production export invariants, legacy JP comparison surface, expected non-parity, guard rejection, sidecar exclusion, and runtime source-text markers | `tests/validation/validate_current_fact_lookup_parity.py` | `PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_lookup_parity.py` | Pass | None | Implementation review pending | Runtime switch remains future work |
+| Validator audit | Records evidence boundary for the new parity validator | `data/validator-audits/20260523-validator-test-fact-source-audit.json`; `docs/validator-audits/20260523-validator-test-fact-source-audit.md` | `PYTHONPATH=src uv run --locked python tests/validation/validate_validator_test_audit.py` | Pass | None | Implementation review pending | Audit proves metadata coverage only |
 
 ## Next Reviewer Prompt
 
 ```text
-Review docs/execplans/2026-05-25-current-fact-lookup-parity-rollback.md.
+Review PR #369 implementation for current-fact lookup parity/rollback.
 
 Check:
-- PR diff initially contains exactly one ExecPlan file.
-- Plan clearly authorizes same-PR validator-only implementation after amended
-  plan review passes.
-- Authorized implementation files are fixed to:
+- PR diff contains exactly the authorized validator-only files:
   - docs/execplans/2026-05-25-current-fact-lookup-parity-rollback.md
   - tests/validation/validate_current_fact_lookup_parity.py
   - data/validator-audits/20260523-validator-test-fact-source-audit.json
   - docs/validator-audits/20260523-validator-test-fact-source-audit.md
-- Plan compares current legacy raw-backed lookup behavior with the reviewed
-  production current-fact export artifact.
-- Plan defines parity criteria, expected non-parity, rollback criteria, and
-  guard requirements.
+- The new validator compares current legacy raw-backed lookup behavior with the
+  reviewed production current-fact export artifact without calling runtime
+  lookup as a new authority path.
+- The validator checks production export invariants, expected non-parity,
+  rollback/guard contract markers, source-record sidecar exclusion, and
+  non-scalar guard rejection for all 13 records.
 - Runtime lookup remains unchanged.
 - No current_facts.py / answering.py behavior switch is planned.
 - No parser/classifier, retrieval, answer, calculator, SymPy, source/live
-  acquisition changes are planned.
+  acquisition, schema, fixture, generated data, or legacy raw retirement changes
+  are included.
 - Legacy raw exports are not retired.
 - Legacy data/exports/*/official_raw.json is comparison input only, not
   replacement source input.
@@ -409,15 +422,12 @@ Run:
 - git show --name-status --oneline --no-renames HEAD
 - git diff --check origin/main...HEAD
 - uv lock --check
-- PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py
-- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py
-- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py
-- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_row_move_cell_candidates.py
-- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py
-- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_export_generator.py
+- PYTHONPATH=src uv run --locked python -m unittest discover -s tests
+- PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_lookup_parity.py
+- PYTHONPATH=src uv run --locked python tests/validation/validate_validator_test_audit.py
+- for f in tests/validation/validate_*.py; do PYTHONPATH=src uv run --locked python "$f" || exit $?; done
 - PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate
 
 Return blocking findings first, validation results, PLAN deviations, remaining
-risks, and whether amended plan is approved for same-PR validator-only
-implementation.
+risks, and whether PR #369 is ready to mark ready and merge.
 ```

--- a/docs/validator-audits/20260523-validator-test-fact-source-audit.md
+++ b/docs/validator-audits/20260523-validator-test-fact-source-audit.md
@@ -26,6 +26,7 @@ privacy/security boundary.
 | `tests/test_value_shape_inventory.py` | source-derived | accepted with limits | representative shape checks are not parser semantics |
 | `tests/validation/validate_clean_slate.py` | governance boundary | accepted with limits | repo shape and approved contract file inventory only |
 | `tests/validation/validate_current_fact_export_generator.py` | artifact consistency | accepted with limits | fixture-contract generator output, guard boundaries, and approved production export consistency only |
+| `tests/validation/validate_current_fact_lookup_parity.py` | artifact consistency | accepted with limits | production export invariants, expected non-parity with legacy JP raw comparison, and runtime boundary markers only |
 | `tests/validation/validate_current_fact_row_move_cell_candidates.py` | source-derived | accepted with limits | candidate schema, synthetic fixtures, production candidate consistency, and approved source-record artifact coexistence only |
 | `tests/validation/validate_current_fact_candidate_evidence.py` | source-derived | accepted with limits | candidate evidence source-review summary; full v4 row context remains ignored local reviewer input |
 | `tests/validation/validate_current_fact_consumer_guards.py` | artifact consistency | accepted with limits | guard behavior against synthetic fixtures and coverage statuses only |

--- a/tests/validation/validate_current_fact_lookup_parity.py
+++ b/tests/validation/validate_current_fact_lookup_parity.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from sf6_knowledge_coach.current_fact_guards import is_scalar_calculation_input
+
+
+ROOT = Path(__file__).resolve().parents[2]
+EXECPLAN = ROOT / "docs/execplans/2026-05-25-current-fact-lookup-parity-rollback.md"
+EXPORT_JSON = ROOT / "data/current-facts/20260525T000000Z-current-fact-export.json"
+SOURCE_RECORD_JSON_REF = "data/current-facts/source-records/20260525T000000Z-current-fact-source-records.json"
+LEGACY_JP_RAW = ROOT / "data/exports/jp/official_raw.json"
+CURRENT_FACTS = ROOT / "src/sf6_knowledge_coach/current_facts.py"
+ANSWERING = ROOT / "src/sf6_knowledge_coach/answering.py"
+EXPECTED_STATUS_COUNTS = {
+    "annotated_candidate_not_calculation_safe": 9,
+    "parsed_range_not_single_value_calculation_safe": 4,
+}
+EXPECTED_FIELD_COUNTS = {
+    "block_advantage": 5,
+    "hit_advantage": 4,
+    "startup": 4,
+}
+SIDECAR_FIELDS = {
+    "raw_value_length",
+    "raw_value_sha256",
+    "source_cell_key",
+    "source_cell_order",
+    "source_record_id",
+    "source_row_key",
+    "source_row_order",
+    "source_value_key",
+}
+FORBIDDEN_RUNTIME_CHANGE_MARKERS = (
+    "data/current-facts/20260525T000000Z-current-fact-export.json",
+    "current_fact_export/v2",
+    "build_production_current_fact_export",
+)
+
+
+def main() -> int:
+    errors: list[str] = []
+    export_payload = _load_json_object(EXPORT_JSON, errors)
+    legacy_records = _load_json_list(LEGACY_JP_RAW, errors)
+    if export_payload:
+        _validate_export_invariants(export_payload, errors)
+    if legacy_records:
+        _validate_legacy_comparison_surface(legacy_records, errors)
+    if export_payload and legacy_records:
+        _validate_expected_non_parity(export_payload, legacy_records, errors)
+    _validate_runtime_still_legacy_backed(errors)
+    _validate_execplan_rollback_contract(errors)
+    return _finish(errors)
+
+
+def _load_json_object(path: Path, errors: list[str]) -> dict[str, Any]:
+    if not path.exists():
+        errors.append(f"Missing {path.relative_to(ROOT)}")
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        errors.append(f"{path.relative_to(ROOT)} must be a JSON object")
+        return {}
+    return payload
+
+
+def _load_json_list(path: Path, errors: list[str]) -> list[dict[str, Any]]:
+    if not path.exists():
+        errors.append(f"Missing {path.relative_to(ROOT)}")
+        return []
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        errors.append(f"{path.relative_to(ROOT)} must be a JSON array")
+        return []
+    if not all(isinstance(record, dict) for record in payload):
+        errors.append(f"{path.relative_to(ROOT)} must contain only JSON objects")
+        return []
+    return payload
+
+
+def _validate_export_invariants(payload: dict[str, Any], errors: list[str]) -> None:
+    if payload.get("artifact_schema_version") != "current_fact_export/v2":
+        errors.append("production export must use current_fact_export/v2")
+    if payload.get("run_id") != "20260525T000000Z":
+        errors.append("production export must keep run_id 20260525T000000Z")
+    if payload.get("generated_from") != [SOURCE_RECORD_JSON_REF]:
+        errors.append("production export generated_from must reference only the source-record JSON")
+    records = payload.get("records")
+    if not isinstance(records, list):
+        errors.append("production export records must be a list")
+        return
+    if len(records) != 13:
+        errors.append("production export must contain exactly 13 records")
+    status_counts = Counter(record.get("calculation_input_status") for record in records if isinstance(record, dict))
+    field_counts = Counter(record.get("field_key") for record in records if isinstance(record, dict))
+    if status_counts != Counter(EXPECTED_STATUS_COUNTS):
+        errors.append("production export status counts changed")
+    if field_counts != Counter(EXPECTED_FIELD_COUNTS):
+        errors.append("production export field counts changed")
+    scalar_eligible = [
+        record for record in records
+        if isinstance(record, dict)
+        and record.get("calculation_input_status") == "eligible_only_after_domain_source_and_unit_checks"
+    ]
+    if scalar_eligible:
+        errors.append("production export must not contain scalar-eligible records")
+    for index, record in enumerate(records):
+        if not isinstance(record, dict):
+            errors.append(f"records[{index}] must be an object")
+            continue
+        parsed_value = record.get("parsed_value")
+        status = record.get("calculation_input_status")
+        parsed_kind = parsed_value.get("kind") if isinstance(parsed_value, dict) else None
+        leaked_sidecar = sorted(SIDECAR_FIELDS & set(record))
+        if leaked_sidecar:
+            errors.append(f"records[{index}] leaked source-record sidecar fields: {leaked_sidecar}")
+        if not isinstance(parsed_value, dict):
+            errors.append(f"records[{index}] must keep parsed_value object")
+            continue
+        if not isinstance(status, str):
+            errors.append(f"records[{index}] must keep calculation_input_status")
+            continue
+        if record.get("source_name") != "official" or record.get("authority_status") != "authority_candidate":
+            errors.append(f"records[{index}] must remain official authority_candidate")
+        if parsed_kind == "annotated_numeric_candidate" and status != "annotated_candidate_not_calculation_safe":
+            errors.append(f"records[{index}] annotated candidate status changed")
+        if parsed_kind == "frame_range" and status != "parsed_range_not_single_value_calculation_safe":
+            errors.append(f"records[{index}] frame_range status changed")
+        if parsed_kind not in {"annotated_numeric_candidate", "frame_range"}:
+            errors.append(f"records[{index}] unexpected parsed_value kind for current export: {parsed_kind}")
+        if isinstance(parsed_value, dict) and is_scalar_calculation_input(parsed_value, status):
+            errors.append(f"records[{index}] must be rejected by scalar calculation guard")
+
+
+def _validate_legacy_comparison_surface(records: list[dict[str, Any]], errors: list[str]) -> None:
+    if len(records) != 61:
+        errors.append("legacy JP raw comparison surface changed from 61 records")
+    required_keys = {"character_slug", "move_id", "move_name", "input"}
+    for index, record in enumerate(records):
+        missing = sorted(required_keys - set(record))
+        if missing:
+            errors.append(f"legacy records[{index}] missing lookup keys: {missing}")
+        if record.get("character_slug") != "jp":
+            errors.append(f"legacy records[{index}] must remain JP-only comparison data")
+    sample = next((record for record in records if record.get("input") == "5LP"), None)
+    if not sample:
+        errors.append("legacy JP raw comparison surface must retain 5LP smoke record")
+    elif sample.get("move_id") != "jp_001_5lp":
+        errors.append("legacy JP 5LP smoke record move_id changed")
+
+
+def _validate_expected_non_parity(
+    export_payload: dict[str, Any],
+    legacy_records: list[dict[str, Any]],
+    errors: list[str],
+) -> None:
+    export_records = [record for record in export_payload.get("records", []) if isinstance(record, dict)]
+    export_characters = {record.get("character_slug") for record in export_records}
+    legacy_characters = {record.get("character_slug") for record in legacy_records}
+    if export_characters & legacy_characters:
+        errors.append("current export unexpectedly overlaps the JP legacy lookup character surface")
+    if any("input" in record or "move_name" in record for record in export_records):
+        errors.append("production export records must not pretend to be legacy input-keyed rows")
+    legacy_field_keys = set().union(*(record.keys() for record in legacy_records))
+    export_field_keys = {record.get("field_key") for record in export_records}
+    if export_field_keys <= legacy_field_keys:
+        errors.append("current expected non-parity changed: export field keys now look legacy-compatible")
+
+
+def _validate_runtime_still_legacy_backed(errors: list[str]) -> None:
+    current_facts_text = CURRENT_FACTS.read_text(encoding="utf-8")
+    answering_text = ANSWERING.read_text(encoding="utf-8")
+    required_current_facts = (
+        'AUTHORITY_DATASET = "official_raw"',
+        "def official_raw_path(character_slug: str) -> Path:",
+        "def load_official_raw(character_slug: str) -> list[dict[str, Any]]:",
+        "def lookup_current_fact(character_slug: str, move_input: str, field: str) -> CurrentFact:",
+        "records = load_official_raw(character_slug)",
+        'authority="data/exports official_raw"',
+    )
+    for marker in required_current_facts:
+        if marker not in current_facts_text:
+            errors.append(f"current_facts.py no longer shows legacy raw-backed lookup marker: {marker}")
+    for marker in FORBIDDEN_RUNTIME_CHANGE_MARKERS:
+        if marker in current_facts_text:
+            errors.append(f"current_facts.py must not reference production export in this validator-only slice: {marker}")
+        if marker in answering_text:
+            errors.append(f"answering.py must not reference production export in this validator-only slice: {marker}")
+    if "from .current_facts import lookup_current_fact" not in answering_text:
+        errors.append("answering.py must still import lookup_current_fact from current_facts")
+    if "fact = lookup_current_fact(context.character_slug, context.move_input, context.field)" not in answering_text:
+        errors.append("answering.py current-fact path must remain lookup_current_fact-backed")
+
+
+def _validate_execplan_rollback_contract(errors: list[str]) -> None:
+    text = EXECPLAN.read_text(encoding="utf-8")
+    required_phrases = (
+        "Rollback Criteria",
+        "annotated_numeric_candidate",
+        "frame_range",
+        "calculation_input_status",
+        "Runtime lookup remains unchanged.",
+        "Legacy raw exports are not retired.",
+        "validator-only implementation",
+    )
+    for phrase in required_phrases:
+        if phrase not in text:
+            errors.append(f"ExecPlan missing parity/rollback contract phrase: {phrase}")
+
+
+def _finish(errors: list[str]) -> int:
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("Current-fact lookup parity validation OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds a docs-only ExecPlan for lookup parity and rollback criteria before any runtime lookup switch.
- Defines how to compare legacy raw-backed lookup behavior with the reviewed production current-fact export artifact.
- Keeps runtime lookup, answer behavior, parser/classifier, retrieval, calculator, SymPy, source/live acquisition, and legacy raw retirement out of scope.

## Boundaries

- No runtime switch in this PR.
- Legacy `data/exports/*/official_raw.json` is comparison input only, not replacement source input.
- All 13 production export records remain non-scalar and not calculation-safe.

## Validation

- `git diff --check`
- `uv lock --check`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_clean_slate.py`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_schemas.py`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_source_records.py`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_row_move_cell_candidates.py`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_consumer_guards.py`
- `PYTHONPATH=src uv run --locked python tests/validation/validate_current_fact_export_generator.py`
- `PYTHONPATH=src uv run --locked python -m sf6_knowledge_coach.parsed_value_classifier validate`
